### PR TITLE
Update to function and events definitions - allow inline array def as…

### DIFF
--- a/schema/events.json
+++ b/schema/events.json
@@ -3,15 +3,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Serverless Workflow specification - events schema",
   "type": "object",
-  "definitions": {
-    "events": {
-      "type": "array",
-      "description": "Workflow CloudEvent definitions. Defines CloudEvents that can be consumed or produced",
-      "items": {
-        "type": "object",
-        "$ref": "#/definitions/eventdef"
-      }
+  "events": {
+    "type": "array",
+    "description": "Workflow CloudEvent definitions. Defines CloudEvents that can be consumed or produced",
+    "items": {
+      "type": "object",
+      "$ref": "#/definitions/eventdef"
     },
+    "minItems": 1
+  },
+  "required": [
+    "events"
+  ],
+  "definitions": {
     "eventdef": {
       "type": "object",
       "properties": {

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -3,16 +3,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Serverless Workflow specification - functions schema",
   "type": "object",
-  "definitions": {
-    "functions": {
-      "type": "array",
-      "description": "Workflow function definitions",
-      "items": {
-        "type": "object",
-        "$ref": "#/definitions/function"
-      },
-      "minLength": 1
+  "functions": {
+    "type": "array",
+    "description": "Workflow function definitions",
+    "items": {
+      "type": "object",
+      "$ref": "#/definitions/function"
     },
+    "minItems": 1
+  },
+  "required": [
+    "functions"
+  ],
+  "definitions": {
     "function": {
       "type": "object",
       "properties": {

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -3,96 +3,196 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Serverless Workflow specification - workflow schema",
   "type": "object",
-  "properties": {
-    "id": {
-      "type": "string",
-      "description": "Workflow unique identifier",
-      "minLength": 1
-    },
-    "name": {
-      "type": "string",
-      "description": "Workflow name",
-      "minLength": 1
-    },
-    "description": {
-      "type": "string",
-      "description": "Workflow description"
-    },
-    "version": {
-      "type": "string",
-      "description": "Workflow version",
-      "minLength": 1
-    },
-    "schemaVersion": {
-      "type": "string",
-      "description": "Serverless Workflow schema version",
-      "minLength": 1
-    },
-    "dataInputSchema": {
-      "type": "string",
-      "format": "uri",
-      "description": "URI to JSON Schema that workflow data input adheres to"
-    },
-    "dataOutputSchema": {
-      "type": "string",
-      "format": "uri",
-      "description": "URI to JSON Schema that workflow data output adheres to"
-    },
-    "metadata": {
-      "$ref": "common.json#/definitions/metadata"
-    },
-    "events": {
-      "$ref": "events.json#/definitions/events"
-    },
-    "functions": {
-      "$ref": "functions.json#/definitions/functions"
-    },
-    "states": {
-      "type": "array",
-      "description": "State definitions",
-      "items": {
-        "anyOf": [
-          {
-            "title": "Delay State",
-            "$ref": "#/definitions/delaystate"
+  "oneOf": [
+    {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Workflow unique identifier",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "description": "Workflow name",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "description": "Workflow description"
+        },
+        "version": {
+          "type": "string",
+          "description": "Workflow version",
+          "minLength": 1
+        },
+        "schemaVersion": {
+          "type": "string",
+          "description": "Serverless Workflow schema version",
+          "minLength": 1
+        },
+        "dataInputSchema": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to JSON Schema that workflow data input adheres to"
+        },
+        "dataOutputSchema": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to JSON Schema that workflow data output adheres to"
+        },
+        "metadata": {
+          "$ref": "common.json#/definitions/metadata"
+        },
+        "events": {
+          "$ref": "events.json#/events"
+        },
+        "functions": {
+          "$ref": "functions.json#/functions"
+        },
+        "states": {
+          "type": "array",
+          "description": "State definitions",
+          "items": {
+            "anyOf": [
+              {
+                "title": "Delay State",
+                "$ref": "#/definitions/delaystate"
+              },
+              {
+                "title": "Event State",
+                "$ref": "#/definitions/eventstate"
+              },
+              {
+                "title": "Operation State",
+                "$ref": "#/definitions/operationstate"
+              },
+              {
+                "title": "Parallel State",
+                "$ref": "#/definitions/parallelstate"
+              },
+              {
+                "title": "Switch State",
+                "$ref": "#/definitions/switchstate"
+              },
+              {
+                "title": "SubFlow State",
+                "$ref": "#/definitions/subflowstate"
+              },
+              {
+                "title": "Inject State",
+                "$ref": "#/definitions/injectstate"
+              },
+              {
+                "title": "ForEach State",
+                "$ref": "#/definitions/foreachstate"
+              },
+              {
+                "title": "Callback State",
+                "$ref": "#/definitions/callbackstate"
+              }
+            ]
           },
-          {
-            "title": "Event State",
-            "$ref": "#/definitions/eventstate"
+          "minItems": 1
+        }
+      }
+    },
+    {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Workflow unique identifier",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "description": "Workflow name",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "description": "Workflow description"
+        },
+        "version": {
+          "type": "string",
+          "description": "Workflow version",
+          "minLength": 1
+        },
+        "schemaVersion": {
+          "type": "string",
+          "description": "Serverless Workflow schema version",
+          "minLength": 1
+        },
+        "dataInputSchema": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to JSON Schema that workflow data input adheres to"
+        },
+        "dataOutputSchema": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to JSON Schema that workflow data output adheres to"
+        },
+        "metadata": {
+          "$ref": "common.json#/definitions/metadata"
+        },
+        "events": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to a resource containing event definitions (json or yaml)"
+        },
+        "functions": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to a resource containing function definitions (json or yaml)"
+        },
+        "states": {
+          "type": "array",
+          "description": "State definitions",
+          "items": {
+            "anyOf": [
+              {
+                "title": "Delay State",
+                "$ref": "#/definitions/delaystate"
+              },
+              {
+                "title": "Event State",
+                "$ref": "#/definitions/eventstate"
+              },
+              {
+                "title": "Operation State",
+                "$ref": "#/definitions/operationstate"
+              },
+              {
+                "title": "Parallel State",
+                "$ref": "#/definitions/parallelstate"
+              },
+              {
+                "title": "Switch State",
+                "$ref": "#/definitions/switchstate"
+              },
+              {
+                "title": "SubFlow State",
+                "$ref": "#/definitions/subflowstate"
+              },
+              {
+                "title": "Inject State",
+                "$ref": "#/definitions/injectstate"
+              },
+              {
+                "title": "ForEach State",
+                "$ref": "#/definitions/foreachstate"
+              },
+              {
+                "title": "Callback State",
+                "$ref": "#/definitions/callbackstate"
+              }
+            ]
           },
-          {
-            "title": "Operation State",
-            "$ref": "#/definitions/operationstate"
-          },
-          {
-            "title": "Parallel State",
-            "$ref": "#/definitions/parallelstate"
-          },
-          {
-            "title": "Switch State",
-            "$ref": "#/definitions/switchstate"
-          },
-          {
-            "title": "SubFlow State",
-            "$ref": "#/definitions/subflowstate"
-          },
-          {
-            "title": "Inject State",
-            "$ref": "#/definitions/injectstate"
-          },
-          {
-            "title": "ForEach State",
-            "$ref": "#/definitions/foreachstate"
-          },
-          {
-            "title": "Callback State",
-            "$ref": "#/definitions/callbackstate"
-          }
-        ]
-      },
-      "minLength": 1
+          "minItems": 1
+        }
+      }
     }
-  },
+  ],
   "required": [
     "id",
     "name",


### PR DESCRIPTION
… well as uri reference to external resource

Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ ] Usecases
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

Allows not only existing inline-definitions of functions / events but also to reference external resource (via URI), for example:

1. Workflow definition:
```json
{  
   "id": "sampleWorkflow",
   "version": "1.0",
   "name": "Sample Workflow",
   "description": "Sample Workflow",
   "functions": "http://myhost:8080/functiondefs.json",
   "events": "http://myhost:8080/eventsdefs.json",
   "states":[
     ...
   ]
}
```

2. Function definitions resource (functiondefs.json)
```json
{
   "functions": [
      {
         "name":"HelloWorldFunction",
         "resource":"https://hellworldservice.test.com:8443/api/hellofunction"
      }
   ]
}
```

3. Event definitions resource (eventsdefs.json)
```json
{
   "events": [
      {  
         "name": "ApplicantInfo",
         "type": "org.application.info",
         "source": "applicationssource",
         "correlation": [
          { 
            "contextAttributeName": "applicantId"
          } 
         ]
      }
   ]
}