### PR TITLE
Use of OpenAPI for function definitions

### DIFF
--- a/examples/examples-argo.md
+++ b/examples/examples-argo.md
@@ -79,9 +79,8 @@ name: Hello World with parameters
 version: '1.0'
 functions:
 - name: whalesayimage
-  resource: docker/whalesay
-  type: container
   metadata:
+    image: docker/whalesay
     command: cowsay
 states:
 - name: whalesay
@@ -166,9 +165,8 @@ name: Multi Step Hello
 version: '1.0'
 functions:
 - name: whalesayimage
-  resource: docker/whalesay
-  type: container
   metadata:
+    image: docker/whalesay
     command: cowsay
 states:
 - name: hello1
@@ -271,9 +269,8 @@ name: DAG Diamond Example
 version: '1.0'
 functions:
 - name: echo
-  resource: alpine:3.7
-  type: container
   metadata:
+    image: alpine:3.7
     command: '[echo, "{{inputs.parameters.message}}"]'
 states:
 - name: A
@@ -396,34 +393,30 @@ name: Scripts and Results Example
 version: '1.0'
 functions:
 - name: gen-random-int-bash
-  resource: debian:9.4
-  type: script
   metadata:
+    image: debian:9.4
     command: bash
     source: |-
       cat /dev/urandom | od -N2 -An -i | awk -v f=1 -v r=100 '{printf "%i
       ", f + r * $1 / 65536}'
 - name: gen-random-int-python
-  resource: python:alpine3.6
-  type: script
   metadata:
+    image: python:alpine3.6
     command: python
     source: | 
       import random 
       i = random.randint(1, 100) 
       print(i)
 - name: gen-random-int-javascript
-  resource: node:9.1-alpine
-  type: script
   metadata:
+    image: node:9.1-alpine
     command: node
     source: |
       var rand = Math.floor(Math.random() * 100); 
       console.log(rand);
 - name: printmessagefunc
-  resource: alpine:latest
-  type: container
   metadata:
+    image: alpine:latest
     command: sh, -c
     source: 'echo result was: {{inputs.parameters.message}}'
 states:
@@ -504,9 +497,8 @@ name: Loop over data example
 version: '1.0'
 functions:
 - name: whalesay
-  resource: docker/whalesay:latest
-  type: container
   metadata:
+    image: docker/whalesay:latest
     command: cowsay
 states:
 - name: injectdata
@@ -602,16 +594,14 @@ name: Conditionals Example
 version: '1.0'
 functions:
 - name: flip-coin-function
-  resource: python:alpine3.6
-  type: script
   metadata:
+    image: python:alpine3.6
     command: python
     source: import random result = "heads" if random.randint(0,1) == 0 else "tails"
       print(result)
 - name: echo
-  resource: alpine:3.6
-  type: container
   metadata:
+    image: alpine:3.6
     command: sh, -c
 states:
 - name: flip-coin
@@ -703,9 +693,8 @@ name: Retry Example
 version: '1.0'
 functions:
 - name: fail-function
-  resource: python:alpine3.6
-  type: container
   metadata:
+    image: python:alpine3.6
     command: python
 states:
 - name: retry-backoff
@@ -790,14 +779,12 @@ name: Recursion Example
 version: '1.0'
 functions:
 - name: heads-function
-  resource: alpine:3.6
-  type: container
   metadata:
+    image: alpine:3.6
     command: echo "it was heads"
 - name: flip-coin-function
-  resource: python:alpine3.6
-  type: script
   metadata:
+    image: python:alpine3.6
     command: python
     source: import random result = "heads" if random.randint(0,1) == 0 else "tail"  print(result)
 states:
@@ -911,19 +898,16 @@ name: Exit/Error Handling Example
 version: '1.0'
 functions:
 - name: intentional-fail-function
-  resource: alpine:latest
-  type: container
   metadata:
+    image: alpine:latest
     command: "[sh, -c]"
 - name: send-email-function
-  resource: alpine:latest
-  type: script
   metadata:
