### PR TITLE
Simplified functionRef and transition properties

### DIFF
--- a/examples/examples-argo.md
+++ b/examples/examples-argo.md
@@ -175,8 +175,7 @@ states:
       refName: whalesayimage
       parameters:
         message: hello1
-  transition:
-    nextState: parallelhello
+  transition: parallelhello
 - name: parallelhello
   type: parallel
   completionType: and
@@ -277,8 +276,7 @@ states:
       refName: echo
       parameters:
         message: A
-  transition:
-    nextState: parallelecho
+  transition: parallelecho
 - name: parallelecho
   type: parallel
   completionType: and
@@ -295,8 +293,7 @@ states:
         refName: echo
         parameters:
           message: C
-  transition:
-    nextState: D
+  transition: D
 - name: D
   type: operation
   start: true
@@ -396,17 +393,12 @@ functions:
   metadata:
     image: python:alpine3.6
     command: python
-    source: | 
-      import random 
-      i = random.randint(1, 100) 
-      print(i)
+    source: "import random \ni = random.randint(1, 100) \nprint(i)\n"
 - name: gen-random-int-javascript
   metadata:
     image: node:9.1-alpine
     command: node
-    source: |
-      var rand = Math.floor(Math.random() * 100); 
-      console.log(rand);
+    source: "var rand = Math.floor(Math.random() * 100); \nconsole.log(rand);\n"
 - name: printmessagefunc
   metadata:
     image: alpine:latest
@@ -417,12 +409,10 @@ states:
   type: operation
   start: true
   actions:
-  - functionRef:
-      refName: gen-random-int-bash
+  - functionRef: gen-random-int-bash
     actionDataFilter:
       dataResultsPath: "{{ $.results }}"
-  transition:
-    nextState: print-message
+  transition: print-message
 - name: print-message
   type: operation
   actions:
@@ -499,8 +489,7 @@ states:
     greetings:
     - hello world
     - goodbye world
-  transition:
-    nextState: printgreetings
+  transition: printgreetings
 - name: printgreetings
   type: foreach
   inputCollection: "{{ $.greetings }}"
@@ -597,34 +586,28 @@ states:
   type: operation
   start: true
   actions:
-  - functionRef:
-      refName: flip-coin-function
+  - functionRef: flip-coin-function
     actionDataFilter:
       dataResultsPath: "{{ $.flip.result }}"
-  transition:
-    nextState: show-flip-results
+  transition: show-flip-results
 - name: show-flip-results
   type: switch
   dataConditions:
   - condition: "{{ $.flip[?(@.result == 'heads')] }}"
-    transition:
-      nextState: show-results-heads
+    transition: show-results-heads
   - condition: "{{ $.flip[?(@.result == 'tails')] }}"
-    transition:
-      nextState: show-results-tails
+    transition: show-results-tails
 - name: show-results-heads
   type: operation
   actions:
-  - functionRef:
-      refName: echo
+  - functionRef: echo
     actionDataFilter:
       dataResultsPath: it was heads
   end: true
 - name: show-results-tails
   type: operation
   actions:
-  - functionRef:
-      refName: echo
+  - functionRef: echo
     actionDataFilter:
       dataResultsPath: it was tails
   end: true
@@ -781,21 +764,17 @@ states:
   type: operation
   start: true
   actions:
-  - functionRef:
-      refName: flip-coin-function
+  - functionRef: flip-coin-function
     actionDataFilter:
       dataResultsPath: "{{ $.steps.flip-coin.outputs.result }}" 
-  transition:
-    nextState: flip-coin-check
+  transition: flip-coin-check
 - name: flip-coin-check
   type: switch
   dataConditions:
   - condition: "{{ $.steps.flip-coin.outputs[?(@.result == 'tails')] }}"
-    transition:
-      nextState: flip-coin-state
+    transition: flip-coin-state
   - condition: "{{ $.steps.flip-coin.outputs[?(@.result == 'heads')] }}"
-    transition:
-      nextState: heads-state
+    transition: heads-state
 - name: heads-state
   type: operation
   actions:
@@ -908,8 +887,7 @@ states:
         args: echo intentional failure; exit 1
   onErrors:
   - error: "*"
-    transition:
-      nextState: send-email-state
+    transition: send-email-state
 - name: send-email-state
   type: operation
   actions:
@@ -917,17 +895,14 @@ states:
       refName: send-email-function
       parameters:
         args: 'echo send e-mail: $.workflow.name $.exit-code'
-  transition:
-    nextState: emo-state
+  transition: emo-state
 - name: emo-state
   type: switch
   dataConditions:
   - condition: "{{ $[?(@.exit_code == '1')] }}"
-    transition:
-      nextState: celebrate-state
+    transition: celebrate-state
   - condition: "{{ $[?(@.exit_code != '1')] }}"
-    transition:
-      nextState: cry-state
+    transition: cry-state
 - name: celebrate-state
   type: operation
   actions:

