### PR TITLE
Update to start/end definitions

### DIFF
--- a/examples/examples-argo.md
+++ b/examples/examples-argo.md
@@ -85,15 +85,13 @@ functions:
 states:
 - name: whalesay
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: whalesayimage
       parameters:
         message: "{{ $.message }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -171,8 +169,7 @@ functions:
 states:
 - name: hello1
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: whalesayimage
@@ -196,8 +193,7 @@ states:
         refName: whalesayimage
         parameters:
           message: hello2b
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -275,8 +271,7 @@ functions:
 states:
 - name: A
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: echo
@@ -304,15 +299,13 @@ states:
     nextState: D
 - name: D
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: echo
       parameters:
         message: D
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -422,8 +415,7 @@ functions:
 states:
 - name: generate
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: gen-random-int-bash
@@ -438,8 +430,7 @@ states:
       refName: printmessagefunc
       parameters:
         message: "{{ $.results }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -503,8 +494,7 @@ functions:
 states:
 - name: injectdata
   type: inject
-  start:
-    kind: default
+  start: true
   data:
     greetings:
     - hello world
@@ -521,8 +511,7 @@ states:
       refName: whalesay
       parameters:
         message: "{{ $.greeting }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -606,8 +595,7 @@ functions:
 states:
 - name: flip-coin
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: flip-coin-function
@@ -631,8 +619,7 @@ states:
       refName: echo
     actionDataFilter:
       dataResultsPath: it was heads
-  end:
-    kind: default
+  end: true
 - name: show-results-tails
   type: operation
   actions:
@@ -640,8 +627,7 @@ states:
       refName: echo
     actionDataFilter:
       dataResultsPath: it was tails
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -705,8 +691,7 @@ retries:
 states:
 - name: retry-backoff
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: flip-coin-function
@@ -716,10 +701,8 @@ states:
   onErrors:
   - error: "*"
     retryRef: All workflow errors retry strategy
-    end:
-      kind: default
-  end:
-    kind: default
+    end: true
+  end: true
 ```
 
 </td>
@@ -796,8 +779,7 @@ functions:
 states:
 - name: flip-coin-state
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: flip-coin-function
@@ -821,8 +803,7 @@ states:
       refName: heads-function
       parameters:
         args: echo "it was heads"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -919,8 +900,7 @@ functions:
 states:
 - name: intentional-fail-state
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: intentional-fail-function
@@ -955,8 +935,7 @@ states:
       refName: celebrate-cry-function
       parameters:
         args: echo hooray!
-  end:
-    kind: default
+  end: true
 - name: cry-state
   type: operation
   actions:
@@ -964,8 +943,7 @@ states:
       refName: celebrate-cry-function
       parameters:
         args: echo boohoo!
-  end:
-    kind: default
+  end: true
 ```
 
 </td>

--- a/examples/examples-brigade.md
+++ b/examples/examples-brigade.md
@@ -78,8 +78,7 @@ functions:
 states:
 - name: GreetingState
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -99,8 +98,7 @@ states:
         refName: consoleLogFunction
         parameters:
           log: done
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -159,8 +157,7 @@ functions:
 states:
 - name: GreetingState
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -184,8 +181,7 @@ states:
   - error: "*"
     transition:
       nextState: HandleErrorState
-  end:
-    kind: default
+  end: true
 - name: HandleErrorState
   type: operation
   actions:
@@ -194,8 +190,7 @@ states:
       refName: consoleLogFunction
       parameters:
         log: Caught Exception $.exception
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -244,8 +239,7 @@ functions:
 states:
 - name: GreetingState
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -263,8 +257,7 @@ states:
         refName: consoleLogFunction
         parameters:
           log: "**** I'm a GitHub 'push' handler"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -330,8 +323,7 @@ functions:
 states:
 - name: FirstGreetGroup
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -361,8 +353,7 @@ states:
       refName: echoFunction
       parameters:
         message: bye-again
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -409,8 +400,7 @@ functions:
 states:
 - name: LogEventData
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -427,8 +417,7 @@ states:
         refName: consoleFunction
         parameters:
           log: ">>> project $event.data.project.name clones the repo at by $.event.data.repo.cloneURL"
-  end:
-    kind: default
+  end: true
 
 ```
 
@@ -492,8 +481,7 @@ functions:
 states:
 - name: ExecActionsAndStoreResults
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -520,8 +508,7 @@ states:
         parameters:
           destination: "{{ $.event.destination }}"
           value: "{{ $.helloResult }} {{ $.worldResults }}"
-  end:
-    kind: default
+  end: true
 
 ```
 
@@ -581,8 +568,7 @@ functions:
 states:
 - name: ExecEventState
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -613,8 +599,7 @@ states:
         refName: consoleLogFunction
         parameters:
           log: fired $.nextEvent.data.type caused by $.nextEvent.data.cause.event
