### PR TITLE
Workflow error handling updates

### DIFF
--- a/examples/examples-argo.md
+++ b/examples/examples-argo.md
@@ -707,12 +707,11 @@ states:
       parameters:
         args:
         - import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)
-  onErrors:
-  - name: "*"
-    retry:
-      maxAttempts: 10
-      multiplier: PT2M
-      delay: PT1M
+  retries:
+  - error: "*"
+    maxAttempts: 10
+    multiplier: PT2M
+    delay: PT1M
   end:
     kind: default
 ```
@@ -922,9 +921,9 @@ states:
       parameters:
         args: echo intentional failure; exit 1
   onErrors:
-  - name: "*"
-  transition:
-    nextState: send-email-state
+  - error: "*"
+    transition:
+      nextState: send-email-state
 - name: send-email-state
   type: operation
   actions:

--- a/examples/examples-argo.md
+++ b/examples/examples-argo.md
@@ -707,11 +707,12 @@ states:
       parameters:
         args:
         - import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)
-  retry:
-  - expression: "{{ $.[?(@.exitcode == '1')] }}"
-    maxAttempts: 10
-    multiplier: PT2M
-    interval: PT1M
+  onErrors:
+  - name: "*"
+    retry:
+      maxAttempts: 10
+      multiplier: PT2M
+      delay: PT1M
   end:
     kind: default
 ```
@@ -829,10 +830,11 @@ states:
 [Argo Example](https://github.com/argoproj/argo/tree/master/examples#exit-handlers)
 
 *Note*: With Serverless Workflow specification we can handle Argos "onExit" functionality
-in couple of ways. One is the "onError" functionality to catch errors and transition to the 
-"error" part of the workflow. Another is to send an event at the end of workflow execution 
+in couple of ways. One is the "onErrors" functionality to define errors and transition to the parts
+of workflow which is capable of handling the errors. 
+Another is to send an event at the end of workflow execution 
 which includes the workflow status. This event can then trigger execution other workflows
-that can handle each status. For this example we use the "onError" definition.
+that can handle each status. For this example we use the "onErrors" definition.
 
 <table>
 <tr>
@@ -919,10 +921,8 @@ states:
       refName: intentional-fail-function
       parameters:
         args: echo intentional failure; exit 1
-  onError:
-  - expression: "{{ $.errors[0] }}"
-    errorDataFilter:
-      dataOutputPath: "{{ $.exit-code }}"
+  onErrors:
+  - name: "*"
   transition:
     nextState: send-email-state
 - name: send-email-state

--- a/examples/examples-argo.md
+++ b/examples/examples-argo.md
@@ -696,6 +696,11 @@ functions:
   metadata:
     image: python:alpine3.6
     command: python
+retries:
+- name: All workflow errors retry strategy
+  maxAttempts: 10
+  multiplier: PT2M
+  delay: PT1M
 states:
 - name: retry-backoff
   type: operation
@@ -707,11 +712,11 @@ states:
       parameters:
         args:
         - import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)
-  retries:
+  onErrors:
   - error: "*"
