### PR TITLE
Update switch state conditions and 'default' property

### DIFF
--- a/examples/examples.md
+++ b/examples/examples.md
@@ -641,7 +641,9 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
      ],
      "eventTimeout": "PT1H",
      "default": {
-        "nextState": "HandleNoVisaDecision"
+        "transition": {
+         "nextState": "HandleNoVisaDecision"
+        }
      }
   },
   {
@@ -701,7 +703,8 @@ states:
       nextState: HandleRejectedVisa
   eventTimeout: PT1H
   default:
-    nextState: HandleNoVisaDecision
+    transition:
+      nextState: HandleNoVisaDecision
 - name: HandleApprovedVisa
   type: subflow
   workflowId: handleApprovedVisaWorkflowID
@@ -795,7 +798,9 @@ If the applicants age is over 18 we start the application (subflow state). Other
             }
          ],
          "default": {
-            "nextState": "RejectApplication"
+            "transition": {
+               "nextState": "RejectApplication"
+            }
          }
       },
       {
@@ -852,7 +857,8 @@ states:
     transition:
       nextState: RejectApplication
   default:
-    nextState: RejectApplication
+    transition:
+      nextState: RejectApplication
 - name: StartApplication
   type: subflow
   workflowId: startApplicationWorkflowId
@@ -1221,7 +1227,9 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       }
     ],
     "default": {
-        "nextState": "WaitForCompletion"
+      "transition": {
+         "nextState": "WaitForCompletion"
+       }
     }
   },
   {  
@@ -1338,7 +1346,8 @@ states:
     transition:
       nextState: JobFailed
   default:
-    nextState: WaitForCompletion
+    transition:
+      nextState: WaitForCompletion
 - name: JobSucceeded
   type: operation
   actionMode: sequential
@@ -2064,7 +2073,9 @@ And for denied credit check, for example:
                 }
             ],
             "default": {
-                "nextState": "RejectApplication"
+               "transition": {
+                 "nextState": "RejectApplication"
+                }
             }
         },
         {
@@ -2141,7 +2152,8 @@ states:
     transition:
       nextState: RejectApplication
   default:
-    nextState: RejectApplication
+    transition:
+      nextState: RejectApplication
 - name: StartApplication
   type: subflow
   workflowId: startApplicationWorkflowId

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -67,3 +67,4 @@ _Status description:_
 | ✔️| Update workflow extensions | [spec doc](../specification.md) |
 | ✔️| Add Workflow KPIs extension | [spec doc](../specification.md) |
 | ✔️| Add Workflow Validation to Java SDK | [sdk repo](https://github.com/serverlessworkflow/sdk-java) |
+| ✔️| Update Switch state conditions and default definition | [spec doc](../specification.md) |

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -337,9 +337,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "delay"
-          ],
+          "const": "delay",
           "description": "State type"
         },
         "start": {
@@ -435,9 +433,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "event"
-          ],
+          "const": "event",
           "description": "State type"
         },
         "exclusive": {
@@ -554,9 +550,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "operation"
-          ],
+          "const": "operation",
           "description": "State type"
         },
         "start": {
@@ -677,9 +671,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "parallel"
-          ],
+          "const": "parallel",
           "description": "State type"
         },
         "start": {
@@ -810,9 +802,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "switch"
-          ],
+          "const": "switch",
           "description": "State type"
         },
         "start": {
@@ -843,8 +833,8 @@
           "description": "If eventConditions is used, defines the time period to wait for events (ISO 8601 format)"
         },
         "default": {
-          "description": "Next transition of the workflow if there is no matching data conditions, or event timeout is reached",
-          "$ref": "#/definitions/transition"
+          "$ref": "#/definitions/defaultdef",
+          "description": "Default transition of the workflow if there is no matching data conditions. Can include a transition or end definition"
         },
         "dataInputSchema": {
           "type": "string",
@@ -895,9 +885,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "switch"
-          ],
+          "const": "switch",
           "description": "State type"
         },
         "start": {
@@ -924,8 +912,8 @@
           }
         },
         "default": {
-          "description": "Next transition of the workflow if there is no matching data conditions, or event timeout is reached",
-          "$ref": "#/definitions/transition"
+          "$ref": "#/definitions/defaultdef",
+          "description": "Default transition of the workflow if there is no matching data conditions. Can include a transition or end definition"
         },
         "dataInputSchema": {
           "type": "string",
@@ -961,7 +949,39 @@
         }
       ]
     },
+    "defaultdef": {
+      "type": "object",
+      "description": "Default definition. Can be either a transition or end definition",
+      "oneOf": [
+        {
+          "properties": {
+            "transition": {
+              "$ref": "#/definitions/transition"
+            }
+          },
+          "required": ["properties"]
+        },
+        {
+          "properties": {
+            "end": {
+              "$ref": "#/definitions/end"
+            }
+          },
+          "required": ["end"]
+        }
+      ]
+    },
     "eventcondition": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/transitioneventcondition"
+        },
+        {
+          "$ref": "#/definitions/enddeventcondition"
+        }
+      ]
+    },
+    "transitioneventcondition": {
       "type": "object",
       "description": "Switch state data event condition",
       "properties": {
@@ -983,7 +1003,39 @@
       },
       "required": ["eventRef", "transition"]
     },
+    "enddeventcondition": {
+      "type": "object",
+      "description": "Switch state data event condition",
+      "properties": {
+        "eventRef": {
+          "type" : "string",
+          "description": "References an unique event name in the defined workflow events"
+        },
+        "end": {
+          "$ref": "#/definitions/end",
+          "description": "Explicit transition to end"
+        }
+      },
+      "eventDataFilter": {
+        "description": "Event data filter definition",
+        "$ref": "#/definitions/eventdatafilter"
+      },
+      "metadata": {
+        "$ref": "common.json#/definitions/metadata"
+      },
+      "required": ["eventRef", "transition"]
+    },
     "datacondition": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/transitiondatacondition"
+        },
+        {
+          "$ref": "#/definitions/enddatacondition"
+        }
+      ]
+    },
+    "transitiondatacondition": {
       "type": "object",
       "description": "Switch state data based condition",
       "properties": {
@@ -1001,6 +1053,24 @@
       },
       "required": ["condition", "transition"]
     },
+    "enddatacondition": {
+      "type": "object",
+      "description": "Switch state data based condition",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "JsonPath expression evaluated against state data. True if results are not empty"
+        },
+        "end": {
+          "$ref": "#/definitions/end",
+          "description": "Explicit transition to end"
+        }
+      },
+      "metadata": {
+        "$ref": "common.json#/definitions/metadata"
+      },
+      "required": ["condition", "end"]
+    },
     "subflowstate": {
       "type": "object",
       "description": "Defines a sub-workflow to be executed",
@@ -1016,9 +1086,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "subflow"
-          ],
+          "const": "subflow",
           "description": "State type"
         },
         "start": {
@@ -1119,9 +1187,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "inject"
-          ],
+          "const": "inject",
           "description": "State type"
         },
         "start": {
@@ -1205,9 +1271,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "foreach"
-          ],
+          "const": "foreach",
           "description": "State type"
         },
         "start": {
@@ -1387,7 +1451,7 @@
         },
         "type": {
           "type" : "string",
-          "enum": ["callback"],
+          "const": "callback",
           "description": "State type"
         },
         "action": {


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Usecases
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Currently in switch state (both data based and event based) you have to specify a transition to another state. Same for the 'default' property which is currently a transition.

This PR adds ability to specify 'end' in both conditions and default property so no longer is it necessary to specify a "dummy" state to just end workflow execution.

**Special notes for reviewers**:

**Additional information (if needed):**