-  end:
-    kind: default
+  end: true
 ```
 
 </td>

--- a/examples/examples-google-cloud-workflows.md
+++ b/examples/examples-google-cloud-workflows.md
@@ -90,14 +90,14 @@ languages.
         {
             "name": "Set Output",
             "type": "inject",
-            "start": { "kind": "default" },
+            "start": true,
             "data": {
                 "outputVar": "Hello {{ $.firstName }} {{ $.lastName }}"
             },
             "stateDataFilter": {
                 "dataOutputPath": "{{ $.outputVar }}"
              },
-            "end": { "kind": "default" }
+            "end": true
         }
     ]
 }
@@ -197,7 +197,7 @@ instance is created. See the Serverless Workflow ["Workflow Data"](../specificat
         {
             "name": "DoConcat",
             "type": "inject",
-            "start": { "kind": "default" },
+            "start": true,
             "data": {
                 "array": [
                     "foo",
@@ -208,7 +208,7 @@ instance is created. See the Serverless Workflow ["Workflow Data"](../specificat
             "stateDataFilter": {
                 "dataOutputPath": "{{ concat($.array.[*]) }}"
              },
-            "end": { "kind": "default" }
+            "end": true
         }
     ]
 }
@@ -288,7 +288,7 @@ it just complicates things and is not needed.
         {
             "name": "DoStop",
             "type": "operation",
-            "start": { "kind": "default" },
+            "start": true,
             "actions": [
                 {
                     "functionRef": {
@@ -301,7 +301,7 @@ it just complicates things and is not needed.
                     }
                 }
             ],
-            "end": { "kind": "default" }
+            "end": true
         }
     ],
     "functions": [
@@ -418,7 +418,7 @@ as service invocations, where as Google Workflow uses the "call" keyword.
         {
             "name": "DoPublish",
             "type": "operation",
-            "start": { "kind": "default" },
+            "start": true,
             "actions": [
                 {
                     "functionRef": {
@@ -436,7 +436,6 @@ as service invocations, where as Google Workflow uses the "call" keyword.
                     "error": "PubSub Topic not found",
                     "code": "404",
                     "end": {
-                        "kind": "event",
                         "produceEvents": [
                             {
                                 "eventRef": "TopicError",
@@ -449,7 +448,6 @@ as service invocations, where as Google Workflow uses the "call" keyword.
                     "error": "Error authenticating to PubSub",
                     "code": "403",
                     "end": {
-                        "kind": "event",
                         "produceEvents": [
                             {
                                 "eventRef": "TopicError",
@@ -461,7 +459,6 @@ as service invocations, where as Google Workflow uses the "call" keyword.
                 {
                     "error": "*",
                     "end": {
-                        "kind": "event",
                         "produceEvents": [
                             {
                                 "eventRef": "TopicError",
@@ -471,7 +468,7 @@ as service invocations, where as Google Workflow uses the "call" keyword.
                     }
                 }
             ],
-            "end": { "kind": "default" }
+            "end": true
         }
     ],
     "functions": [
@@ -583,7 +580,7 @@ to interested parties via events (CloudEvents specification format), which we ar
         {
             "name": "ReadItem",
             "type": "operation",
-            "start": { "kind": "default" },
+            "start": true,
             "actions": [
                 {
                     "functionRef": {
@@ -596,10 +593,10 @@ to interested parties via events (CloudEvents specification format), which we ar
                     "error": "Service Not Available",
                     "code": "500",
                     "retryRef": "ServiceNotAvailableRetry",
-                    "end": { "kind": "default" }
+                    "end": true
                 }
             ],
-            "end": { "kind": "default" }
+            "end": true
         }
     ],
     "functions": [
@@ -688,9 +685,9 @@ error handlers in the "retry" statement as an expression/variable.
         {
             "name": "CallSub",
             "type":"subflow",
-            "start": { "kind": "default" },
+            "start": true,
             "workflowId": "calledsubflow",
-            "end": { "kind": "default" }
+            "end": true
         }
     ]
 }
@@ -786,7 +783,7 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
         {
             "name": "CallA",
             "type":"operation",
-            "start": { "kind": "default" },
+            "start": true,
             "actions": [
                 {
                     "functionRef": {
@@ -825,7 +822,7 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
                     }
                 }
             ],
-            "end": { "kind": "default" }
+            "end": true
         },
         {
             "name": "CallMedium",
@@ -837,7 +834,7 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
                     }
                 }
             ],
-            "end": { "kind": "default" }
+            "end": true
         },
         {
             "name": "CallLarge",
@@ -849,7 +846,7 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
                     }
                 }
             ],
-            "end": { "kind": "default" }
+            "end": true
         }
     ],
     "functions": [

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -62,15 +62,11 @@ data output, which is:
   {  
      "name":"Hello State",
      "type":"inject",
-     "start": {
-       "kind": "default"
-     },
+     "start": true,
      "data": {
         "result": "Hello World!"
      },
-     "end": {
-        "kind": "default"
-     }
+     "end": true
   }
 ]
 }
@@ -87,12 +83,10 @@ description: Inject Hello World
 states:
 - name: Hello State
   type: inject
-  start:
-    kind: default
+  start: true
   data:
     result: Hello World!
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -156,9 +150,7 @@ Which is added to the states data and becomes the workflow data output.
   {  
      "name":"Greet",
      "type":"operation",
-     "start": {
-       "kind": "default"
-     },
+     "start": true,
      "actions":[  
         {  
            "functionRef": {
@@ -172,9 +164,7 @@ Which is added to the states data and becomes the workflow data output.
            }
         }
      ],
-     "end": {
-       "kind": "default"
-     }
+     "end": true
   }
 ]
 }
@@ -194,8 +184,7 @@ functions:
 states:
 - name: Greet
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - functionRef:
       refName: greetingFunction
@@ -203,8 +192,7 @@ states:
         name: "{{ $.person.name }}"
     actionDataFilter:
       dataResultsPath: "{{ $.greeting }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -312,9 +300,7 @@ filters what is selected to be the state data output which then becomes the work
   {  
      "name":"Greet",
      "type":"event",
-     "start": {
-       "kind": "default"
-     },
+     "start": true,
      "onEvents": [{
          "eventRefs": ["GreetingEvent"],
          "eventDataFilter": {
@@ -334,9 +320,7 @@ filters what is selected to be the state data output which then becomes the work
      "stateDataFilter": {
         "dataOutputPath": "{{ $.payload.greeting }}"
      },
-     "end": {
-       "kind": "default"
-     }
+     "end": true
   }
 ]
 }
@@ -360,8 +344,7 @@ functions:
 states:
 - name: Greet
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - GreetingEvent
@@ -374,8 +357,7 @@ states:
           name: "{{ $.greet.name }}"
   stateDataFilter:
     dataOutputPath: "{{ $.payload.greeting }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -434,9 +416,7 @@ result of the workflow execution.
 "states":[  
 {
  "name":"Solve",
- "start": {
-  "kind": "default"
-},
+ "start": true,
  "type":"foreach",
  "inputCollection": "{{ $.expressions }}",
  "iterationParam": "singleexpression",
@@ -454,9 +434,7 @@ result of the workflow execution.
  "stateDataFilter": {
     "dataOutputPath": "{{ $.results }}"
  },
- "end": {
-   "kind": "default"
- }
+ "end": true
 }
 ]
 }
@@ -475,8 +453,7 @@ functions:
   operation: http://myapis.org/mapthapis.json#solveExpression
 states:
 - name: Solve
-  start:
-    kind: default
+  start: true
   type: foreach
   inputCollection: "{{ $.expressions }}"
   iterationParam: singleexpression
@@ -488,8 +465,7 @@ states:
         expression: "{{ $.singleexpression }}"
   stateDataFilter:
     dataOutputPath: "{{ $.results }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -530,9 +506,7 @@ to finish execution before it can transition (end workflow execution in this cas
   {  
      "name": "ParallelExec",
      "type": "parallel",
-     "start": {
-       "kind": "default"
-     },
+     "start": true,
      "completionType": "and",
      "branches": [
         {
@@ -544,9 +518,7 @@ to finish execution before it can transition (end workflow execution in this cas
           "workflowId": "longdelayworkflowid"
         }
      ],
-     "end": {
-       "kind": "default"
-     }
+     "end": true
   }
 ]
 }
@@ -563,16 +535,14 @@ description: Executes two branches in parallel
 states:
 - name: ParallelExec
   type: parallel
-  start:
-    kind: default
+  start: true
   completionType: and
   branches:
   - name: ShortDelayBranch
     workflowId: shortdelayworkflowid
   - name: LongDelayBranch
     workflowId: longdelayworkflowid
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -630,9 +600,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
   {  
      "name":"CheckVisaStatus",
      "type":"switch",
-     "start": {
-        "kind": "default"
-     },
+     "start": true,
      "eventConditions": [
         {
           "eventRef": "visaApprovedEvent",
@@ -658,25 +626,19 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
     "name": "HandleApprovedVisa",
     "type": "subflow",
     "workflowId": "handleApprovedVisaWorkflowID",
-    "end": {
-      "kind": "default"
-    }
+    "end": true
   },
   {
       "name": "HandleRejectedVisa",
       "type": "subflow",
       "workflowId": "handleRejectedVisaWorkflowID",
-      "end": {
-        "kind": "default"
-      }
+      "end": true
   },
   {
       "name": "HandleNoVisaDecision",
       "type": "subflow",
       "workflowId": "handleNoVisaDecisionWorkfowId",
-      "end": {
-        "kind": "default"
-      }
+      "end": true
   }
 ]
 }
@@ -700,8 +662,7 @@ events:
 states:
 - name: CheckVisaStatus
   type: switch
-  start:
-    kind: default
+  start: true
   eventConditions:
   - eventRef: visaApprovedEvent
     transition:
@@ -716,18 +677,15 @@ states:
 - name: HandleApprovedVisa
   type: subflow
   workflowId: handleApprovedVisaWorkflowID
-  end:
-    kind: default
+  end: true
 - name: HandleRejectedVisa
   type: subflow
   workflowId: handleRejectedVisaWorkflowID
-  end:
-    kind: default
+  end: true
 - name: HandleNoVisaDecision
   type: subflow
   workflowId: handleNoVisaDecisionWorkfowId
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -787,9 +745,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
       {  
          "name":"CheckApplication",
          "type":"switch",
-         "start": {
-            "kind": "default"
-         },
+         "start": true,
          "dataConditions": [
             {
               "condition": "{{ $.applicants[?(@.age >= 18)] }}",
@@ -814,9 +770,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
         "name": "StartApplication",
         "type": "subflow",
         "workflowId": "startApplicationWorkflowId",
-        "end": {
-          "kind": "default"
-        }
+        "end": true
       },
       {  
         "name":"RejectApplication",
@@ -832,9 +786,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
               }
            }
         ],
-        "end": {
-          "kind": "default"
-        }
+        "end": true
     }
    ]
 }
@@ -854,8 +806,7 @@ functions:
 states:
 - name: CheckApplication
   type: switch
-  start:
-    kind: default
+  start: true
   dataConditions:
   - condition: "{{ $.applicants[?(@.age >= 18)] }}"
     transition:
@@ -869,8 +820,7 @@ states:
 - name: StartApplication
   type: subflow
   workflowId: startApplicationWorkflowId
-  end:
-    kind: default
+  end: true
 - name: RejectApplication
   type: operation
   actionMode: sequential
@@ -879,8 +829,7 @@ states:
       refName: sendRejectionEmailFunction
       parameters:
         applicant: "{{ $.applicant }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -942,9 +891,7 @@ The data output of the workflow contains the information of the exception caught
   {  
     "name":"ProvisionOrder",
     "type":"operation",
-    "start": {
-      "kind": "default"
-    },
+    "start": true,
     "actionMode":"sequential",
     "actions":[  
        {  
@@ -987,33 +934,25 @@ The data output of the workflow contains the information of the exception caught
    "name": "MissingId",
    "type": "subflow",
    "workflowId": "handleMissingIdExceptionWorkflow",
-   "end": {
-     "kind": "default"
-   }
+   "end": true
 },
 {
    "name": "MissingItem",
    "type": "subflow",
    "workflowId": "handleMissingItemExceptionWorkflow",
-   "end": {
-     "kind": "default"
-   }
+   "end": true
 },
 {
    "name": "MissingQuantity",
    "type": "subflow",
    "workflowId": "handleMissingQuantityExceptionWorkflow",
-   "end": {
-     "kind": "default"
-   }
+   "end": true
 },
 {
    "name": "ApplyOrder",
    "type": "subflow",
    "workflowId": "applyOrderWorkflowId",
-   "end": {
-     "kind": "default"
-   }
+   "end": true
 }
 ]
 }
@@ -1033,8 +972,7 @@ functions:
 states:
 - name: ProvisionOrder
   type: operation
-  start:
-    kind: default
+  start: true
   actionMode: sequential
   actions:
   - functionRef:
@@ -1058,23 +996,19 @@ states:
 - name: MissingId
   type: subflow
   workflowId: handleMissingIdExceptionWorkflow
-  end:
-    kind: default
+  end: true
 - name: MissingItem
   type: subflow
   workflowId: handleMissingItemExceptionWorkflow
-  end:
-    kind: default
+  end: true
 - name: MissingQuantity
   type: subflow
   workflowId: handleMissingQuantityExceptionWorkflow
-  end:
-    kind: default
+  end: true
 - name: ApplyOrder
   type: subflow
   workflowId: applyOrderWorkflowId
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -1139,9 +1073,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
     {  
       "name":"SubmitJob",
       "type":"operation",
-      "start": {
-         "kind": "default"
-      },
+      "start": true,
       "actionMode":"sequential",
       "actions":[  
       {  
@@ -1175,9 +1107,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       "name": "SubmitError",
       "type": "subflow",
       "workflowId": "handleJobSubmissionErrorWorkflow",
-      "end": {
-        "kind": "default"
-      }
+      "end": true
   },
   {
       "name": "WaitForCompletion",
@@ -1248,9 +1178,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
         }
       }
       ],
-      "end": {
-        "kind": "default"
-      }
+      "end": true
   },
   {  
     "name":"JobFailed",
@@ -1266,9 +1194,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
         }
     }
     ],
-    "end": {
-      "kind": "default"
-    }
+    "end": true
   }
   ]
 }
@@ -1294,8 +1220,7 @@ functions:
 states:
 - name: SubmitJob
   type: operation
-  start:
-    kind: default
+  start: true
   actionMode: sequential
   actions:
   - functionRef:
@@ -1315,8 +1240,7 @@ states:
 - name: SubmitError
   type: subflow
   workflowId: handleJobSubmissionErrorWorkflow
-  end:
-    kind: default
+  end: true
 - name: WaitForCompletion
   type: delay
   timeDelay: PT5S
@@ -1356,8 +1280,7 @@ states:
       refName: reportJobSuceeded
       parameters:
         name: "{{ $.jobuid }}"
-  end:
-    kind: default
+  end: true
 - name: JobFailed
   type: operation
   actionMode: sequential
@@ -1366,8 +1289,7 @@ states:
       refName: reportJobFailed
       parameters:
         name: "{{ $.jobuid }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -1474,9 +1396,7 @@ CloudEvent upon completion of the workflow could look like:
 {
     "name": "ProvisionOrdersState",
     "type": "foreach",
-    "start": {
-       "kind": "default"
-    },
+    "start": true,
     "inputCollection": "{{ $.orders }}",
     "iterationParam": "singleorder",
     "outputCollection": "{{ $.provisionedOrders }}",
@@ -1491,7 +1411,6 @@ CloudEvent upon completion of the workflow could look like:
         }
     ],
     "end": {
-        "kind": "event",
         "produceEvents": [{
             "eventRef": "provisioningCompleteEvent",
             "data": "{{ $.provisionedOrders }}"
@@ -1519,8 +1438,7 @@ functions:
 states:
 - name: ProvisionOrdersState
   type: foreach
-  start:
-    kind: default
+  start: true
   inputCollection: "{{ $.orders }}"
   iterationParam: singleorder
   outputCollection: "{{ $.provisionedOrders }}"
@@ -1530,7 +1448,6 @@ states:
       parameters:
         order: "{{ $.singleorder }}"
   end:
-    kind: event
     produceEvents:
     - eventRef: provisioningCompleteEvent
       data: "{{ $.provisionedOrders }}"
@@ -1643,9 +1560,7 @@ have the matching patient id.
 {
 "name": "MonitorVitals",
 "type": "event",
-"start": {
-    "kind": "default"
-},
+"start": true,
 "exclusive": true,
 "onEvents": [{
         "eventRefs": ["HighBodyTemperature"],
@@ -1682,7 +1597,7 @@ have the matching patient id.
     }
 ],
 "end": {
-    "kind": "terminate"
+    "terminate": true
 }
 }]
 }
@@ -1721,8 +1636,7 @@ functions:
 states:
 - name: MonitorVitals
   type: event
-  start:
-    kind: default
+  start: true
   exclusive: true
   onEvents:
   - eventRefs:
@@ -1747,7 +1661,7 @@ states:
         parameters:
           patientid: "{{ $.patientId }}"
   end:
-    kind: terminate
+    terminate: true
 ```
 
 </td>