+    image: alpine:latest
     command: "[sh, -c]"
 - name: celebrate-cry-function
-  resource: alpine:latest
-  type: script
   metadata:
+    image: alpine:latest
     command: "[sh, -c]"
 states:
 - name: intentional-fail-state

--- a/examples/examples-brigade.md
+++ b/examples/examples-brigade.md
@@ -70,8 +70,9 @@ events:
   type: exec
 functions:
 - name: greetingFunction
-  resource: alpine:3.7
-  type: echo
+  metadata:
+    image: alpine:3.7
+    command: echo
 - name: consoleLogFunction
   type: console
 states:
@@ -150,8 +151,9 @@ events:
   type: exec
 functions:
 - name: greetingFunction
-  resource: alpine:3.7
-  type: echo
+  metadata:
+    image: alpine:3.7
+    command: echo
 - name: consoleLogFunction
   type: console
 states:
@@ -324,8 +326,9 @@ events:
   type: exec
 functions:
 - name: echoFunction
-  resource: alpine:3.7
-  type: echo
+  metadata:
+    image: alpine:3.7
+    command: echo
 states:
 - name: FirstGreetGroup
   type: event
@@ -481,11 +484,13 @@ events:
   type: exec
 functions:
 - name: greetingFunction
-  resource: alpine:3.7
-  type: echo
+  metadata:
+    image: alpine:3.7
+    command: echo
 - name: storeToFileFunction