--- a/examples/examples-brigade.md
+++ b/examples/examples-brigade.md
@@ -179,8 +179,7 @@ states:
           log: done
   onErrors:
   - error: "*"
-    transition:
-      nextState: HandleErrorState
+    transition: HandleErrorState
   end: true
 - name: HandleErrorState
   type: operation
@@ -338,8 +337,7 @@ states:
         refName: echoFunction
         parameters:
           message: goodbye
-  transition:
-    nextState: SecondGreetGroup
+  transition: SecondGreetGroup
 - name: SecondGreetGroup
   type: operation
   actions:

--- a/examples/examples-google-cloud-workflows.md
+++ b/examples/examples-google-cloud-workflows.md
@@ -583,9 +583,7 @@ to interested parties via events (CloudEvents specification format), which we ar
             "start": true,
             "actions": [
                 {
-                    "functionRef": {
-                        "refName": "ReadItemFromApi"
-                    }
+                    "functionRef": "ReadItemFromApi"
                 }
             ],
             "onErrors": [
@@ -786,12 +784,10 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
             "start": true,
             "actions": [
                 {
-                    "functionRef": {
-                        "refName": "callFunctionA"
-                    }
+                    "functionRef": "callFunctionA"
                 }
             ],
-            "transition": { "nextState": "EvaluateAResults" }
+            "transition": "EvaluateAResults"
         },
         {
             "name": "EvaluateAResults",
@@ -800,16 +796,16 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
                 {
                     "name": "Less than 10",
                     "condition": "{{ $.body[?(@.SomeField < 10)] }}",
-                    "transition": { "nextState": "CallSmall" }
+                    "transition": "CallSmall"
                 },
                 {
                     "name": "Less than 100",
                     "condition": "{{ $.body[?(@.SomeField < 100)] }}",
-                    "transition": { "nextState": "CallMedium" }
+                    "transition": "CallMedium"
                 }
             ],
             "default": {
-                "transition": { "nextState": "CallLarge" }
+                "transition": "CallLarge"
             }
         },
         {
@@ -817,9 +813,7 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
             "type":"operation",
             "actions": [
                 {
-                    "functionRef": {
-                        "refName": "callFunctionSmall"
-                    }
+                    "functionRef": "callFunctionSmall"
                 }
             ],
             "end": true
@@ -829,9 +823,7 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
             "type":"operation",
             "actions": [
                 {
-                    "functionRef": {
-                        "refName": "callFunctionMedium"
-                    }
+                    "functionRef": "callFunctionMedium"
                 }
             ],
             "end": true
@@ -841,9 +833,7 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
             "type":"operation",
             "actions": [
                 {
-                    "functionRef": {
-                        "refName": "callFunctionMedium"
-                    }
+                    "functionRef": "callFunctionMedium"
                 }
             ],
             "end": true

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -604,22 +604,16 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
      "eventConditions": [
         {
           "eventRef": "visaApprovedEvent",
-          "transition": {
-            "nextState": "HandleApprovedVisa"
-          }
+          "transition": "HandleApprovedVisa"
         },
         {
           "eventRef": "visaRejectedEvent",
-          "transition": {
-            "nextState": "HandleRejectedVisa"
-          }
+          "transition": "HandleRejectedVisa"
         }
      ],
      "eventTimeout": "PT1H",
      "default": {
-        "transition": {
-         "nextState": "HandleNoVisaDecision"
-        }
+        "transition": "HandleNoVisaDecision"
      }
   },
   {
@@ -665,15 +659,12 @@ states:
   start: true
   eventConditions:
   - eventRef: visaApprovedEvent
-    transition:
-      nextState: HandleApprovedVisa
+    transition: HandleApprovedVisa
   - eventRef: visaRejectedEvent
-    transition:
-      nextState: HandleRejectedVisa
+    transition: HandleRejectedVisa
   eventTimeout: PT1H
   default:
-    transition:
-      nextState: HandleNoVisaDecision
+    transition: HandleNoVisaDecision
 - name: HandleApprovedVisa
   type: subflow
   workflowId: handleApprovedVisaWorkflowID
@@ -749,21 +740,15 @@ If the applicants age is over 18 we start the application (subflow state). Other
          "dataConditions": [
             {
               "condition": "{{ $.applicants[?(@.age >= 18)] }}",
-              "transition": {
-                "nextState": "StartApplication"
-              }
+              "transition": "StartApplication"
             },
             {
               "condition": "{{ $.applicants[?(@.age < 18)] }}",
-              "transition": {
-                "nextState": "RejectApplication"
-              }
+              "transition": "RejectApplication"
             }
          ],
          "default": {
-            "transition": {
-               "nextState": "RejectApplication"
-            }
+            "transition": "RejectApplication"
          }
       },
       {
@@ -809,14 +794,11 @@ states:
   start: true
   dataConditions:
   - condition: "{{ $.applicants[?(@.age >= 18)] }}"
-    transition:
-      nextState: StartApplication
+    transition: StartApplication
   - condition: "{{ $.applicants[?(@.age < 18)] }}"
-    transition:
-      nextState: RejectApplication
+    transition: RejectApplication
   default:
-    transition:
-      nextState: RejectApplication
+    transition: RejectApplication
 - name: StartApplication
   type: subflow
   workflowId: startApplicationWorkflowId
@@ -906,27 +888,19 @@ The data output of the workflow contains the information of the exception caught
     "stateDataFilter": {
        "dataOutputPath": "{{ $.exceptions }}"
     },
-    "transition": {
-       "nextState":"ApplyOrder"
-    },
+    "transition": "ApplyOrder",
     "onErrors": [
        {
          "error": "Missing order id",
-         "transition": {
-           "nextState": "MissingId"
-         }
+         "transition": "MissingId"
        },
        {
          "error": "Missing order item",
-         "transition": {
-           "nextState": "MissingItem"
-         }
+         "transition": "MissingItem"
        },
        {
         "error": "Missing order quantity",
-        "transition": {
-          "nextState": "MissingQuantity"
-        }
+        "transition": "MissingQuantity"
        }
     ]
 },