@@ -1831,9 +1745,7 @@ when all three of these events happened (in no particular order).
 {
     "name": "FinalizeApplication",
     "type": "event",
-    "start": {
-       "kind": "default"
-    },
+    "start": true,
     "exclusive": false,
     "onEvents": [
         {
@@ -1855,7 +1767,7 @@ when all three of these events happened (in no particular order).
         }
     ],
     "end": {
-        "kind": "terminate"
+        "terminate": true
     }
 }
 ]
@@ -1891,8 +1803,7 @@ functions:
 states:
 - name: FinalizeApplication
   type: event
-  start:
-    kind: default
+  start: true
   exclusive: false
   onEvents:
   - eventRefs:
@@ -1905,7 +1816,7 @@ states:
         parameters:
           student: "{{ $.applicantId }}"
   end:
-    kind: terminate
+    terminate: true
 ```
 
 </td>
@@ -2029,9 +1940,7 @@ And for denied credit check, for example:
         {
             "name": "CheckCredit",
             "type": "callback",
-            "start": {
-               "kind": "default"
-            },
+            "start": true,
             "action": {
                 "functionRef": {
                     "refName": "callCreditCheckMicroservice",
@@ -2073,9 +1982,7 @@ And for denied credit check, for example:
             "name": "StartApplication",
             "type": "subflow",
             "workflowId": "startApplicationWorkflowId",
-            "end": {
-                "kind": "default"
-            }
+            "end": true
         },
         {
             "name": "RejectApplication",
@@ -2091,9 +1998,7 @@ And for denied credit check, for example:
                     }
                 }
             ],
-            "end": {
-                "kind": "default"
-            }
+            "end": true
         }
     ]
 }
@@ -2121,8 +2026,7 @@ events:
 states:
 - name: CheckCredit
   type: callback
-  start:
-    kind: default
+  start: true
   action:
     functionRef:
       refName: callCreditCheckMicroservice
@@ -2147,8 +2051,7 @@ states:
 - name: StartApplication
   type: subflow
   workflowId: startApplicationWorkflowId
-  end:
-    kind: default
+  end: true
 - name: RejectApplication
   type: operation
   actionMode: sequential
@@ -2157,8 +2060,7 @@ states:
       refName: sendRejectionEmailFunction
       parameters:
         applicant: "{{ $.customer }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -2237,7 +2139,6 @@ Bidding is done via an online application and bids are received as events are as
           "name": "StoreCarAuctionBid",
           "type": "event",
           "start": {
-              "kind": "scheduled",
               "schedule": {
                 "interval": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
               }
@@ -2256,9 +2157,7 @@ Bidding is done via an online application and bids are received as events are as
                 }]
             }
           ],
-          "end": {
-              "kind": "terminate"
-          }
+          "end": true
         }
     ]
 }
@@ -2283,7 +2182,6 @@ states:
 - name: StoreCarAuctionBid
   type: event
   start:
-    kind: scheduled
     schedule:
       interval: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
   exclusive: true
@@ -2295,8 +2193,7 @@ states:
         refName: StoreBidFunction
         parameters:
           bid: "{{ $.bid }}"
-  end:
-    kind: terminate
+  end: true
 ```
 
 </td>