-  resource: alpine:3.7
-  type: filestore
+  metadata:
+    image: alpine:3.7
+    command: filestore
 states:
 - name: ExecActionsAndStoreResults
   type: event

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -148,7 +148,7 @@ Which is added to the states data and becomes the workflow data output.
 "functions": [
   {
      "name": "greetingFunction",
-     "resource": "functionResourse"
+     "operation": "file://myapis/greetingapis.json#greeting"
   }
 ],
 "states":[  
@@ -189,7 +189,7 @@ name: Greeting Workflow
 description: Greet Someone
 functions:
 - name: greetingFunction
-  resource: functionResourse
+  operation: file://myapis/greetingapis.json#greeting
 states:
 - name: Greet
   type: operation
@@ -304,7 +304,7 @@ filters what is selected to be the state data output which then becomes the work
 "functions": [
   {
      "name": "greetingFunction",
-     "resource": "functionResourse"
+     "operation": "file://myapis/greetingapis.json#greeting"
   }
 ],
 "states":[  
@@ -355,7 +355,7 @@ events:
   source: greetingEventSource
 functions:
 - name: greetingFunction
-  resource: functionResourse
+  operation: file://myapis/greetingapis.json#greeting
 states:
 - name: Greet
   type: event
@@ -427,7 +427,7 @@ result of the workflow execution.
 "functions": [
 {
   "name": "solveMathExpressionFunction",
-  "resource": "functionResourse"
+  "operation": "http://myapis.org/mapthapis.json#solveExpression"
 }
 ],
 "states":[  
@@ -471,7 +471,7 @@ name: Solve Math Problems Workflow
 description: Solve math problems
 functions:
 - name: solveMathExpressionFunction
-  resource: functionResourse
+  operation: http://myapis.org/mapthapis.json#solveExpression
 states:
 - name: Solve
   start:
@@ -779,7 +779,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
    "functions": [
      {
         "name": "sendRejectionEmailFunction",
-        "resource": "functionResourse"
+        "operation": "http://myapis.org/applicationapi.json#emailRejection"
      }
    ],
    "states":[  
@@ -849,7 +849,7 @@ name: Applicant Request Decision Workflow
 description: Determine if applicant request is valid
 functions:
 - name: sendRejectionEmailFunction
-  resource: functionResourse
+  operation: http://myapis.org/applicationapi.json#emailRejection
 states:
 - name: CheckApplication
   type: switch
@@ -935,7 +935,7 @@ The data output of the workflow contains the information of the exception caught
 "functions": [
   {
      "name": "provisionOrderFunction",
-     "resource": "functionResourse"
+     "operation": "http://myapis.org/provisioningapi.json#doProvision"
   }
 ],
 "states":[  
@@ -1029,7 +1029,7 @@ name: Provision Orders
 description: Provision Orders and handle errors thrown
 functions:
 - name: provisionOrderFunction
-  resource: functionResourse
+  operation: http://myapis.org/provisioningapi.json#doProvision
 states:
 - name: ProvisionOrder
   type: operation
@@ -1120,19 +1120,19 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   "functions": [
     {
       "name": "submitJob",
-      "resource": "submitJobResource"
+      "operation": "http://myapis.org/monitorapi.json#doSubmit"
     },
     {
       "name": "checkJobStatus",
-      "resource": "checkJobStatusResource"
+      "operation": "http://myapis.org/monitorapi.json#checkStatus"
     },
     {
       "name": "reportJobSuceeded",
-      "resource": "reportJobSuceededResource"
+      "operation": "http://myapis.org/monitorapi.json#reportSucceeded"
     },
     {
       "name": "reportJobFailed",
-      "resource": "reportJobFailedResource"
+      "operation": "http://myapis.org/monitorapi.json#reportFailure"
     }
   ],
   "states":[  
@@ -1287,13 +1287,13 @@ name: Job Monitoring
 description: Monitor finished execution of a submitted job
 functions:
 - name: submitJob
-  resource: submitJobResource
+  operation: http://myapis.org/monitorapi.json#doSubmit
 - name: checkJobStatus
-  resource: checkJobStatusResource
+  operation: http://myapis.org/monitorapi.json#checkStatus
 - name: reportJobSuceeded
-  resource: reportJobSuceededResource
+  operation: http://myapis.org/monitorapi.json#reportSucceeded
 - name: reportJobFailed
-  resource: reportJobFailedResource
+  operation: http://myapis.org/monitorapi.json#reportFailure
 states:
 - name: SubmitJob
   type: operation
@@ -1472,7 +1472,7 @@ CloudEvent upon completion of the workflow could look like:
 "functions": [
 {
     "name": "provisionOrderFunction",
-    "resource": "functionResourse"
+    "operation": "http://myapis.org/provisioning.json#doProvision"
 }
 ],
 "states": [
@@ -1520,7 +1520,7 @@ events:
   kind: produced
 functions:
 - name: provisionOrderFunction
-  resource: functionResourse
+  operation: http://myapis.org/provisioning.json#doProvision
 states:
 - name: ProvisionOrdersState
   type: foreach
@@ -1633,18 +1633,15 @@ have the matching patient id.
 "functions": [
 {
     "name": "callPulmonologist",
-    "type": "function",
-    "resource": "callPulmonologistResource"
+    "operation": "http://myapis.org/patientapis.json#callPulmonologist"
 },
 {
     "name": "sendTylenolOrder",
-    "type": "function",
-    "resource": "sendTylenolOrderFunction"
+    "operation": "http://myapis.org/patientapis.json#tylenolOrder"
 },
 {
     "name": "callNurse",
-    "type": "function",
-    "resource": "callNurseResource"
+    "operation": "http://myapis.org/patientapis.json#callNurse"
 }
 ],
 "states": [
@@ -1721,14 +1718,11 @@ events:
   - contextAttributeName: patientId
 functions:
 - name: callPulmonologist
-  type: function
-  resource: callPulmonologistResource
+  operation: http://myapis.org/patientapis.json#callPulmonologist
 - name: sendTylenolOrder
-  type: function
-  resource: sendTylenolOrderFunction
+  operation: http://myapis.org/patientapis.json#tylenolOrder
 - name: callNurse
-  type: function
-  resource: callNurseResource
+  operation: http://myapis.org/patientapis.json#callNurse
 states:
 - name: MonitorVitals
   type: event
@@ -1835,8 +1829,7 @@ when all three of these events happened (in no particular order).
 "functions": [
 {
     "name": "finalizeApplicationFunction",
-    "type": "function",
-    "resource": "finalizeApplicationResource"
+    "operation": "http://myapis.org/collegeapplicationapi.json#finalize"
 }
 ],
 "states": [
@@ -1899,8 +1892,7 @@ events:
   - contextAttributeName: applicantId
 functions:
 - name: finalizeApplicationFunction
-  type: function
-  resource: finalizeApplicationResource
+  operation: http://myapis.org/collegeapplicationapi.json#finalize
 states:
 - name: FinalizeApplication
   type: event
@@ -2018,13 +2010,12 @@ And for denied credit check, for example:
     "description": "Perform Customer Credit Check",
     "functions": [
         {
-            "name": "callCreditCheckMicroservice",
-            "resource": "creditCheckResource",
-            "type": "microservice"
+            "name": "creditCheckFunction",
+            "operation": "http://myapis.org/creditcheckapi.json#doCreditCheck"
         },
         {
             "name": "sendRejectionEmailFunction",
-            "resource": "rejectEmailResource"
+            "operation": "http://myapis.org/creditcheckapi.json#rejectionEmail"
         }
     ],
     "events": [
@@ -2122,11 +2113,10 @@ version: '1.0'
 name: Customer Credit Check Workflow
 description: Perform Customer Credit Check
 functions:
-- name: callCreditCheckMicroservice
-  resource: creditCheckResource
-  type: microservice
+- name: creditCheckFunction
+  operation: http://myapis.org/creditcheckapi.json#doCreditCheck
 - name: sendRejectionEmailFunction
-  resource: rejectEmailResource
+  operation: http://myapis.org/creditcheckapi.json#rejectionEmail
 events:
 - name: CreditCheckCompletedEvent
   type: creditCheckCompleteType
@@ -2237,8 +2227,7 @@ Bidding is done via an online application and bids are received as events are as
     "functions": [
         {
             "name": "StoreBidFunction",
-            "resource": "storeBidResource",
-            "type": "function"
+            "operation": "http://myapis.org/carauctionapi.json#storeBid"
         }
     ],
     "events": [
@@ -2290,8 +2279,7 @@ name: Car Auction Bidding Workflow
 description: Store a single bid whole the car auction is active
 functions:
 - name: StoreBidFunction
-  resource: storeBidResource
-  type: function
+  operation: http://myapis.org/carauctionapi.json#storeBid
 events:
 - name: CarBidEvent
   type: carBidMadeType
@@ -2372,12 +2360,11 @@ The results of the inbox service called is expected to be for example:
 "functions": [
     {
         "name": "checkInboxFunction",
-        "resource": "inboxFunctionResource",
-        "type": "getNewMessages"
+        "operation": "http://myapis.org/inboxapi.json#checkNewMessages"
     },
     {
         "name": "sendTextFunction",
-        "resource": "sendTextFunctionResource"
+        "operation": "http://myapis.org/inboxapi.json#sendText"
     }
 ],
 "states": [
@@ -2399,11 +2386,11 @@ The results of the inbox service called is expected to be for example:
             }
         ],
         "transition": {
-            "nextState": "SendTextForHighPrioriry"
+            "nextState": "SendTextForHighPriority"
         }
     },
     {
-        "name": "SendTextForHighPrioriry",
+        "name": "SendTextForHighPriority",
         "type": "foreach",
         "inputCollection": "{{ $.messages }}",
         "iterationParam": "singlemessage",
@@ -2435,10 +2422,9 @@ description: Periodically Check Inbox
 version: '1.0'
 functions:
 - name: checkInboxFunction
-  resource: inboxFunctionResource
-  type: getNewMessages
+  operation: http://myapis.org/inboxapi.json#checkNewMessages
 - name: sendTextFunction
-  resource: sendTextFunctionResource
+  operation: http://myapis.org/inboxapi.json#sendText
 states:
 - name: CheckInbox
   type: operation
@@ -2451,8 +2437,8 @@ states:
   - functionRef:
       refName: checkInboxFunction
   transition:
-    nextState: SendTextForHighPrioriry
-- name: SendTextForHighPrioriry
+    nextState: SendTextForHighPriority
+- name: SendTextForHighPriority
   type: foreach
   inputCollection: "{{ $.messages }}"
   iterationParam: singlemessage

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -2603,15 +2603,15 @@ These hold our function and event definitions which then can be referenced by mu
   "functions": [
       {
         "name": "checkFundsAvailability",
-        "resource": "accountFundsResource"
+        "operation": "file://myapis/billingapis.json#checkFunds"
       },
       {
         "name": "sendSuccessEmail",
-        "resource": "emailServiceResource"
+        "operation": "file://myapis/emailapis.json#paymentSuccess"
       },
       {
         "name": "sendInsufficientFundsEmail",
-        "resource": "emailServiceResource"
+        "operation": "file://myapis/emailapis.json#paymentInsufficientFunds"
       }
     ]
 }

--- a/extensions/kpi.md
+++ b/extensions/kpi.md
@@ -143,14 +143,11 @@ events:
   - contextAttributeName: patientId
 functions:
 - name: callPulmonologist
-  type: function
-  resource: callPulmonologistResource
+  operation: http://myapi.org/patientapi.json#callPulmonologist
 - name: sendTylenolOrder
-  type: function
-  resource: sendTylenolOrderFunction
+  operation: http://myapi.org/patientapi.json#sendTylenol
 - name: callNurse
-  type: function
-  resource: callNurseResource
+  operation: http://myapi.org/patientapi.json#callNurse
 states:
 - name: MonitorVitals
   type: event

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -71,3 +71,4 @@ _Status description:_
 | ✔️| Update transitions and end definition 'produceEvents' definition | [spec doc](../specification.md) |
 | ✔️| Events definition update - add convenience way to define multiple events that share properties | [spec doc](../specification.md) |
 | ✔️| Update to function and events definitions - allow inline array def as well as uri reference to external resource | [spec doc](../specification.md) |
+| ✔️| Enforce use of OpenAPI specification in function definitions for portability | [spec doc](../specification.md) |

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -24,21 +24,16 @@
           "description": "Unique function name",
           "minLength": 1
         },
-        "resource": {
+        "operation": {
           "type": "string",
-          "description": "Function resource (URI)"
-        },
-        "type": {
-          "type": "string",
-          "description": "Function type"
+          "description": "Combination of the function/service OpenAPI definition URI and the operationID of the operation that needs to be invoked, separated by a '#'. For example 'https://petstore.swagger.io/v2/swagger.json#getPetById'"
         },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"
         }
       },
       "required": [
-        "name",
-        "resource"
+        "name"
       ]
     }
   }

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -29,19 +29,12 @@
           "description": "Combination of the function/service OpenAPI definition URI and the operationID of the operation that needs to be invoked, separated by a '#'. For example 'https://petstore.swagger.io/v2/swagger.json#getPetById'",
           "minLength": 1
         },
-        "type": {
-          "type": "string",
-          "description": "Can be used to further describe the function defined (e.g. 'http', 'webhook', etc). This parameter should not be relied upon to be portable across platforms. Its main use is to give additional information about the function definition.",
-          "default": "rest-openapi",
-          "minLength": 1
-        },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"
         }
       },
       "required": [
-        "name",
-        "operation"
+        "name"
       ]
     }
   }

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -26,14 +26,22 @@
         },
         "operation": {
           "type": "string",
-          "description": "Combination of the function/service OpenAPI definition URI and the operationID of the operation that needs to be invoked, separated by a '#'. For example 'https://petstore.swagger.io/v2/swagger.json#getPetById'"
+          "description": "Combination of the function/service OpenAPI definition URI and the operationID of the operation that needs to be invoked, separated by a '#'. For example 'https://petstore.swagger.io/v2/swagger.json#getPetById'",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "description": "Can be used to further describe the function defined (e.g. 'http', 'webhook', etc). This parameter should not be relied upon to be portable across platforms. Its main use is to give additional information about the function definition.",
+          "default": "rest-openapi",
+          "minLength": 1
         },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"
         }
       },
       "required": [
-        "name"
+        "name",
+        "operation"
       ]
     }
   }

