### PR TITLE
Remove 'names' property from event defs

### DIFF
--- a/schema/events.json
+++ b/schema/events.json
@@ -24,15 +24,6 @@
           "description": "Unique event name",
           "minLength": 1
         },
-        "names": {
-          "type": "array",
-          "description": "List of unique event names that share the rest of the properties (source, type, kind, default)",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 2,
-          "uniqueItems": true
-        },
         "source": {
           "type": "string",
           "description": "CloudEvent source"
@@ -72,37 +63,16 @@
         }
       },
       "then": {
-        "oneOf": [
-          {
-            "required": [
-              "name",
-              "source",
-              "type"
-            ]
-          },
-          {
-            "required": [
-              "names",
-              "source",
-              "type"
-            ]
-          }
+        "required": [
+          "name",
+          "source",
+          "type"
         ]
       },
       "else": {
-        "oneOf": [
-          {
-            "required": [
-              "name",
-              "type"
-            ]
-          },
-          {
-            "required": [
-              "names",
-              "type"
-            ]
-          }
+        "required": [
+          "name",
+          "type"
         ]
       }
     },

--- a/specification.md
+++ b/specification.md
@@ -470,8 +470,7 @@ defined via the `parameters` property in [function definitions](#FunctionRef-Def
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| name | Unique event name | string | yes if `names` is not used |
-| names | List of unique event names that share the rest of the properties (source, type, kind, ...) | array | yes if `name` is not used |
+| name | Unique event name | string | yes |
 | source | CloudEvent source | string | yes if kind is set to "consumed", otherwise no |
 | type | CloudEvent type | string | yes |
 | kind | Defines the event is either `consumed` or `produced` by the workflow. Default is `consumed` | enum | no |
@@ -529,59 +528,6 @@ This is to assure consistency and portability of the events format used.
 
 The `name` property defines a single name of the event that is unique inside the workflow definition. This event name can be 
 then referenced within [function](#Function-Definition) and [state](#State-Definition) definitions.
-
-The `names` property can be used instead of `name` when you want to define multiple events that share
-the same `source`, `type`, `kind`, and correlation rules. 
-To give an example, the following two events definitions are considered to be equal:
-
-<table>
-<tr>
-    <th>(1)</th>
-    <th>(2)</th>
-</tr>
-<tr>
-<td valign="top">
-
-```json
-{  
-  "events": [
-    {
-      "name": "Event1",
-      "type": "org.events",
-      "source": "eventssource"
-    },
-    {
-      "name": "Event2",
-      "type": "org.events",
-      "source": "eventssource"
-    },
-    {
-      "name": "Event3",
-      "type": "org.events",
-      "source": "eventssource"
-    }
-  ]
-}
-```
-
-</td>
-<td valign="top">
-
-```json
-{  
-  "events": [
-    {
-      "names": ["Event1", "Event2", "Event3"],
-      "type": "org.events",
-      "source": "eventssource"
-    }
-  ]
-}
-```
-
-</td>
-</tr>
-</table>
 
 The `source` property matches this event definition with the [source](https://github.com/cloudevents/spec/blob/master/spec.md#source-1)
 property of the CloudEvent required attributes.


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Removes the "names" property from event defs. Having both "name" and "names" is confusing. 
There is a benefit for aliasing but we can add that again upon request. 

**Special notes for reviewers**:
**Additional information (if needed):**