@@ -2367,7 +2264,6 @@ The results of the inbox service called is expected to be for example:
         "name": "CheckInbox",
         "type": "operation",
         "start": {
-            "kind": "scheduled",
             "schedule": {
                 "cron": "0 0/15 * * * ?"
             }
@@ -2399,9 +2295,7 @@ The results of the inbox service called is expected to be for example:
                 }
             }
         ],
-        "end": {
-            "kind": "default"
-        }
+        "end": true
     }
 ]
 }
@@ -2424,7 +2318,6 @@ states:
 - name: CheckInbox
   type: operation
   start:
-    kind: scheduled
     schedule:
       cron: 0 0/15 * * * ?
   actionMode: sequential
@@ -2442,8 +2335,7 @@ states:
       refName: sendTextFunction
       parameters:
         message: "{{ $.singlemessage }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -2518,9 +2410,7 @@ For this example we assume that the workflow instance is started given the follo
         {
             "name": "MakeVetAppointmentState",
             "type": "operation",
-            "start": {
-                "kind": "default"
-            },
+            "start": true,
             "actions": [
                 {
                     "name": "MakeAppointmentAction",
@@ -2535,9 +2425,7 @@ For this example we assume that the workflow instance is started given the follo
                     "timeout": "PT15M"
                 }
             ],
-            "end": {
-                "kind": "default"
-            }
+            "end": true
         }
     ]
 }