--- a/specification.md
+++ b/specification.md
@@ -377,7 +377,8 @@ Referenced resource must conform to the specifications [Workflow Events JSON Sch
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name | Unique function name | string | yes |
-| operation | Combination of the function/service OpenAPI definition URI and the operationID of the operation that needs to be invoked, separated by a '#'. For example 'https://petstore.swagger.io/v2/swagger.json#getPetById' | string | no |
+| operation | Combination of the function/service OpenAPI definition URI and the operationID of the operation that needs to be invoked, separated by a '#'. For example 'https://petstore.swagger.io/v2/swagger.json#getPetById' | string | yes |
+| type | Can be used to further describe the function defined (e.g. 'http', 'webhook', etc). This parameter should not be relied upon to be portable across platforms. Its main use is to give additional information about the function definition. The default value for this parameter is `rest-openapi`. | string | no |
 | [metadata](#Workflow-Metadata) | Metadata information | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -443,11 +444,16 @@ For example 'https://petstore.swagger.io/v2/swagger.json#getPetById'.
 In this example "getPetById" is the OpenAPI ["operationId"](https://swagger.io/docs/specification/paths-and-operations/)
 property in the services OpenAPI definition document which uniquely identifies a specific service operation that needs to be infoked.
 
+The `type` property can be used to further describe the function defined (e.g. 'http', 'webhook', etc). 
+This parameter should not be relied upon to be portable across platforms. 
+Its main use is to give additional information about the function definition. The default value for this parameter is `rest-openapi`.
+
 Function definitions themselves do not define data input parameters as they are reusable definitions. Parameters can be 
 defined via the `parameters` property of [function definitions](#FunctionRef-Definition) inside [actions](#Action-Definition).
 
 If the use of OpenAPI is not feasible in some scenarios, users and runtimes can chose to describe their custom function
-invocation using the [`metadata` property](#Workflow-Metadata). Please note however that such definitions cannot be considered portable across 
+invocation using the [`metadata` property](#Workflow-Metadata). 
+Please note however that such definitions cannot be considered portable across 
 multiple container/cloud environments.
 
 #### Event Definition

--- a/specification.md
+++ b/specification.md
@@ -436,10 +436,10 @@ Runtimes can utilize the function definition `metadata` information to invoke no
 
 The `name` property defines an unique name of the function definition.
 
-The `operation` property is a combination of the function/service OpenAPI definition document URI and the particular service operation that needs to be onvoked, separated by a '#'. 
+The `operation` property is a combination of the function/service OpenAPI definition document URI and the particular service operation that needs to be invoked, separated by a '#'. 
 For example `https://petstore.swagger.io/v2/swagger.json#getPetById`. 
 In this example "getPetById" is the OpenAPI ["operationId"](https://swagger.io/docs/specification/paths-and-operations/)
-property in the services OpenAPI definition document which uniquely identifies a specific service operation that needs to be infoked.
+property in the services OpenAPI definition document which uniquely identifies a specific service operation that needs to be invoked.
 
 The [`metadata`](#Workflow-Metadata) property allows users to define custom information to the custom definitions.
 This allows runtimes to define services and their operations that cannot be described via OpenAPI.


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Usecases
- [ ] Extensions
- [x] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
It is needed: Our function definitions are currently **not** portable. We cannot keep having a custom descriptor for function/service invocations. 
What is done: We enforce the use of OpenAPI specification for function/service invocation. The invoked operations from services those services must have an OpenAPI description (json/yaml) and use the operationId parameter to uniquely identify each of their exposed operations.

The function definition now becomes for example:

```json
{  
   "name": "HelloWorldFunction",
   "operation": "https://hellworldservice.api.com/api.json#helloWorld"
}
```

where https://hellworldservice.api.com/api.json is the URI to the service OpenAPI descriptor file and helloWorld is the unique operationId in such descriptor

It is mentioned that for users that simply cannot use OpenAPI to describe their services to be invoked can still use the function definition metadata parameter, but noted that such workflow models using it cannot be considered portable across multiple runtimes / cloud/container platforms.