@@ -981,18 +955,14 @@ states:
         order: "{{ $.order }}"
   stateDataFilter:
     dataOutputPath: "{{ $.exceptions }}"
-  transition:
-    nextState: ApplyOrder
+  transition: ApplyOrder
   onErrors:
   - error: Missing order id
-    transition:
-      nextState: MissingId
+    transition: MissingId
   - error: Missing order item
-    transition:
-      nextState: MissingItem
+    transition: MissingItem
   - error: Missing order quantity
-    transition:
-      nextState: MissingQuantity
+    transition: MissingQuantity
 - name: MissingId
   type: subflow
   workflowId: handleMissingIdExceptionWorkflow
@@ -1091,17 +1061,13 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       "onErrors": [
       {
         "error": "*",
-        "transition": {
-          "nextState": "SubmitError"
-        }
+        "transition": "SubmitError"
       }
       ],
       "stateDataFilter": {
           "dataOutputPath": "{{ $.jobuid }}"
       },
-      "transition": {
-          "nextState":"WaitForCompletion"
-      }
+      "transition": "WaitForCompletion"
   },
   {
       "name": "SubmitError",
@@ -1113,9 +1079,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       "name": "WaitForCompletion",
       "type": "delay",
       "timeDelay": "PT5S",
-      "transition": {
-        "nextState":"GetJobStatus"
-      }
+      "transition": "GetJobStatus"
   },
   {  
       "name":"GetJobStatus",
@@ -1137,9 +1101,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       "stateDataFilter": {
           "dataOutputPath": "{{ $.jobstatus }}"
       },
-      "transition": {
-          "nextState":"DetermineCompletion"
-      }
+      "transition": "DetermineCompletion"
   },
   {  
     "name":"DetermineCompletion",
@@ -1147,21 +1109,15 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
     "dataConditions": [
       {
         "condition": "{{ $[?(@.jobstatus == 'SUCCEEDED')] }}",
-        "transition": {
-          "nextState": "JobSucceeded"
-        }
+        "transition": "JobSucceeded"
       },
       {
         "condition": "{{ $[?(@.jobstatus == 'FAILED')] }}",
-        "transition": {
-          "nextState": "JobFailed"
-        }
+        "transition": "JobFailed"
       }
     ],
     "default": {
-      "transition": {
-         "nextState": "WaitForCompletion"
-       }
+      "transition": "WaitForCompletion"
     }
   },
   {  
@@ -1231,12 +1187,11 @@ states:
       dataResultsPath: "{{ $.jobuid }}"
   onErrors:
   - error: "*"
-    transition:
-      nextState: SubmitError
+    transition: SubmitError
+
   stateDataFilter:
     dataOutputPath: "{{ $.jobuid }}"
-  transition:
-    nextState: WaitForCompletion
+  transition: WaitForCompletion
 - name: SubmitError
   type: subflow
   workflowId: handleJobSubmissionErrorWorkflow
@@ -1244,8 +1199,7 @@ states:
 - name: WaitForCompletion
   type: delay
   timeDelay: PT5S
-  transition:
-    nextState: GetJobStatus
+  transition: GetJobStatus
 - name: GetJobStatus
   type: operation
   actionMode: sequential
@@ -1258,20 +1212,16 @@ states:
       dataResultsPath: "{{ $.jobstatus }}"
   stateDataFilter:
     dataOutputPath: "{{ $.jobstatus }}"
-  transition:
-    nextState: DetermineCompletion
+  transition: DetermineCompletion
 - name: DetermineCompletion
   type: switch
   dataConditions:
   - condition: "{{ $[?(@.jobstatus == 'SUCCEEDED')] }}"
-    transition:
-      nextState: JobSucceeded
+    transition: JobSucceeded
   - condition: "{{ $[?(@.jobstatus == 'FAILED')] }}"
-    transition:
-      nextState: JobFailed
+    transition: JobFailed
   default:
-    transition:
-      nextState: WaitForCompletion
+    transition: WaitForCompletion
 - name: JobSucceeded
   type: operation
   actionMode: sequential
@@ -1951,9 +1901,7 @@ And for denied credit check, for example:
             },
             "eventRef": "CreditCheckCompletedEvent",
             "timeout": "PT15M",