@@ -2561,8 +2449,7 @@ events:
 states:
 - name: MakeVetAppointmentState
   type: operation
-  start:
-    kind: default
+  start: true
   actions:
   - name: MakeAppointmentAction
     eventRef:
@@ -2572,8 +2459,7 @@ states:
     actionDataFilter:
       dataResultsPath: "{{ $.appointmentInfo }}"
     timeout: PT15M
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -2716,7 +2602,6 @@ In our workflow definition then we can reference these files rather than definin
         }
       ],
       "end": {
-        "kind": "event",
         "produceEvents": [
           {
             "eventRef": "ConfirmationCompletedEvent",
@@ -2739,7 +2624,6 @@ In our workflow definition then we can reference these files rather than definin
         }
       ],
       "end": {
-        "kind": "event",
         "produceEvents": [
           {
             "eventRef": "ConfirmationCompletedEvent",
@@ -2797,7 +2681,6 @@ states:
       parameters:
         applicant: "{{ $.customer }}"
   end:
-    kind: event
     produceEvents:
     - eventRef: ConfirmationCompletedEvent
       data: "{{ $.payment }}"
@@ -2809,7 +2692,6 @@ states:
       parameters:
         applicant: "{{ $.customer }}"
   end:
-    kind: event
     produceEvents:
     - eventRef: ConfirmationCompletedEvent
       data: "{{ $.payment }}"
@@ -2870,9 +2752,7 @@ If the retries are not successful, we want to just gracefully end workflow execu
     {
       "name": "Onboard",
       "type": "event",
-      "start": {
-        "kind": "default"
-      },
+      "start": true,
       "onEvents": [
         {
           "eventRefs": [
@@ -2902,14 +2782,10 @@ If the retries are not successful, we want to just gracefully end workflow execu
           "error": "ServiceNotAvailable",
           "code": "503",
           "retryRef": "ServicesNotAvailableRetryStrategy",
-          "end": {
-            "kind":"default"
-          }
+          "end": true
         }
       ],
-      "end": {
-        "kind": "default"
-      }
+      "end": true
     }
   ],
   "events": [
@@ -2953,8 +2829,7 @@ version: '1.0'
 states:
 - name: Onboard
   type: event
-  start:
-    kind: default
+  start: true
   onEvents:
   - eventRefs:
     - NewPatientEvent
@@ -2969,10 +2844,8 @@ states:
   - error: ServiceNotAvailable
     code: '503'
     retryRef: ServicesNotAvailableRetryStrategy
-    end:
-      kind: default
-  end:
-    kind: default
+    end: true
+  end: true
 events:
 - name: StorePatient
   type: new.patients.event

--- a/extensions/kpi.md
+++ b/extensions/kpi.md
@@ -151,8 +151,7 @@ functions:
 states:
 - name: MonitorVitals
   type: event
-  start:
-    kind: default
+  start: true
   exclusive: true
   onEvents:
   - eventRefs:
@@ -176,8 +175,7 @@ states:
         refName: callPulmonologist
         parameters:
           patientid: "{{ $.patientId }}"
-  end:
-    kind: terminate
+  end: true
 ```
 
 </td>

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -84,6 +84,7 @@ _Status description:_
 | ✔️| Updates to retry functionality | [retries: exponential backoff & max backoff](https://github.com/serverlessworkflow/specification/issues/137) [retries: max-attempts & interval](https://github.com/serverlessworkflow/specification/issues/136)|
 | ✔️| Update "directInvoke" property type | [spec doc](../specification.md) |
 | ✔️| Data schema input/output update | [spec doc](../specification.md) |
+| ✔️| Updating start and end state definitions| [spec doc](../specification.md) |
 | 🚩 | JSONPatch transformations | [issue](https://github.com/serverlessworkflow/specification/issues/149) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1792,40 +1792,25 @@
       }
     },
     "start": {
-      "type": "object",
-      "description": "State start definition",
-      "properties": {
-        "kind": {
-          "type": "string",
-          "enum": [
-            "default",
-            "scheduled"
-          ],
-          "description": "Kind of start definition"
+      "anyOf": [
+        {
+          "type": "boolean",
+          "description": "State start definition",
+          "default": true
         },
-        "schedule": {
-          "description": "If kind is 'scheduled', define when the time/repeating intervals at which workflow instances can/should be started",
-          "$ref": "#/definitions/schedule"
+        {
+          "type": "object",
+          "description": "State start definition",
+          "properties": {
+            "schedule": {
+              "description": "Define the time/repeating intervals at which workflow instances can/should be started",
+              "$ref": "#/definitions/schedule"
+            }
+          },
+          "required": [
+          ]
         }
-      },
-      "if": {
-        "properties": {
-          "kind": {
-            "const": "scheduled"
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "kind",
-          "schedule"
-        ]
-      },
-      "else": {
-        "required": [
-          "kind"
-        ]
-      }
+      ]
     },
     "schedule": {
       "type": "object",
@@ -1863,50 +1848,39 @@
       ]
     },
     "end": {
-      "type": "object",
-      "description": "State end definition",
-      "properties": {
-        "kind": {
-          "type": "string",
-          "enum": [
-            "default",
-            "terminate",
-            "event"
-          ],
-          "description": "Kind of end definition"
-        },
-        "produceEvents": {
-          "type": "array",
-          "description": "Used if kind is event. Array of events to be produced",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/produceeventdef"
-          }
-        },
-        "compensate": {
+      "anyOf": [
+        {
           "type": "boolean",
-          "default": false,
-          "description": "If set to true, triggers workflow compensation before workflow execution completes. Default is false"
+          "description": "State end definition",
+          "default": true
+        },
+        {
+          "type": "object",
+          "description": "State end definition",
+          "properties": {
+            "terminate": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, completes all execution flows in the given workflow instance"
+            },
+            "produceEvents": {
+              "type": "array",
+              "description": "Used if kind is event. Array of events to be produced",
+              "items": {
+                "type": "object",
+                "$ref": "#/definitions/produceeventdef"
+              }
+            },
+            "compensate": {
+              "type": "boolean",
+              "default": false,
+              "description": "If set to true, triggers workflow compensation before workflow execution completes. Default is false"
+            }
+          },
+          "required": [
+          ]
         }
-      },
-      "if": {
-        "properties": {
-          "kind": {
-            "const": "event"
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "kind",
-          "produceEvents"
-        ]
-      },
-      "else": {
-        "required": [
-          "kind"
-        ]
-      }
+      ]
     },
     "produceeventdef": {
       "type": "object",

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1792,7 +1792,7 @@
       }
     },
     "start": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "boolean",
           "description": "State start definition",
@@ -1848,7 +1848,7 @@
       ]
     },
     "end": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "boolean",
           "description": "State end definition",

--- a/specification.md
+++ b/specification.md
@@ -831,9 +831,7 @@ The following is a detailed description of each of the defined states.
 {
 "name": "MonitorVitals",
 "type": "event",
-"start": {
-    "kind": "default"
-},
+"start": true,
 "exclusive": true,
 "onEvents": [{
         "eventRefs": ["HighBodyTemperature"],
@@ -870,7 +868,7 @@ The following is a detailed description of each of the defined states.
     }
 ],
 "end": {
-    "kind": "terminate"
+    "terminate": true
 }
 }
 ```
@@ -881,8 +879,7 @@ The following is a detailed description of each of the defined states.
 ```yaml
 name: MonitorVitals
 type: event
-start:
-  kind: default
+start: true
 exclusive: true
 onEvents:
 - eventRefs:
@@ -907,7 +904,7 @@ onEvents:
       parameters:
         patientid: "{{ $.patientId }}"
 end:
-  kind: terminate
+  terminate: true
 ```
 
 </td>
@@ -1088,7 +1085,7 @@ between arrival of specified events. To give an example, consider the following:
         }
     ],
     "end": {
-        "kind": "terminate"
+        "terminate": true
     }
 }
 ]
@@ -1556,9 +1553,7 @@ Transitions allow you to move from one state (control-logic block) to another. F
             }
         }
     ],
