### PR TITLE
Adding roadmap items from call 07/12/12

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -79,7 +79,15 @@ _Status description:_
 
 | Status | Description | Comments |
 | --- | --- |  --- |
-| 🚩 | Start discussions on Serverless Workflow Technology Compatibility Kit (TCK) | |
-| 🚩 | Decide on state/task/stage/step naming convention | [issue link](https://github.com/cncf/wg-serverless/issues/127) |
-| ✏️ | Finish specification primer document | [wiki](https://github.com/serverlessworkflow/specification/wiki) |
-| ✔️| Adding Workflow Compensation capabilities | [spec doc](../specification.md) |
+| ✔️| Adding Workflow Compensation capabilities (cmp [Compensating Transaction](https://docs.microsoft.com/en-us/azure/architecture/patterns/compensating-transaction), [SAGA pattern](https://microservices.io/patterns/data/saga.html)) | [spec doc](../specification.md) |
+| 🚩 | JSONPatch transformations | [issue](https://github.com/serverlessworkflow/specification/issues/149) |
+| 🚩 | Workflow invocation bindings |  |
+| 🚩 | CE Subscriptions & Discovery |  |
+| 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 
+| 🚩 | Uniqueness constraint for workflows | [issue](https://github.com/serverlessworkflow/specification/issues/146) |
+| 🚩 | Function invocations (GRPC) |  |
+| 🚩 | OpenAPI endpoint selection |  |
+| 🚩 | Data triggers |  |
+| 🚩 | JSON schema checks |  |
+| 🚩 | Start discussions on Serverless Workflow Technology Compatibility Kit (TCK) |  |
+| ✏️ | Specification primer | [google doc](https://docs.google.com/document/d/11rD3Azj63G2Si0VpokSpr-1ib3mFRFHSwN6tJb-0LQM/edit#heading=h.paewfy83tetm) continued in [wiki](https://github.com/serverlessworkflow/specification/wiki) |


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [ ] Schema
- [ ] Examples
- [ ] Usecases
- [ ] Extensions
- [X] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
We had a couple of new roadmap items in our [community call on 07/12/20](https://docs.google.com/document/d/1xwcsWQmMiRN24a7o7oy9MstzMroAup31oOkM5Dru1jQ/edit#). This PR adds them

Also, I believe the terminology has been discussed and is motivated in the [wiki terminology discussion](https://github.com/serverlessworkflow/specification/wiki/Terminology#control-perspective---state-vs-task-vs-step-vs-stage-vs-event-driven), so closing it

And eventually, the primer content sections that were completed have been moved to the wiki. The primer is an ever ongoing item (lots of potential topics), so keeping it for now.

**Special notes for reviewers**:
Happy to add links to issues as soon as they're written.

**Additional information (if needed):**