-            "transition": {
-                "nextState": "EvaluateDecision"
-            }
+            "transition": "EvaluateDecision"
         },
         {
             "name": "EvaluateDecision",
@@ -1961,21 +1909,15 @@ And for denied credit check, for example:
             "dataConditions": [
                 {
                     "condition": "{{ $.creditCheck[?(@.decision == 'Approved')] }}",
-                    "transition": {
-                        "nextState": "StartApplication"
-                    }
+                    "transition": "StartApplication"
                 },
                 {
                     "condition": "{{ $.creditCheck[?(@.decision == 'Denied')] }}",
-                    "transition": {
-                        "nextState": "RejectApplication"
-                    }
+                    "transition": "RejectApplication"
                 }
             ],
             "default": {
-               "transition": {
-                 "nextState": "RejectApplication"
-                }
+               "transition": "RejectApplication"
             }
         },
         {
@@ -2034,20 +1976,16 @@ states:
         customer: "{{ $.customer }}"
   eventRef: CreditCheckCompletedEvent
   timeout: PT15M
-  transition:
-    nextState: EvaluateDecision
+  transition: EvaluateDecision
 - name: EvaluateDecision
   type: switch
   dataConditions:
   - condition: "{{ $.creditCheck[?(@.decision == 'Approved')] }}"
-    transition:
-      nextState: StartApplication
+    transition: StartApplication
   - condition: "{{ $.creditCheck[?(@.decision == 'Denied')] }}"
-    transition:
-      nextState: RejectApplication
+    transition: RejectApplication
   default:
-    transition:
-      nextState: RejectApplication
+    transition: RejectApplication
 - name: StartApplication
   type: subflow
   workflowId: startApplicationWorkflowId
@@ -2273,14 +2211,10 @@ The results of the inbox service called is expected to be for example:
         "actionMode": "sequential",
         "actions": [
             {
-                "functionRef": {
-                    "refName": "checkInboxFunction"
-                }
+                "functionRef": "checkInboxFunction"
             }
         ],
-        "transition": {
-            "nextState": "SendTextForHighPriority"
-        }
+        "transition": "SendTextForHighPriority"
     },
     {
         "name": "SendTextForHighPriority",
@@ -2325,10 +2259,8 @@ states:
         expression: 0 0/15 * * * ?
   actionMode: sequential
   actions:
-  - functionRef:
-      refName: checkInboxFunction
-  transition:
-    nextState: SendTextForHighPriority
+  - functionRef: checkInboxFunction
+  transition: SendTextForHighPriority
 - name: SendTextForHighPriority
   type: foreach
   inputCollection: "{{ $.messages }}"
@@ -2564,9 +2496,7 @@ In our workflow definition then we can reference these files rather than definin
           ]
         }
       ],
-      "transition": {
-        "nextState": "ConfirmBasedOnFunds"
-      }
+      "transition": "ConfirmBasedOnFunds"
     },
     {
       "name": "ConfirmBasedOnFunds",
@@ -2574,21 +2504,15 @@ In our workflow definition then we can reference these files rather than definin
       "dataConditions": [
         {
           "condition": "{{ $.funds[?(@.available == 'true')] }}",
-          "transition": {
-            "nextState": "SendPaymentSuccess"
-          }
+          "transition": "SendPaymentSuccess"
         },
         {
           "condition": "{{ $.funds[?(@.available == 'false')] }}",
-          "transition": {
-            "nextState": "SendInsufficientResults"
-          }
+          "transition": "SendInsufficientResults"
         }
       ],
       "default": {
-        "transition": {
-          "nextState": "SendPaymentSuccess"
-        }
+        "transition": "SendPaymentSuccess"
       }
     },
     {
@@ -2662,20 +2586,16 @@ states:
         parameters:
           account: "{{ $.accountId }}"
           paymentamount: "{{ $.payment.amount }}"
-  transition:
-    nextState: ConfirmBasedOnFunds
+  transition: ConfirmBasedOnFunds
 - name: ConfirmBasedOnFunds
   type: switch
   dataConditions:
   - condition: "{{ $.funds[?(@.available == 'true')] }}"
-    transition:
-      nextState: SendPaymentSuccess
+    transition: SendPaymentSuccess
   - condition: "{{ $.funds[?(@.available == 'false')] }}"
-    transition:
-      nextState: SendInsufficientResults
+    transition: SendInsufficientResults
   default:
-    transition:
-      nextState: SendPaymentSuccess
+    transition: SendPaymentSuccess
 - name: SendPaymentSuccess
   type: operation
   actions:
@@ -2763,19 +2683,13 @@ If the retries are not successful, we want to just gracefully end workflow execu
           ],
           "actions": [
             {
-              "functionRef": {
-                "refName": "StorePatient"
-              }
+              "functionRef": "StorePatient"
             },
             {
-              "functionRef": {
-                "refName": "AssignDoctor"
-              }
+              "functionRef": "AssignDoctor"
             },
             {
-              "functionRef": {
-                "refName": "ScheduleAppt"
-              }
+              "functionRef": "ScheduleAppt"
             }
           ]
         }