-    "end": {
-        "kind": "default"
-    }
+    "end": true
 }
 ```
 
@@ -1574,8 +1569,7 @@ actions:
     refName: sendRejectionEmailFunction
     parameters:
       applicant: "{{ $.customer }}"
-end:
-  kind: default
+end: true
 ```
 
 </td>
@@ -1620,9 +1614,7 @@ Once all actions have been performed, a transition to another state can occur.
 {  
      "name":"CheckVisaStatus",
      "type":"switch",
-     "start": {
-        "kind": "default"
-     },
+     "start": true,
      "eventConditions": [
         {
           "eventRef": "visaApprovedEvent",
@@ -1652,8 +1644,7 @@ Once all actions have been performed, a transition to another state can occur.
 ```yaml
 name: CheckVisaStatus
 type: switch
-start:
-  kind: default
+start: true
 eventConditions:
 - eventRef: visaApprovedEvent
   transition:
@@ -1897,9 +1888,7 @@ Delay state waits for a certain amount of time before transitioning to a next st
  {  
      "name":"ParallelExec",
      "type":"parallel",
-     "start": {
-       "kind": "default"
-     },
+     "start": true,
      "completionType": "and",
      "branches": [
         {
@@ -1929,9 +1918,7 @@ Delay state waits for a certain amount of time before transitioning to a next st
           ]
         }
      ],
-     "end": {
-       "kind": "default"
-     }
+     "end": true
 }
 ```
 
@@ -1941,8 +1928,7 @@ Delay state waits for a certain amount of time before transitioning to a next st
 ```yaml
 name: ParallelExec
 type: parallel
-start:
-  kind: default
+start: true
 completionType: and
 branches:
 - name: Branch1
@@ -1957,8 +1943,7 @@ branches:
       refName: functionNameTwo
       parameters:
         order: "{{ $.someParam }}"
-end:
-  kind: default
+end: true
 ```
 
 </td>
@@ -2106,9 +2091,7 @@ For more information, see the [Workflow Error Handling](#Workflow-Error-Handling
     "name": "HandleApprovedVisa",
     "type": "subflow",
     "workflowId": "handleApprovedVisaWorkflowID",
-    "end": {
-      "kind": "default"
-    }
+    "end": true
 }
 ```
 
@@ -2119,8 +2102,7 @@ For more information, see the [Workflow Error Handling](#Workflow-Error-Handling
 name: HandleApprovedVisa
 type: subflow
 workflowId: handleApprovedVisaWorkflowID
-end:
-  kind: default
+end: true
 ```
 
 </td>
@@ -2185,9 +2167,7 @@ Referenced workflows must declare their own [function](#Function-Definition) and
 {  
      "name":"Hello",
      "type":"inject",
-     "start": {
-       "kind": "default"
-     },
+     "start": true,
      "data": {
         "result": "Hello"
      },
@@ -2203,8 +2183,7 @@ Referenced workflows must declare their own [function](#Function-Definition) and
 ```yaml
 name: Hello
 type: inject
-start:
-  kind: default
+start: true
 data:
   result: Hello
 transition:
@@ -2412,9 +2391,7 @@ This allows you to test if your workflow behaves properly for cases when there a
 {
     "name": "ProvisionOrdersState",
     "type": "foreach",
-    "start": {
-       "kind": "default"
-    },
+    "start": true,
     "inputCollection": "{{ $.orders }}",
     "iterationParam": "singleorder",
     "outputCollection": "{{ $.provisionresults }}",
@@ -2437,8 +2414,7 @@ This allows you to test if your workflow behaves properly for cases when there a
 ```yaml
 name: ProvisionOrdersState
 type: foreach
-start:
-  kind: default
+start: true
 inputCollection: "{{ $.orders }}"
 iterationParam: "singleorder"
 outputCollection: "{{ $.provisionresults }}"
@@ -2526,7 +2502,7 @@ and our workflow is defined as:
   ],
   "states": [
   {
-      "start": { "kind":  "default" },
+      "start": true,
       "name":"SendConfirmState",
       "type":"foreach",
       "inputCollection": "{{ $.orders[?(@.completed == true)] }}",
@@ -2542,7 +2518,7 @@ and our workflow is defined as:
          }
        }
       }],
-      "end": { "kind": "default" }
+      "end": true
   }]
 }
 ```
@@ -2558,8 +2534,7 @@ functions:
 - name: sendConfirmationFunction
   operation: file://confirmationapi.json#sendOrderConfirmation
 states:
-- start:
-    kind: default
+- start: true
   name: SendConfirmState
   type: foreach
   inputCollection: "{{ $.orders[?(@.completed == true)] }}"
@@ -2571,8 +2546,7 @@ states:
       parameters:
         orderNumber: "{{ $.completedorder.orderNumber }}"
         email: "{{ $.completedorder.email }}"
-  end:
-    kind: default
+  end: true
 ```
 
 </td>