-    maxAttempts: 10
-    multiplier: PT2M
-    delay: PT1M
+    retryRef: All workflow errors retry strategy
+    end:
+      kind: default
   end:
     kind: default
 ```

--- a/examples/examples-brigade.md
+++ b/examples/examples-brigade.md
@@ -180,10 +180,9 @@ states:
         refName: consoleLogFunction
         parameters:
           log: done
-  onError:
+  onErrors:
   - expression:
-      language: spel
-      body: "{{ $.exceptions[0] }}"
+      name: "*"
     transition:
       nextState: HandleErrorState
   end:

--- a/examples/examples-brigade.md
+++ b/examples/examples-brigade.md
@@ -181,8 +181,7 @@ states:
         parameters:
           log: done
   onErrors:
-  - expression:
-      name: "*"
+  - error: "*"
     transition:
       nextState: HandleErrorState
   end:

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -963,19 +963,19 @@ The data output of the workflow contains the information of the exception caught
     },
     "onErrors": [
        {
-         "name": "Missing order id",
+         "error": "Missing order id",
          "transition": {
            "nextState": "MissingId"
          }
        },
        {
-         "name": "Missing order item",
+         "error": "Missing order item",
          "transition": {
            "nextState": "MissingItem"
          }
        },
        {
-        "expression": "Missing order quantity",
+        "error": "Missing order quantity",
         "transition": {
           "nextState": "MissingQuantity"
         }
@@ -1045,13 +1045,13 @@ states:
   transition:
     nextState: ApplyOrder
   onErrors:
-  - name: Missing order id
+  - error: Missing order id
     transition:
       nextState: MissingId
-  - name: Missing order item
+  - error: Missing order item
     transition:
       nextState: MissingItem
-  - expression: Missing order quantity
+  - error: Missing order quantity
     transition:
       nextState: MissingQuantity
 - name: MissingId
@@ -1157,7 +1157,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       ],
       "onErrors": [
       {
-        "name": "*",
+        "error": "*",
         "transition": {
           "nextState": "SubmitError"
         }
@@ -1304,7 +1304,7 @@ states:
     actionDataFilter:
       dataResultsPath: "{{ $.jobuid }}"
   onErrors:
-  - name: "*"
+  - error: "*"
     transition:
       nextState: SubmitError
   stateDataFilter:

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -891,10 +891,9 @@ states:
 #### Description
 
 In this example we show off the states error handling capability. The workflow data input that's passed in contains
-missing order information that causes the function in the "ProvisionOrder" state to throw a runtime exception. With the "onError" expression we
-can transition the workflow to different error handling states depending on the error thrown. Each type of error
-in this example is handled by simple delay states, each including an error data filter which sets the exception info as their
-data output. If no error is caught the workflow can transition to the "ApplyOrder" state.
+missing order information that causes the function in the "ProvisionOrder" state to throw a runtime exception. With the "onErrors" definition we
+can transition the workflow to different error handling states. Each type of error
+in this example is handled by simple delay states. If no errors are encountered the workflow can transition to the "ApplyOrder" state.
 
 Workflow data is assumed to me:
 
@@ -956,32 +955,32 @@ The data output of the workflow contains the information of the exception caught
           }
        }
     ],
-    "onError": [
-       {
-         "expression": "{{ $.exceptions[?(@.name == 'MissingOrderIdException')] }}",
-         "transition": {
-           "nextState": "MissingId"
-         }
-       },
-       {
-         "expression": "{{ $.exceptions[?(@.name == 'MissingOrderItemException')] }}",
-         "transition": {
-           "nextState": "MissingItem"
-         }
-       },
-       {
-        "expression": "{{ $.exceptions[?(@.name == 'MissingOrderQuantityException')] }}",
-        "transition": {
-          "nextState": "MissingQuantity"
-        }
-       }
-    ],
     "stateDataFilter": {
        "dataOutputPath": "{{ $.exceptions }}"
     },
     "transition": {
        "nextState":"ApplyOrder"
-    }
+    },
+    "onErrors": [
+       {
+         "name": "Missing order id",
+         "transition": {
+           "nextState": "MissingId"
+         }
+       },
+       {
+         "name": "Missing order item",
+         "transition": {
+           "nextState": "MissingItem"
+         }
+       },
+       {
+        "expression": "Missing order quantity",
+        "transition": {
+          "nextState": "MissingQuantity"
+        }
+       }
+    ]
 },
 {
    "name": "MissingId",
@@ -1041,20 +1040,20 @@ states:
       refName: provisionOrderFunction
       parameters:
         order: "{{ $.order }}"
-  onError:
-  - expression: "{{ $.exceptions[?(@.name == 'MissingOrderIdException')] }}"
-    transition:
-      nextState: MissingId
-  - expression: "{{ $.exceptions[?(@.name == 'MissingOrderItemException')] }}"
-    transition:
-      nextState: MissingItem
-  - expression: "{{ $.exceptions[?(@.name == 'MissingOrderQuantityException')] }}"
-    transition:
-      nextState: MissingQuantity
   stateDataFilter:
     dataOutputPath: "{{ $.exceptions }}"
   transition:
     nextState: ApplyOrder
+  onErrors:
+  - name: Missing order id
+    transition:
+      nextState: MissingId
+  - name: Missing order item
+    transition:
+      nextState: MissingItem
+  - expression: Missing order quantity
+    transition:
+      nextState: MissingQuantity
 - name: MissingId
   type: subflow
   workflowId: handleMissingIdExceptionWorkflow
@@ -1156,12 +1155,9 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
           }
       }
       ],
-      "onError": [
+      "onErrors": [
       {
-        "expression": "{{ $.exceptions[0] }}",
-        "errorDataFilter": {
-          "dataOutputPath": "{{ $.exception }}"
-        },
+        "name": "*",
         "transition": {
           "nextState": "SubmitError"
         }
@@ -1307,10 +1303,8 @@ states:
         name: "{{ $.job.name }}"
     actionDataFilter:
       dataResultsPath: "{{ $.jobuid }}"
-  onError:
-  - expression: "{{ $.exceptions[0] }}"
-    errorDataFilter:
-      dataOutputPath: "{{ $.exception }}"
+  onErrors:
+  - name: "*"
     transition:
       nextState: SubmitError
   stateDataFilter:

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -38,7 +38,7 @@ _Status description:_
 | ✔️| Update workflow start definition | [spec doc](https://github.com/cncf/wg-serverless/blob/v0.1/workflow/spec/spec.md) |
 | ✔️| Prepare github branch and docs for v0.1 | [branch](https://github.com/cncf/wg-serverless/tree/v0.1/workflow/spec) |
 
-## 1.0-alpha-1 (Release data TBD)
+## v0.5
 
 | Status | Description | Comments |
 | --- | --- |  --- |
@@ -72,3 +72,4 @@ _Status description:_
 | ✔️| Events definition update - add convenience way to define multiple events that share properties | [spec doc](../specification.md) |
 | ✔️| Update to function and events definitions - allow inline array def as well as uri reference to external resource | [spec doc](../specification.md) |
 | ✔️| Enforce use of OpenAPI specification in function definitions for portability | [spec doc](../specification.md) |
+| ✔️| Update workflow Error Handling | [spec doc](../specification.md) |

--- a/schema/retries.json
+++ b/schema/retries.json
@@ -1,0 +1,54 @@
+{
+  "$id": "https://serverlessworkflow.org/core/retries.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Serverless Workflow specification - retries schema",
+  "type": "object",
+  "retries": {
+    "type": "array",
+    "description": "Workflow Retry definitions. Define retry strategies that can be referenced in states onError definitions",
+    "items": {
+      "type": "object",
+      "$ref": "#/definitions/retrydef"
+    },
+    "minItems": 1
+  },
+  "required": [
+    "retries"
+  ],
+  "definitions": {
+    "retrydef": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique retry strategy name",
+          "minLength": 1
+        },
+        "delay": {
+          "type": "string",
+          "description": "Time delay between retry attempts (ISO 8601 duration format)"
+        },
+        "multiplier": {
+          "type": "string",
+          "description": "Multiplier value by which interval increases during each attempt (ISO 8601 time format)"
+        },
+        "maxAttempts": {
+          "type": ["integer","string"],
+          "minimum": 1,
+          "minLength": 0,
+          "description": "Maximum number of retry attempts."
+        },
+        "jitter": {
+          "type": ["number","string"],
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "If float type, maximum amount of random time added or subtracted from the delay between each retry relative to total delay (between 0.0 and 1.0). If string type, absolute maximum amount of random time added or subtracted from the delay between each retry (ISO 8601 duration format)"
+        }
+      },
+      "required": [
+        "name",
+        "maxAttempts"
+      ]
+    }
+  }
+}

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -247,7 +247,7 @@
           "minLength": 1
         },
         "transition": {
-          "description": "Transition to next state to handle the error. If retryRef is define, this transition is taken only if retries were unsuccessful.",
+          "description": "Transition to next state to handle the error. If retryRef is defined, this transition is taken only if retries were unsuccessful.",
           "$ref": "#/definitions/transition"
         },
         "end": {

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -228,7 +228,7 @@
     "error": {
       "type": "object",
       "properties": {
-        "name": {
+        "error": {
           "type": "string",
           "description": "Domain-specific error name, or '*' to indicate all possible errors",
           "minLength": 1
@@ -238,18 +238,28 @@
           "description": "Error code. Can be used in addition to the name to help runtimes resolve to technical errors/exceptions",
           "minLength": 1
         },
-        "retry": {
-          "description": "Retry Definition",
-          "$ref": "#/definitions/retry"
-        },
         "transition": {
-          "description": "Transition to next state. If retry is defined, it is taken if defined retries were not successful",
+          "description": "Transition to next state to handle the error.",
           "$ref": "#/definitions/transition"
+        },
+        "end": {
+          "description": "End workflow execution in case of this error",
+          "$ref": "#/definitions/end"
         }
       },
-      "required": [
-        "name",
-        "transition"
+      "oneOf": [
+        {
+          "required": [
+            "error",
+            "transition"
+          ]
+        },
+        {
+          "required": [
+            "error",
+            "end"
+          ]
+        }
       ]
     },
     "onevents": {
@@ -329,9 +339,19 @@
       "type": "object",
       "description": "Retry Definition",
       "properties": {
+        "error": {
+          "type": "string",
+          "description": "Domain-specific error name, or '*' to indicate all possible errors",
+          "minLength": 1
+        },
+        "code": {
+          "type": "string",
+          "description": "Error code. Can be used in addition to the error to help runtimes resolve to technical errors/exceptions",
+          "minLength": 1
+        },
         "delay": {
           "type": "string",
-          "description": "Time delay between retry attempts (ISO 8601 time format)"
+          "description": "Time delay between retry attempts (ISO 8601 duration format)"
         },
         "multiplier": {
           "type": "string",
@@ -348,10 +368,31 @@
           "minimum": 0.0,
           "maximum": 1.0,
           "description": "If float type, maximum amount of random time added or subtracted from the delay between each retry relative to total delay (between 0.0 and 1.0). If string type, absolute maximum amount of random time added or subtracted from the delay between each retry (ISO 8601 duration format)"
+        },
+        "transition": {
+          "description": "Transition to next state if retries were unsuccessful",
+          "$ref": "#/definitions/transition"
+        },
+        "end": {
+          "description": "End workflow execution definition if retries were unsuccessful",
+          "$ref": "#/definitions/end"
         }
       },
-      "required": [
-        "maxAttempts"
+      "oneOf": [
+        {
+          "required": [
+            "error",
+            "maxAttempts",
+            "transition"
+          ]
+        },
+        {
+          "required": [
+            "error",
+            "maxAttempts",
+            "end"
+          ]
+        }
       ]
     },
     "functionref": {
@@ -477,6 +518,14 @@
             "$ref": "#/definitions/error"
           }
         },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
+          }
+        },
         "transition": {
           "description": "Next transition of the workflow after the time delay",
           "$ref": "#/definitions/transition"
@@ -576,6 +625,14 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
+          }
+        },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
           }
         },
         "dataInputSchema": {
@@ -695,6 +752,14 @@
             "$ref": "#/definitions/error"
           }
         },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
+          }
+        },
         "transition": {
           "description": "Next transition of the workflow after all the actions have been performed",
           "$ref": "#/definitions/transition"
@@ -811,6 +876,14 @@
             "$ref": "#/definitions/error"
           }
         },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
+          }
+        },
         "transition": {
           "description": "Next transition of the workflow after all branches have completed execution",
           "$ref": "#/definitions/transition"
@@ -918,6 +991,14 @@
             "$ref": "#/definitions/error"
           }
         },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
+          }
+        },
         "eventTimeout": {
           "type": "string",
           "description": "If eventConditions is used, defines the time period to wait for events (ISO 8601 format)"
@@ -999,6 +1080,14 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
+          }
+        },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
           }
         },
         "default": {
@@ -1225,6 +1314,14 @@
             "$ref": "#/definitions/error"
           }
         },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
+          }
+        },
         "transition": {
           "description": "Next transition of the workflow after SubFlow has completed execution",
           "$ref": "#/definitions/transition"
@@ -1431,6 +1528,14 @@
             "$ref": "#/definitions/error"
           }
         },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
+          }
+        },
         "transition": {
           "description": "Next transition of the workflow after state has completed",
           "$ref": "#/definitions/transition"
@@ -1580,6 +1685,14 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
+          }
+        },
+        "retries": {
+          "type": "array",
+          "description": "States retry definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
           }
         },
         "dataInputSchema": {

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -238,7 +238,7 @@
         },
         "code": {
           "type": "string",
-          "description": "Error code. Can be used in addition to the name to help runtimes resolve to technical errors/exceptions",
+          "description": "Error code. Can be used in addition to the name to help runtimes resolve to technical errors/exceptions. Should not be defined if error is set to '*'",
           "minLength": 1
         },
         "retryRef": {

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -228,20 +228,27 @@
     "error": {
       "type": "object",
       "properties": {
-        "expression": {
+        "name": {
           "type": "string",
-          "description": "JsonPath expression. Evaluated against error data. Is true if returns non empty result"
+          "description": "Domain-specific error name, or '*' to indicate all possible errors",
+          "minLength": 1
         },
-        "errorDataFilter": {
-          "$ref": "#/definitions/errordatafilter"
+        "code": {
+          "type": "string",
+          "description": "Error code. Can be used in addition to the name to help runtimes resolve to technical errors/exceptions",
+          "minLength": 1
+        },
+        "retry": {
+          "description": "Retry Definition",
+          "$ref": "#/definitions/retry"
         },
         "transition": {
-          "description": "Next transition of the workflow when expression is matched",
+          "description": "Transition to next state. If retry is defined, it is taken if defined retries were not successful",
           "$ref": "#/definitions/transition"
         }
       },
       "required": [
-        "expression",
+        "name",
         "transition"
       ]
     },
@@ -322,13 +329,9 @@
       "type": "object",
       "description": "Retry Definition",
       "properties": {
-        "expression": {
+        "delay": {
           "type": "string",
-          "description": "JsonPath expression. Evaluated against state data. Is true if returns non empty data"
-        },
-        "interval": {
-          "type": "string",
-          "description": "Interval value for retry (ISO 8601 repeatable format)"
+          "description": "Time delay between retry attempts (ISO 8601 time format)"
         },
         "multiplier": {
           "type": "string",
@@ -336,9 +339,9 @@
         },
         "maxAttempts": {
           "type": ["integer","string"],
-          "minimum": 0,
+          "minimum": 1,
           "minLength": 0,
-          "description": "Maximum number of retry attempts. Value of 0 means no retries are performed"
+          "description": "Maximum number of retry attempts."
         },
         "jitter": {
           "type": ["number","string"],
@@ -348,7 +351,7 @@
         }
       },
       "required": [
-        "expression"
+        "maxAttempts"
       ]
     },
     "functionref": {
@@ -466,9 +469,9 @@
           "type": "string",
           "description": "Amount of time (ISO 8601 format) to delay"
         },
-        "onError": {
+        "onErrors": {
           "type": "array",
-          "description": "OnError Definition",
+          "description": "States error handling definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
@@ -567,15 +570,7 @@
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
         },
-        "retry": {
-          "type": "array",
-          "description": "Retry Definition",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
-          }
-        },
-        "onError": {
+        "onErrors": {
           "type": "array",
           "description": "States error handling definitions",
           "items": {
@@ -692,15 +687,7 @@
             "$ref": "#/definitions/action"
           }
         },
-        "retry": {
-          "type": "array",
-          "description": "Retry Definition",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
-          }
-        },
-        "onError": {
+        "onErrors": {
           "type": "array",
           "description": "States error handling definitions",
           "items": {
@@ -816,15 +803,7 @@
           "minLength": 0,
           "description": "Used when completionType is set to 'n_of_m' to specify the 'N' value"
         },
-        "retry": {
-          "type": "array",
-          "description": "Retry Definition",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
-          }
-        },
-        "onError": {
+        "onErrors": {
           "type": "array",
           "description": "States error handling definitions",
           "items": {
@@ -931,7 +910,7 @@
             "$ref": "#/definitions/eventcondition"
           }
         },
-        "onError": {
+        "onErrors": {
           "type": "array",
           "description": "States error handling definitions",
           "items": {
@@ -1014,7 +993,7 @@
             "$ref": "#/definitions/datacondition"
           }
         },
-        "onError": {
+        "onErrors": {
           "type": "array",
           "description": "States error handling definitions",
           "items": {
@@ -1238,7 +1217,7 @@
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
         },
-        "onError": {
+        "onErrors": {
           "type": "array",
           "description": "States error handling definitions",
           "items": {
@@ -1444,15 +1423,7 @@
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
         },
-        "retry": {
-          "type": "array",
-          "description": "Retry Definition",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
-          }
-        },
-        "onError": {
+        "onErrors": {
           "type": "array",
           "description": "States error handling definitions",
           "items": {
@@ -1603,15 +1574,7 @@
           "description": "State data filter definition",
           "$ref": "#/definitions/statedatafilter"
         },
-        "retry": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
-          }
-        },
-        "onError": {
+        "onErrors": {
           "type": "array",
           "description": "States error handling definitions",
           "items": {

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -49,6 +49,9 @@
         "functions": {
           "$ref": "functions.json#/functions"
         },
+        "retries": {
+          "$ref": "retries.json#/retries"
+        },
         "states": {
           "type": "array",
           "description": "State definitions",
@@ -238,12 +241,17 @@
           "description": "Error code. Can be used in addition to the name to help runtimes resolve to technical errors/exceptions",
           "minLength": 1
         },
+        "retryRef": {
+          "type": "string",
+          "description": "References a unique name of a retry definition.",
+          "minLength": 1
+        },
         "transition": {
-          "description": "Transition to next state to handle the error.",
+          "description": "Transition to next state to handle the error. If retryRef is define, this transition is taken only if retries were unsuccessful.",
           "$ref": "#/definitions/transition"
         },
         "end": {
-          "description": "End workflow execution in case of this error",
+          "description": "End workflow execution in case of this error. If retryRef is defined, this ends workflow only if retries were unsuccessful.",
           "$ref": "#/definitions/end"
         }
       },
@@ -331,66 +339,6 @@
         {
           "required": [
             "eventRef"
-          ]
-        }
-      ]
-    },
-    "retry": {
-      "type": "object",
-      "description": "Retry Definition",
-      "properties": {
-        "error": {
-          "type": "string",
-          "description": "Domain-specific error name, or '*' to indicate all possible errors",
-          "minLength": 1
-        },
-        "code": {
-          "type": "string",
-          "description": "Error code. Can be used in addition to the error to help runtimes resolve to technical errors/exceptions",
-          "minLength": 1
-        },
-        "delay": {
-          "type": "string",
-          "description": "Time delay between retry attempts (ISO 8601 duration format)"
-        },
-        "multiplier": {
-          "type": "string",
-          "description": "Multiplier value by which interval increases during each attempt (ISO 8601 time format)"
-        },
-        "maxAttempts": {
-          "type": ["integer","string"],
-          "minimum": 1,
-          "minLength": 0,
-          "description": "Maximum number of retry attempts."
-        },
-        "jitter": {
-          "type": ["number","string"],
-          "minimum": 0.0,
-          "maximum": 1.0,
-          "description": "If float type, maximum amount of random time added or subtracted from the delay between each retry relative to total delay (between 0.0 and 1.0). If string type, absolute maximum amount of random time added or subtracted from the delay between each retry (ISO 8601 duration format)"
-        },
-        "transition": {
-          "description": "Transition to next state if retries were unsuccessful",
-          "$ref": "#/definitions/transition"
-        },
-        "end": {
-          "description": "End workflow execution definition if retries were unsuccessful",
-          "$ref": "#/definitions/end"
-        }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "error",
-            "maxAttempts",
-            "transition"
-          ]
-        },
-        {
-          "required": [
-            "error",
-            "maxAttempts",
-            "end"
           ]
         }
       ]
@@ -512,18 +460,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "transition": {
@@ -621,18 +561,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "dataInputSchema": {
@@ -746,18 +678,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "transition": {
@@ -870,18 +794,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "transition": {
@@ -985,18 +901,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "eventTimeout": {
@@ -1076,18 +984,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "default": {
@@ -1308,18 +1208,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "transition": {
@@ -1522,18 +1414,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "transition": {
@@ -1681,18 +1565,10 @@
         },
         "onErrors": {
           "type": "array",
-          "description": "States error handling definitions",
+          "description": "States error handling and retries definitions",
           "items": {
             "type": "object",
             "$ref": "#/definitions/error"
-          }
-        },
-        "retries": {
-          "type": "array",
-          "description": "States retry definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/retry"
           }
         },
         "dataInputSchema": {

--- a/specification.md
+++ b/specification.md
@@ -3850,9 +3850,9 @@ onErrors:
 </tr>
 </table>
 
-Here is say that when the "Inventory service timeout" is encountered, we want to use our defined "Service Call Timeout Retry Strategy"
-which hold the needed retry information. If the error definition does not include a `retryRef` property
-it means that we do not want to perform retries when this error is encountered during workflow execution.
+In this example we say that if the  "Inventory service timeout" error is encountered, we want to use our defined "Service Call Timeout Retry Strategy"
+which holds the needed retry information. If the error definition does not include a `retryRef` property
+it means that we do not want to perform retries for the defined error.
 
 
 When referencing a retry strategy in your states error definitions, if the maximum amount of unsuccessful retries is reached, 

--- a/specification.md
+++ b/specification.md
@@ -248,7 +248,7 @@ which would set the workflow version to `1.0.0`.
 | [dataOutputSchema](#Workflow-data-output) | URI to JSON Schema that workflow data output adheres to | string | no |
 | [events](#Event-Definition) | Workflow event definitions.  | array or string | no |
 | [functions](#Function-Definition) | Workflow function definitions. Can be either inline function definitions (if array) or URI pointing to a resource containing json/yaml function definitions (if string) | array or string| no |
-| [retries](#Retry-Definition) | Workflow retries definitions. Can be either inline function definitions (if array) or URI pointing to a resource containing json/yaml retry definitions (if string) | array or string| no |
+| [retries](#Retry-Definition) | Workflow retries definitions. Can be either inline retries definitions (if array) or URI pointing to a resource containing json/yaml retry definitions (if string) | array or string| no |
 | [states](#State-Definition) | Workflow states | array | yes |
 | [metadata](#Workflow-Metadata) | Metadata information| object | no |
 


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x ] Specification
- [ x] Schema
- [ x] Examples
- [ ] Usecases
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
This PR updates the workflow error handling for the specification:

allows for defining domain-specific errors
combines error and retry handling which was separate before
significantly reduces error handling complexity
removes error data filter

retry definition strategies can be defined in a top-level workflow "retries" array now.
on states onErrors error definitions you can reference a particular strategy to be used for the specific error defined

**Special notes for reviewers**:

**Additional information (if needed):**