@@ -2837,12 +2751,9 @@ states:
   - eventRefs:
     - NewPatientEvent
     actions:
-    - functionRef:
-        refName: StorePatient
-    - functionRef:
-        refName: AssignDoctor
-    - functionRef:
-        refName: ScheduleAppt
+    - functionRef: StorePatient
+    - functionRef: AssignDoctor
+    - functionRef: ScheduleAppt
   onErrors:
   - error: ServiceNotAvailable
     code: '503'

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -87,6 +87,7 @@ _Status description:_
 | ✔️| Updating start and end state definitions| [spec doc](../specification.md) |
 | ✔️| Update cron definition (adding validUntil parameter)| [spec doc](../specification.md) |
 | ✔️| Adding comparison examples with Temporal | [examples doc](../examples/examples.md) |
+| ✔️| Simplified functionRef and transition properties | [spc doc](../specification.md) |
 | 🚩 | JSONPatch transformations | [issue](https://github.com/serverlessworkflow/specification/issues/149) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -208,29 +208,39 @@
       ]
     },
     "transition": {
-      "type": "object",
-      "properties": {
-        "produceEvents": {
-          "type": "array",
-          "description": "Array of events to be produced",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/produceeventdef"
-          }
-        },
-        "nextState": {
+      "oneOf": [
+        {
           "type": "string",
           "description": "Name of state to transition to",
           "minLength": 1
         },
-        "compensate": {
-          "type": "boolean",
-          "default": false,
-          "description": "If set to true, triggers workflow compensation when before this transition is taken. Default is false"
+        {
+          "type": "object",
+          "description": "Function Reference",
+          "properties": {
+            "nextState": {
+              "type": "string",
+              "description": "Name of state to transition to",
+              "minLength": 1
+            },
+            "produceEvents": {
+              "type": "array",
+              "description": "Array of events to be produced before the transition happens",
+              "items": {
+                "type": "object",
+                "$ref": "#/definitions/produceeventdef"
+              }
+            },
+            "compensate": {
+              "type": "boolean",
+              "default": false,
+              "description": "If set to true, triggers workflow compensation when before this transition is taken. Default is false"
+            }
+          },
+          "required": [
+            "nextState"
+          ]
         }
-      },
-      "required": [
-        "nextState"
       ]
     },
     "error": {
@@ -320,8 +330,30 @@
           "description": "Unique action definition name"
         },
         "functionRef": {
-          "description": "References a reusable function definition",
-          "$ref": "#/definitions/functionref"
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Name of the referenced function",
+              "minLength": 1
+            },
+            {
+              "type": "object",
+              "description": "Function Reference",
+              "properties": {
+                "refName": {
+                  "type": "string",
+                  "description": "Name of the referenced function"
+                },
+                "parameters": {
+                  "type": "object",
+                  "description": "Function parameters"
+                }
+              },
+              "required": [
+                "refName"
+              ]
+            }
+          ]
         },
         "eventRef": {
           "description": "References a 'trigger' and 'result' reusable event definitions",
@@ -346,23 +378,6 @@
             "eventRef"
           ]
         }
-      ]
-    },
-    "functionref": {
-      "type": "object",
-      "description": "Function Reference",
-      "properties": {
-        "refName": {
-          "type": "string",
-          "description": "Name of the referenced function"
-        },
-        "parameters": {
-          "type": "object",
-          "description": "Function parameters"
-        }
-      },
-      "required": [
-        "refName"
       ]
     },
     "eventref": {

--- a/specification.md
+++ b/specification.md
@@ -174,9 +174,7 @@ For example:
       "start": true,
       "actions":[  
        {  
-       "functionRef": {
-         "refName": "sendOrderConfirmation"
-       }
+       "functionRef": "sendOrderConfirmation"
       }],
       "end": true
   }]
@@ -237,22 +235,16 @@ Our expression function definitions can now be referenced by workflow states whe
         {
           "name": "Applicant is adult",
           "condition": "{{ fn(isAdult) }}",
-          "transition": {
-            "nextState": "ApproveApplication"
-          }
+          "transition": "ApproveApplication"
         },
         {
           "name": "Applicant is minor",
           "condition": "{{ fn(isMinor) }}",
-          "transition": {
-            "nextState": "RejectApplication"
-          }
+          "transition": "RejectApplication"
         }
      ],
      "default": {
-        "transition": {
-           "nextState": "RejectApplication"
-        }
+        "transition": "RejectApplication"
      }
   }
 ]