@@ -2647,9 +2621,7 @@ The results of each parallel action execution are stored as elements in the stat
 {
         "name": "CheckCredit",
         "type": "callback",
-        "start": {
-           "kind": "default"
-        },
+        "start": true,
         "action": {
             "functionRef": {
                 "refName": "callCreditCheckMicroservice",
@@ -2672,8 +2644,7 @@ The results of each parallel action execution are stored as elements in the stat
 ```yaml
 name: CheckCredit
 type: callback
-start:
-  kind: default
+start: true
 action:
   functionRef:
     refName: callCreditCheckMicroservice
@@ -2715,10 +2686,12 @@ If the defined callback event has not been received during this time period, the
 
 #### Start Definition
 
+Can be either `boolean` or `object` type. 
+If `object` type it has the following structure:
+
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| kind | End kind ("default", "scheduled") | enum | yes |
-| [schedule](#Schedule-Definition) | If kind is "scheduled", define time/repeating intervals at which workflow instances can/should be started | object | yes only if kind is "scheduled" |
+| [schedule](#Schedule-Definition) | If kind is "scheduled", define time/repeating intervals at which workflow instances can/should be started | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -2733,7 +2706,6 @@ If the defined callback event has not been received during this time period, the
 
 ```json
 {
-  "kind": "scheduled",
   "schedule": {
     "interval": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
   }
@@ -2744,7 +2716,6 @@ If the defined callback event has not been received during this time period, the
 <td valign="top">
 
 ```yaml
-kind: scheduled
 schedule:
   interval: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
 ```
@@ -2755,13 +2726,14 @@ schedule:
 
 </details>
 
-Any state can declare to be the start state of the workflow, meaning that when a workflow instance is created it will be the initial
+Any state can declare to be the start state of the workflow, meaning when a workflow instance is created it will be the initial
 state to be executed. A workflow definition can declare one workflow start state.
 
-The start definition provides a `kind` property, which describes the starting options:
-
-- **default** - The start state is always "active" and there are no restrictions imposed on its execution.
-- **scheduled** - Scheduled start states have two different choices. You can define time-based intervals during which workflow instances are **allowed**
+The start definition can be either `boolean` or `object` type.
+If `boolean` type, when set to `true`, there are no restrictions imposed on its execution.
+If `object` type, it provides the ability to set the `scheduled` property.
+The `scheduled` property allows to define scheduled workflow instances. 
+Scheduled starts have two different choices. You can define time-based intervals during which workflow instances are **allowed**
 to be created, or cron-based repeating times at which a workflow instance **should** be created. 
 
 Defining a schedule for the start definition allows you to set time intervals during which workflow instances can be created, or 
@@ -2876,10 +2848,13 @@ The `directInvoke` property defines if workflow instances are allowed to be crea
 
 #### End Definition
 
+Can be either `boolean` or `object` type. 
+If `object` type it has the following structure:
+
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| kind | End kind ("default", "terminate", or "event") | enum | yes |
-| produceEvents | Array of [producedEvent](#ProducedEvent-Definition) definitions. If `kind` is "event", define what type of event to produce | array | yes only if `kind` is "event" |
+| terminate | If true, completes all execution flows in the given workflow instance | boolean | no |
+| produceEvents | Array of [producedEvent](#ProducedEvent-Definition) definitions. If `kind` is "event", define what type of event to produce | array | no |
 | [compensate](#Workflow-Compensation) | If set to `true`, triggers workflow compensation before workflow execution completes. Default is `false` | boolean | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -2895,7 +2870,6 @@ The `directInvoke` property defines if workflow instances are allowed to be crea
 
 ```json
 {
-    "kind": "event",
     "produceEvents": [{
         "eventRef": "provisioningCompleteEvent",
         "data": "{{ $.provisionedOrders }}"
@@ -2907,7 +2881,6 @@ The `directInvoke` property defines if workflow instances are allowed to be crea
 <td valign="top">
 
 ```yaml
-kind: event
 produceEvents:
 - eventRef: provisioningCompleteEvent
   data: "{{ $.provisionedOrders }}"
@@ -2919,14 +2892,21 @@ produceEvents:
 
 </details>
 
-Any state with the exception of the [Switch](#Switch-State) state can declare to be the end state of the workflow, meaning that after the execution of this state is completed, workflow execution ends. Switch states require a transition to happen after their execution, thus cannot be workflow end states.
+Any state with the exception of the [Switch](#Switch-State) state can declare to be the end state of the workflow, meaning after the execution of this state is completed, workflow execution ends. 
+Switch states require a transition to happen after their execution, thus cannot be workflow end states.
+
+The end definition can be either `boolean` or `object` type.
+If `boolean` type, when set to `true`, there are no restrictions imposed on its execution.
+If `object` type, it provides the ability to set the [`produceEvents`](#ProducedEvent-Definition) `terminate`, and `compensate` properties.
 
 The end definitions provides different ways to complete workflow execution, which is set by the `kind` property:
 
-- **default** - Default workflow execution completion; no other special behavior.
-- **terminate** - Completes all execution flows in the given workflow instance. All activities/actions being executed
-are completed. If a terminate end is reached inside a ForEach, Parallel, or SubFlow state, the entire workflow instance is terminated.
-- **event** - Workflow executions completes, and one or moreCloudEvents can be produced.
+The `terminate` property, if set to `true`, completes all execution flows in the given workflow instance. 
+All activities/actions being executed are completed. 
+If a terminate end is reached inside a ForEach, Parallel, or SubFlow state, the entire workflow instance is terminated.
+
+The [`produceEvents`](#ProducedEvent-Definition) allows to define events which should be produced
+by the workflow instance before workflow stops its execution.
 
 #### ProducedEvent Definition
 
@@ -3050,9 +3030,7 @@ output of the state to transition from includes an user with the title "MANAGER"
 ],
 "states":[  
   {  
-   "start": {
-     "kind": "default"
-   },
+   "start": true,
    "name":"lowRiskState",
    "type":"operation",
    "actionMode":"Sequential",
@@ -3071,9 +3049,7 @@ output of the state to transition from includes an user with the title "MANAGER"
   {  
    "name":"highRiskState",
    "type":"operation",
-   "end": {
-     "kind": "default"
-   },
+   "end": true,
    "actionMode":"Sequential",
    "actions":[  
     {  
@@ -3097,8 +3073,7 @@ functions:
 - name: doHighRiskOperationFunction
   operation: file://myapi.json#highRisk
 states:
-- start:
-    kind: default
+- start: true
   name: lowRiskState
   type: operation
   actionMode: Sequential
@@ -3110,8 +3085,7 @@ states:
     expression: "{{ $.users[?(@.title == 'MANAGER')] }}"
 - name: highRiskState
   type: operation
-  end:
-    kind: default
+  end: true
   actionMode: Sequential
   actions:
   - functionRef:
@@ -3490,9 +3464,7 @@ and then lets us know how to greet this customer in different languages. We coul
     }],
     "states":[
         {
-            "start": {
-               "kind": "default"
-            },
+            "start": true,
             "name": "WaitForCustomerToArrive",
             "type": "event",
             "onEvents": [{
@@ -3519,9 +3491,7 @@ and then lets us know how to greet this customer in different languages. We coul
                 "dataInputPath": "{{ $.hello }} ",
                 "dataOutputPath": "{{ $.finalCustomerGreeting }}"
             },
-            "end": {
-              "kind": "default"
-            }
+            "end": true
         }
     ]
 }
@@ -4132,8 +4102,7 @@ workflow compensation must be performed.
 ```json
 {
   "end": {
-    "compensate": true,
-    "kind":"default"
+    "compensate": true
   }
 }
 ```
@@ -4143,7 +4112,6 @@ workflow compensation must be performed.
 ```yaml
 end:
   compensate: true
-  kind: default
 ```
 </td>
 </tr>
@@ -4151,7 +4119,7 @@ end:
 
 End definitions can trigger compensations by specifying the `compensate` property and setting it to `true`.
 This means that before workflow finishes its execution workflow compensation must be performed. Note that 
-in case when the end definition has its "kind" set to "event", compensation must be performed before 
+in case when the end definition has its `produceEvents` property set, compensation must be performed before 
 producing the specified events and ending workflow execution.
 
 #### Compensation Execution Details


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [x ] Schema
- [x ] Examples
- [ ] Usecases
- [ x] Extensions
- [ x] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Updates the definitions of start and end definitions. Allows them to be either boolean or object types.
This removes the need for:
```json
"start": { "kind": "default" }
```
```json
"end": { "kind": "default" }
```
to
```json
"start": true
```
```json
"end": true
```

Also streamlines the definitions by removing their "kind" property completely.

**Special notes for reviewers**:

**Additional information (if needed):**