### PR TITLE
Add name prop to switch state data and event based conditions

### DIFF
--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -938,8 +938,8 @@
           "description": "If eventConditions is used, defines the time period to wait for events (ISO 8601 format)"
         },
         "default": {
-          "$ref": "#/definitions/defaultdef",
-          "description": "Default transition of the workflow if there is no matching data conditions. Can include a transition or end definition"
+          "description": "Default transition of the workflow if there is no matching data conditions. Can include a transition or end definition",
+          "$ref": "#/definitions/defaultdef"
         },
         "dataInputSchema": {
           "type": "string",
@@ -1017,8 +1017,8 @@
           }
         },
         "default": {
-          "$ref": "#/definitions/defaultdef",
-          "description": "Default transition of the workflow if there is no matching data conditions. Can include a transition or end definition"
+          "description": "Default transition of the workflow if there is no matching data conditions. Can include a transition or end definition",
+          "$ref": "#/definitions/defaultdef"
         },
         "dataInputSchema": {
           "type": "string",
@@ -1057,22 +1057,24 @@
     "defaultdef": {
       "type": "object",
       "description": "Default definition. Can be either a transition or end definition",
+      "properties": {
+        "transition": {
+          "$ref": "#/definitions/transition"
+        },
+        "end": {
+          "$ref": "#/definitions/end"
+        }
+      },
       "oneOf": [
         {
-          "properties": {
-            "transition": {
-              "$ref": "#/definitions/transition"
-            }
-          },
-          "required": ["properties"]
+          "required": [
+            "transition"
+          ]
         },
         {
-          "properties": {
-            "end": {
-              "$ref": "#/definitions/end"
-            }
-          },
-          "required": ["end"]
+          "required": [
+            "end"
+          ]
         }
       ]
     },
@@ -1090,6 +1092,10 @@
       "type": "object",
       "description": "Switch state data event condition",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Event condition name"
+        },
         "eventRef": {
           "type" : "string",
           "description": "References an unique event name in the defined workflow events"
@@ -1112,6 +1118,10 @@
       "type": "object",
       "description": "Switch state data event condition",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Event condition name"
+        },
         "eventRef": {
           "type" : "string",
           "description": "References an unique event name in the defined workflow events"
@@ -1144,6 +1154,10 @@
       "type": "object",
       "description": "Switch state data based condition",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Data condition name"
+        },
         "condition": {
           "type": "string",
           "description": "JsonPath expression evaluated against state data. True if results are not empty"
@@ -1162,6 +1176,10 @@
       "type": "object",
       "description": "Switch state data based condition",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Data condition name"
+        },
         "condition": {
           "type": "string",
           "description": "JsonPath expression evaluated against state data. True if results are not empty"

--- a/specification.md
+++ b/specification.md
@@ -1597,6 +1597,7 @@ If events defined in event-based conditions do not arrive before the states `eve
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
+| name | Data condition name | string | no |
 | condition | JsonPath expression evaluated against state data. True if results are not empty | string | yes |
 | [transition](#Transitions) or [end](#End-Definition) | Defines what to do if condition is true. Transition to another state, or end workflow | object | yes |
 | [metadata](#Workflow-Metadata) | Metadata information| object | no |
@@ -1614,6 +1615,7 @@ If events defined in event-based conditions do not arrive before the states `eve
 
 ```json
 {
+      "name": "Eighteen or older",
       "condition": "{{ $.applicants[?(@.age >= 18)] }}",
       "transition": {
         "nextState": "StartApplication"
@@ -1625,6 +1627,7 @@ If events defined in event-based conditions do not arrive before the states `eve
 <td valign="top">
 
 ```yaml
+name: Eighteen or older
 condition: "{{ $.applicants[?(@.age >= 18)] }}"
 transition:
   nextState: StartApplication
@@ -1648,6 +1651,7 @@ to decide what to do, transition to another workflow state, or end workflow exec
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
+| name | Event condition name | string | no |
 | eventRef | References an unique event name in the defined workflow events | string | yes |
 | [transition](#Transitions) or [end](#End-Definition) | Defines what to do if condition is true. Transition to another state, or end workflow | object | yes |
 | [eventDataFilter](#event-data-filter) | Event data filter definition | object | no |
@@ -1666,6 +1670,7 @@ to decide what to do, transition to another workflow state, or end workflow exec
 
 ```json
 {
+      "name": "Visa approved",
       "eventRef": "visaApprovedEvent",
       "transition": {
         "nextState": "HandleApprovedVisa"
@@ -1677,6 +1682,7 @@ to decide what to do, transition to another workflow state, or end workflow exec
 <td valign="top">
 
 ```yaml
+name: Visa approved
 eventRef: visaApprovedEvent
 transition:
   nextState: HandleApprovedVisa


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [x ] Schema
- [ ] Examples
- [ ] Usecases
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Adds "name" property to switch states data and event based conditions. This is needed so describe the condition rather than just having to infer it based on the condition jsonpath expression. Also can be used by tooling as a logical name.

Includes also a small fix for defaultdef definition