@@ -382,9 +374,7 @@ In the following example we want reference the previously defined "IsAdultApplic
 ```json
 {
       "condition": "{{ fn(IsAdultApplicant) }}",
-      "transition": {
-        "nextState": "StartApplication"
-      }
+      "transition": "StartApplication"
 }
 ```
 
@@ -1333,6 +1323,17 @@ Possible invocation timeouts should be handled via the states [onErrors](#Workfl
 
 #### FunctionRef Definition
 
+`FunctionRef` definition can have two types, either `string` or `object`.
+If `string`, it defines the name of the referenced [function](#Function-Definition).
+This can be used as a short-cut definition when you don't need to define any parameters, for example:
+
+```json
+"functionRef": "myFunction"
+```
+
+If you need to define parameters in your `functionRef` definition, you can define 
+it with its `object` type which has the following properties:
+
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | refName | Name of the referenced [function](#Function-Definition) | string | yes |
@@ -1373,8 +1374,9 @@ parameters:
 
 </details>
 
-Used by actions to reference a defined serverless function by its unique name. Parameters are values passed to the
-function. They can include either static values or reference the states data input.
+The `refName` property is the name of the referenced [function](#Function-Definition).
+The `parameters` property defines the parameters you can pass as input parameters to the referenced function.
+Values of the `parameters` property can be either static values, or an expression.
 
 #### EventRef Definition
 
@@ -1453,9 +1455,7 @@ to the trigger/produced event.
 ```json
 {
    "error": "Item not in inventory",
-   "transition": {
-     "nextState": "IssueRefundToCustomer"
-   }
+   "transition": "IssueRefundToCustomer"
 }
 ```
 
@@ -1464,8 +1464,7 @@ to the trigger/produced event.
 
 ```yaml
 error: Item not in inventory
-transition:
-  nextState: IssueRefundToCustomer
+transition: IssueRefundToCustomer
 ```
 
 </td>
@@ -1621,11 +1620,22 @@ For more information, refer to the [Workflow Error Handling](#Workflow-Error-Han
 
 #### Transition Definition
 
+`Transition` definition can have two types, either `string` or `object`.
+If `string`, it defines the name of the state to transition to.
+This can be used as a short-cut definition when you don't need to define any other parameters, for example:
+
+```json
+"transition": "myNextState"
+```
+
+If you need to define additional parameters in your `transition` definition, you can define 
+it with its `object` type which has the following properties:
+
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
+| [nextState](#Transitions) | Name of the state to transition to next | string | yes |
 | [compensate](#Workflow-Compensation) | If set to `true`, triggers workflow compensation before this transition is taken. Default is `false` | boolean | no |
-| produceEvents | Array of [producedEvent](#ProducedEvent-Definition) definitions. Events to be produced when this transition happens | array | no |
-| [nextState](#Transitions) | State to transition to next | string | yes |
+| produceEvents | Array of [producedEvent](#ProducedEvent-Definition) definitions. Events to be produced before the transition takes place | array | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -1663,6 +1673,10 @@ nextState: EvalResultState
 </table>
 
 </details>
+
+The `nextState` property defines the name of the state to transition to next.
+The `compensate` property allows you to trigger [compensation](#Workflow-Compensation) before the transition (if set to true).
+The `produceEvents` property allows you to define a list of events to produce before the transition happens.
 
 Transitions allow you to move from one state (control-logic block) to another. For more information see the
 [Transitions section](#Transitions) section.
@@ -1777,22 +1791,16 @@ Once all actions have been performed, a transition to another state can occur.
      "eventConditions": [
         {
           "eventRef": "visaApprovedEvent",
-          "transition": {
-            "nextState": "HandleApprovedVisa"
-          }
+          "transition": "HandleApprovedVisa"
         },
         {
           "eventRef": "visaRejectedEvent",
-          "transition": {
-            "nextState": "HandleRejectedVisa"
-          }
+          "transition": "HandleRejectedVisa"
         }
      ],
      "eventTimeout": "PT1H",
      "default": {
-        "transition": {
-          "nextState": "HandleNoVisaDecision"
-        }
+        "transition": "HandleNoVisaDecision"
      }
 }
 ```
@@ -1806,15 +1814,12 @@ type: switch
 start: true
 eventConditions:
 - eventRef: visaApprovedEvent
-  transition:
-    nextState: HandleApprovedVisa
+  transition: HandleApprovedVisa
 - eventRef: visaRejectedEvent
-  transition:
-    nextState: HandleRejectedVisa
+  transition: HandleRejectedVisa
 eventTimeout: PT1H
 default:
-  transition:
-    nextState: HandleNoVisaDecision
+  transition: HandleNoVisaDecision
 ```
 
 </td>
@@ -1868,9 +1873,7 @@ If events defined in event-based conditions do not arrive before the states `eve
 {
       "name": "Eighteen or older",
       "condition": "{{ $.applicants[?(@.age >= 18)] }}",
-      "transition": {
-        "nextState": "StartApplication"
-      }
+      "transition": "StartApplication"
 }
 ```
 
@@ -1880,8 +1883,7 @@ If events defined in event-based conditions do not arrive before the states `eve
 ```yaml
 name: Eighteen or older
 condition: "{{ $.applicants[?(@.age >= 18)] }}"
-transition:
-  nextState: StartApplication
+transition: StartApplication
 ```
 
 </td>
@@ -1923,9 +1925,7 @@ to decide what to do, transition to another workflow state, or end workflow exec
 {
       "name": "Visa approved",
       "eventRef": "visaApprovedEvent",
-      "transition": {
-        "nextState": "HandleApprovedVisa"
-      }
+      "transition": "HandleApprovedVisa"
 }
 ```
 
@@ -1935,8 +1935,7 @@ to decide what to do, transition to another workflow state, or end workflow exec
 ```yaml
 name: Visa approved
 eventRef: visaApprovedEvent
-transition:
-  nextState: HandleApprovedVisa
+transition: HandleApprovedVisa
 ```
 
 </td>
@@ -1987,9 +1986,7 @@ The `eventDataFilter` property can be used to filter event when it is received.
       "name": "WaitForCompletion",
       "type": "delay",
       "timeDelay": "PT5S",
-      "transition": {
-        "nextState":"GetJobStatus"
-      }
+      "transition": "GetJobStatus"
 }
 ```
 
@@ -2000,8 +1997,7 @@ The `eventDataFilter` property can be used to filter event when it is received.
 name: WaitForCompletion
 type: delay
 timeDelay: PT5S
-transition:
-  nextState: GetJobStatus
+transition: GetJobStatus
 ```
 
 </td>
@@ -2330,9 +2326,7 @@ Referenced workflows must declare their own [function](#Function-Definition) and
      "data": {
         "result": "Hello"
      },
-     "transition": {
-       "nextState": "World"
-     }
+     "transition": "World"
 }
 ```
 
@@ -2345,8 +2339,7 @@ type: inject
 start: true
 data:
   result: Hello
-transition:
-  nextState: World
+transition: World
 ```
 
 </td>
@@ -2385,9 +2378,7 @@ as data output to the transition state:
         "age": 40
       }
    },
-   "transition": {
-      "nextState": "GreetPersonState"
-   }
+   "transition": "GreetPersonState"
   }
   ```
 
@@ -2403,8 +2394,7 @@ as data output to the transition state:
       lname: Doe
       address: 1234 SomeStreet
       age: 40
-  transition:
-    nextState: GreetPersonState
+  transition: GreetPersonState
 ```
 
 </td>
@@ -2467,9 +2457,7 @@ You can also use the filter property to filter the state data after data is inje
      "stateDataFilter": {
         "dataOutputPath": "{{ $.people[?(@.age < 40)] }}"
      },
-     "transition": {
-        "nextState": "GreetPersonState"
-     }
+     "transition": "GreetPersonState"
     }
 ```
 
@@ -2495,8 +2483,7 @@ You can also use the filter property to filter the state data after data is inje
       age: 30
   stateDataFilter:
     dataOutputPath: "{{ $.people[?(@.age < 40)] }}"
-  transition:
-    nextState: GreetPersonState
+  transition: GreetPersonState
 ```
 
 </td>
@@ -2791,9 +2778,7 @@ The results of each parallel action execution are stored as elements in the stat
         },
         "eventRef": "CreditCheckCompletedEvent",
         "timeout": "PT15M",
-        "transition": {
-            "nextState": "EvaluateDecision"
-        }
+        "transition": "EvaluateDecision"
 }
 ```
 
@@ -2811,8 +2796,7 @@ action:
       customer: "{{ $.customer }}"
 eventRef: CreditCheckCompletedEvent
 timeout: PT15M
-transition:
-  nextState: EvaluateDecision
+transition: EvaluateDecision
 ```
 
 </td>
@@ -3197,8 +3181,6 @@ Serverless workflow states can have one or more incoming and outgoing transition
 Each state can define a `transition` definition that is used to determine which
 state to transition to next.
 
-To define a transition, set the `nextState` property in your transition definitions.
-
 Implementers can choose to use the states `name` property
 for determining the transition; however, we realize that in most cases this is not an
 optimal solution that can lead to ambiguity. This is why each state also include an "id"
@@ -3258,9 +3240,7 @@ output of the state to transition from includes an user with the title "MANAGER"
    "actionMode":"Sequential",
    "actions":[  
     {  
-     "functionRef":{
-        "refName": "doLowRiskOperationFunction"
-     }
+     "functionRef": "doLowRiskOperationFunction"
     }
     ],
     "transition": {
@@ -3275,9 +3255,7 @@ output of the state to transition from includes an user with the title "MANAGER"
    "actionMode":"Sequential",
    "actions":[  
     {  
-     "functionRef":{
-       "refName": "doHighRiskOperationFunction"
-     }
+     "functionRef": "doHighRiskOperationFunction"
     }
    ]
   }
@@ -3300,8 +3278,7 @@ states:
   type: operation
   actionMode: Sequential
   actions:
-  - functionRef:
-      refName: doLowRiskOperationFunction
+  - functionRef: doLowRiskOperationFunction
   transition:
     nextState: highRiskState
     expression: "{{ $.users[?(@.title == 'MANAGER')] }}"
@@ -3310,8 +3287,7 @@ states:
   end: true
   actionMode: Sequential
   actions:
-  - functionRef:
-      refName: doHighRiskOperationFunction
+  - functionRef: doHighRiskOperationFunction
 ```
 
 </td>
@@ -3484,9 +3460,7 @@ we can define a state filter:
   "stateDataFilter": {
     "dataInputPath": "{{ $.fruits }}"
   },
-  "transition": {
-     "nextState": "someNextState"
-  }
+  "transition": "someNextState"
 }
 ```
 
@@ -3509,9 +3483,7 @@ The first way would be to use both "dataInputPath", and "dataOutputPath":
     "dataInputPath": "{{ $.vegetables }}",
     "dataOutputPath": "{{ $.[?(@.veggieLike)] }}"
   },
-  "transition": {
-     "nextState": "someNextState"
-  }
+  "transition": "someNextState"
 }
 ```
 
@@ -3531,9 +3503,7 @@ The second way would be to directly filter only the "veggie like" vegetables wit
   "stateDataFilter": {
     "dataInputPath": "{{ $.vegetables.[?(@.veggieLike)] }}"
   },
-  "transition": {
-     "nextState": "someNextState"
-  }
+  "transition": "someNextState"
 }
 ```
 
@@ -3603,9 +3573,7 @@ We can use an action data filter to filter only the breads data:
 {
 "actions":[  
     {  
-       "functionRef": {
-          "refName": "breadAndPastaTypesFunction"
-       },
+       "functionRef": "breadAndPastaTypesFunction",
        "actionDataFilter": {
           "dataResultsPath": "{{ $.breads }}"
        }
@@ -3924,15 +3892,11 @@ Let's take a look at an example of each of these two cases:
 "onErrors": [
   {
     "error": "Item not in inventory",
-    "transition": {
-      "nextState": "ReimburseCustomer"
-    }
+    "transition": "ReimburseCustomer"
   },
   {
     "error": "*",
-    "transition": {
-      "nextState": "handleAnyOtherError"
-    }
+    "transition": "handleAnyOtherError"
   }
 ]
 }
@@ -3944,11 +3908,9 @@ Let's take a look at an example of each of these two cases:
 ```yaml
 onErrors:
 - error: Item not in inventory
-  transition:
-    nextState: ReimburseCustomer
+  transition: ReimburseCustomer
 - error: "*"
-  transition:
-    nextState: handleAnyOtherError
+  transition: handleAnyOtherError
 ```
 
 </td>
@@ -3973,9 +3935,7 @@ On the other hand the following example shows how to handle "all" errors with th
 "onErrors": [
   {
     "error": "*",
-    "transition": {
-      "nextState": "handleAllErrors"
-    }
+    "transition": "handleAllErrors"
   }
 ]
 }
@@ -3987,8 +3947,7 @@ On the other hand the following example shows how to handle "all" errors with th
 ```yaml
 onErrors:
 - error: "*"
-  transition:
-    nextState: handleAllErrors
+  transition: handleAllErrors
 ```
 
 </td>
@@ -4068,9 +4027,7 @@ Different states now can use this retry strategy defined. For example:
   {
     "error": "Inventory service timeout",
     "retryRef": "Service Call Timeout Retry Strategy",
-    "transition": {
-      "nextState": "ReimburseCustomer"
-    }
+    "transition": "ReimburseCustomer"
   }
 ]
 }
@@ -4083,8 +4040,7 @@ Different states now can use this retry strategy defined. For example:
 onErrors:
 - error: Inventory service timeout
   retryRef: Service Call Timeout Retry Strategy
-  transition:
-    nextState: ReimburseCustomer
+  transition: ReimburseCustomer
 ```
 
 </td>
@@ -4193,9 +4149,7 @@ state it references:
             }
           ],
           "compensatedBy": "CancelPurchase",
-          "transition": {
-              "nextState": "SomeNextWorkflowState"
-          }
+          "transition": "SomeNextWorkflowState"
       },
       {
         "name": "CancelPurchase",
@@ -4245,8 +4199,7 @@ states:
         parameters:
           customerid: "{{ $.purchase.customerid }}"
   compensatedBy: CancelPurchase
-  transition:
-    nextState: SomeNextWorkflowState
+  transition: SomeNextWorkflowState
 - name: CancelPurchase
   type: operation
   usedForCompensation: true


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [x ] Schema
- [x ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Simplifies the functionRef and transition properties. In both cases if only the name of the functionref/state name 
needs to be defined (no additional properties) these can now be defined as simple string value (not an object).
So for example:

```json
"functionRef": "myFunction"
```

```json
"transition": "myNextState"
```

This significantly reduces the amount of lines defined in the json/yaml definitions
**Special notes for reviewers**:

**Additional information (if needed):**