### PR TITLE
Adding validUntil property to cron definition

### DIFF
--- a/examples/examples.md
+++ b/examples/examples.md
@@ -2265,7 +2265,9 @@ The results of the inbox service called is expected to be for example:
         "type": "operation",
         "start": {
             "schedule": {
-                "cron": "0 0/15 * * * ?"
+                "cron": {
+                   "expression": "0 0/15 * * * ?"
+                }
             }
         },
         "actionMode": "sequential",
@@ -2319,7 +2321,8 @@ states:
   type: operation
   start:
     schedule:
-      cron: 0 0/15 * * * ?
+      cron:
+        expression: 0 0/15 * * * ?
   actionMode: sequential
   actions:
   - functionRef:

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -85,6 +85,7 @@ _Status description:_
 | ✔️| Update "directInvoke" property type | [spec doc](../specification.md) |
 | ✔️| Data schema input/output update | [spec doc](../specification.md) |
 | ✔️| Updating start and end state definitions| [spec doc](../specification.md) |
+| ✔️| Update cron definition (adding deadline parameter)| [spec doc](../specification.md) |
 | 🚩 | JSONPatch transformations | [issue](https://github.com/serverlessworkflow/specification/issues/149) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -85,7 +85,7 @@ _Status description:_
 | ✔️| Update "directInvoke" property type | [spec doc](../specification.md) |
 | ✔️| Data schema input/output update | [spec doc](../specification.md) |
 | ✔️| Updating start and end state definitions| [spec doc](../specification.md) |
-| ✔️| Update cron definition (adding deadline parameter)| [spec doc](../specification.md) |
+| ✔️| Update cron definition (adding validUntil parameter)| [spec doc](../specification.md) |
 | 🚩 | JSONPatch transformations | [issue](https://github.com/serverlessworkflow/specification/issues/149) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -189,6 +189,24 @@
     "states"
   ],
   "definitions": {
+    "crondef": {
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string",
+          "description": "Repeating interval (cron expression) describing when the workflow instance should be created",
+          "minLength": 1
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Specific date and time (ISO 8601 format) when the cron expression invocation should be stopped",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "expression"
+      ]
+    },
     "transition": {
       "type": "object",
       "properties": {
@@ -1821,8 +1839,7 @@
           "description":  "Time interval (ISO 8601 format) describing when the workflow starting state is active"
         },
         "cron": {
-          "type": "string",
-          "description":  "Repeating interval (cron expression) describing when the workflow starting state should be triggered"
+          "$ref": "#/definitions/crondef"
         },
         "directInvoke": {
           "description": "Defines if workflow instances can be created outside of the interval/cron interval",

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -197,9 +197,9 @@
           "description": "Repeating interval (cron expression) describing when the workflow instance should be created",
           "minLength": 1
         },
-        "deadline": {
+        "validUntil": {
           "type": "string",
-          "description": "Specific date and time (ISO 8601 format) when the cron expression invocation should be stopped",
+          "description": "Specific date and time (ISO 8601 format) when the cron expression invocation is no longer valid",
           "minLength": 1
         }
       },

--- a/specification.md
+++ b/specification.md
@@ -2779,8 +2779,8 @@ the needed events at the defined times to trigger workflow instance creation.
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| interval | Time interval describing when the workflow starting state is active. (ISO 8601 time interval format). | string | yes if `cron` not defined |
-| cron | Repeating interval (cron expression) describing when the workflow starting state should be triggered | string | yes if `interval` not defined |
+| interval | Time interval describing when the workflow instance can be created (ISO 8601 time interval format). | string | yes if `cron` not defined |
+| [cron](#Cron-Definition) | Define expression (cron) when the workflow instance should be created | object | yes if `interval` not defined |
 | directInvoke | Defines if workflow instances can be created outside of the interval/cron interval. Default value is `false` | boolean | no |
 | timezone | Timezone name (for example "America/Los_Angeles") used to evaluate the cron expression against. Not used for `interval` property as timezone can be specified there directly. If not specified, should default to local machine timezone | string | no |
 
@@ -2797,7 +2797,9 @@ the needed events at the defined times to trigger workflow instance creation.
 
 ```json
 {
-   "cron": "0 0/15 * * * ?",
+   "cron": {
+      "expression": "0 0/15 * * * ?"
+   },
    "directInvoke": true
 }
 ```
@@ -2806,7 +2808,8 @@ the needed events at the defined times to trigger workflow instance creation.
 <td valign="top">
 
 ```yaml
-cron: 0 0/15 * * * ?
+cron:
+  expression: 0 0/15 * * * ?
 directInvoke: true
 ```
 
@@ -2836,6 +2839,7 @@ Once a workflow instance is created, the start state schedule can be ignored for
 
 The `cron` property uses a [cron expression](http://crontab.org/) 
 to describe a repeating interval upon which the state becomes active and a new workflow instance is created.
+For more information see the [cron definition](#Cron-Definition) section.
 
 The `timezone` property is used to define a time zone name to evaluate the cron expression against. If not specified, it should default to the local
 machine time zone. See [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of timezone names.
@@ -2845,6 +2849,65 @@ defining cron-based scheduled starts for the runtime implementations would mean 
 the needed events at the defined times to trigger workflow instance creation.
 
 The `directInvoke` property defines if workflow instances are allowed to be created outside of the defined interval or cron expression.
+
+#### Cron Definition
+
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| expression | Repeating interval (cron expression) describing when the workflow instance should be created | string | yes |
+| deadline | Specific date and time (ISO 8601 format) when the cron expression invocation should be stopped | string | no |
+
+<details><summary><strong>Click to view example definition</strong></summary>
+<p>
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td valign="top">
+
+```json
+{
+    "expression": "0 15,30,45 * ? * *",
+    "deadline": "2021-11-05T08:15:30-05:00"
+}
+```
+
+</td>
+<td valign="top">
+
+```yaml
+expression: 0 15,30,45 * ? * *
+deadline: '2021-11-05T08:15:30-05:00'
+```
+
+</td>
+</tr>
+</table>
+
+</details>
+
+The `expression` property is a a [cron expression](http://crontab.org/) which defines 
+when a workflow instance should be created.
+
+The `deadline` property defines a date and time (using ISO 8601 format). When the 
+`deadline` is reached, the cron expression for instances creations of this workflow 
+should be stopped.
+
+For example let's say we have to following cron definitions:
+
+```json
+{
+    "expression": "0 15,30,45 * ? * *",
+    "deadline": "2021-11-05T08:15:30-05:00"
+}
+```
+
+This tells the runtime engine to create an instance of this workflow every hour 
+at minutes 15, 30 and 45. This is to be done until November 5, 2021, 8:15:30 am, US Eastern Standard Time
+as defined by the `deadline` property value.
 
 #### End Definition
 

--- a/specification.md
+++ b/specification.md
@@ -2855,7 +2855,7 @@ The `directInvoke` property defines if workflow instances are allowed to be crea
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | expression | Repeating interval (cron expression) describing when the workflow instance should be created | string | yes |
-| deadline | Specific date and time (ISO 8601 format) when the cron expression invocation should be stopped | string | no |
+| validUntil | Specific date and time (ISO 8601 format) when the cron expression invocation is no longer valid | string | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -2871,7 +2871,7 @@ The `directInvoke` property defines if workflow instances are allowed to be crea
 ```json
 {
     "expression": "0 15,30,45 * ? * *",
-    "deadline": "2021-11-05T08:15:30-05:00"
+    "validUntil": "2021-11-05T08:15:30-05:00"
 }
 ```
 
@@ -2880,7 +2880,7 @@ The `directInvoke` property defines if workflow instances are allowed to be crea
 
 ```yaml
 expression: 0 15,30,45 * ? * *
-deadline: '2021-11-05T08:15:30-05:00'
+validUntil: '2021-11-05T08:15:30-05:00'
 ```
 
 </td>
@@ -2892,22 +2892,22 @@ deadline: '2021-11-05T08:15:30-05:00'
 The `expression` property is a a [cron expression](http://crontab.org/) which defines 
 when a workflow instance should be created.
 
-The `deadline` property defines a date and time (using ISO 8601 format). When the 
-`deadline` is reached, the cron expression for instances creations of this workflow 
-should be stopped.
+The `validUntil` property defines a date and time (using ISO 8601 format). When the 
+`validUntil` time is reached, the cron expression for instances creations of this workflow 
+should should no longer be valid.
 
 For example let's say we have to following cron definitions:
 
 ```json
 {
     "expression": "0 15,30,45 * ? * *",
-    "deadline": "2021-11-05T08:15:30-05:00"
+    "validUntil": "2021-11-05T08:15:30-05:00"
 }
 ```
 
 This tells the runtime engine to create an instance of this workflow every hour 
 at minutes 15, 30 and 45. This is to be done until November 5, 2021, 8:15:30 am, US Eastern Standard Time
-as defined by the `deadline` property value.
+as defined by the `validUntil` property value.
 
 #### End Definition
 


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Adds "deadline" property to cron definition. Currently we only have expression which cannot alone say when 
the creation of instances according to the cron expression should end (there are use cases for this)
Deadline allows to set a hard date when the cron expression becomes obsolete.
**Special notes for reviewers**:

**Additional information (if needed):**