### PR TITLE
Events definition update - add convenience way to define multiple eve…

### DIFF
--- a/schema/events.json
+++ b/schema/events.json
@@ -20,6 +20,15 @@
           "description": "Unique event name",
           "minLength": 1
         },
+        "names": {
+          "type": "array",
+          "description": "List of unique event names that share the rest of the properties (source, type, kind, default)",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 2,
+          "uniqueItems": true
+        },
         "source": {
           "type": "string",
           "description": "CloudEvent source"
@@ -59,16 +68,37 @@
         }
       },
       "then": {
-        "required": [
-          "name",
-          "source",
-          "type"
+        "oneOf": [
+          {
+            "required": [
+              "name",
+              "source",
+              "type"
+            ]
+          },
+          {
+            "required": [
+              "names",
+              "source",
+              "type"
+            ]
+          }
         ]
       },
       "else": {
-        "required": [
-          "name",
-          "type"
+        "oneOf": [
+          {
+            "required": [
+              "name",
+              "type"
+            ]
+          },
+          {
+            "required": [
+              "names",
+              "type"
+            ]
+          }
         ]
       }
     },

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -10,7 +10,8 @@
       "items": {
         "type": "object",
         "$ref": "#/definitions/function"
-      }
+      },
+      "minLength": 1
     },
     "function": {
       "type": "object",

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -89,7 +89,8 @@
             "$ref": "#/definitions/callbackstate"
           }
         ]
-      }
+      },
+      "minLength": 1
     }
   },
   "required": [

--- a/specification.md
+++ b/specification.md
@@ -365,7 +365,8 @@ defined via the `parameters` property of [function definitions](#FunctionRef-Def
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| name | Unique event name | string | yes |
+| name | Unique event name | string | yes if `names` is not used |
+| names | List of unique event names that share the rest of the properties (source, type, kind, ...) | array | yes if `name` is not used |
 | source | CloudEvent source | string | yes if kind is set to "consumed", otherwise no |
 | type | CloudEvent type | string | yes |
 | kind | Defines the event is either `consumed` or `produced` by the workflow. Default is `consumed` | enum | no |
@@ -420,8 +421,61 @@ Used to define events and their correlations. These events can be either consume
 The Serverless Workflow specification mandates that all events conform to the [CloudEvents](https://github.com/cloudevents/spec) specification. 
 This is to assure consistency and portability of the events format used.
 
-The `name` property defines the name of the event that is unique inside the workflow definition. This event name can be 
+The `name` property defines a single name of the event that is unique inside the workflow definition. This event name can be 
 then referenced within [function](#Function-Definition) and [state](#State-Definition) definitions.
+
+The `names` property can be used instead of `name` when you want to define multiple events that share
+the same `source`, `type`, `kind`, and correlation rules. 
+To give an example, the following two events definitions are considered to be equal:
+
+<table>
+<tr>
+    <th>(1)</th>
+    <th>(2)</th>
+</tr>
+<tr>
+<td valign="top">
+
+```json
+{  
+  "events": [
+    {
+      "name": "Event1",
+      "type": "org.events",
+      "source": "eventssource"
+    },
+    {
+      "name": "Event2",
+      "type": "org.events",
+      "source": "eventssource"
+    },
+    {
+      "name": "Event3",
+      "type": "org.events",
+      "source": "eventssource"
+    }
+  ]
+}
+```
+
+</td>
+<td valign="top">
+
+```json
+{  
+  "events": [
+    {
+      "names": ["Event1", "Event2", "Event3"],
+      "type": "org.events",
+      "source": "eventssource"
+    }
+  ]
+}
+```
+
+</td>
+</tr>
+</table>
 
 The `source` property matches this event definition with the [source](https://github.com/cloudevents/spec/blob/master/spec.md#source-1)
 property of the CloudEvent required attributes.


### PR DESCRIPTION
…nts that share properties

Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ ] Usecases
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

Adds convenience way to define multiple events that share properties like source, type, kind, and correlation rules. 
With this change the following two events defs are considered equivalent:

1) 
```json
{  
  "events": [
    {
      "name": "Event1",
      "type": "org.events",
      "source": "eventssource"
    },
    {
      "name": "Event2",
      "type": "org.events",
      "source": "eventssource"
    },
    {
      "name": "Event3",
      "type": "org.events",
      "source": "eventssource"
    }
  ]
}
```

2) 
```json
{  
  "events": [
    {
      "names": ["Event1", "Event2", "Event3"],
      "type": "org.events",
      "source": "eventssource"
    }
  ]
}
```