### PR TITLE
Simplify schedule and cron definitions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2208,9 +2208,7 @@ The results of the inbox service called is expected to be for example:
         "type": "operation",
         "start": {
             "schedule": {
-                "cron": {
-                   "expression": "0 0/15 * * * ?"
-                }
+                "cron": "0 0/15 * * * ?"
             }
         },
         "actionMode": "sequential",

--- a/examples/README.md
+++ b/examples/README.md
@@ -2082,9 +2082,7 @@ Bidding is done via an online application and bids are received as events are as
           "name": "StoreCarAuctionBid",
           "type": "event",
           "start": {
-              "schedule": {
-                "interval": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
-              }
+              "schedule": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
           },
           "exclusive": true,
           "onEvents": [
@@ -2125,8 +2123,7 @@ states:
 - name: StoreCarAuctionBid
   type: event
   start:
-    schedule:
-      interval: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
+    schedule: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
   exclusive: true
   onEvents:
   - eventRefs:
@@ -2258,8 +2255,7 @@ states:
   type: operation
   start:
     schedule:
-      cron:
-        expression: 0 0/15 * * * ?
+      cron: 0 0/15 * * * ?
   actionMode: sequential
   actions:
   - functionRef: checkInboxFunction

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1777,35 +1777,45 @@
       ]
     },
     "schedule": {
-      "type": "object",
-      "description": "Start state schedule definition",
-      "properties": {
-        "interval": {
-          "type": "string",
-          "description": "Time interval (ISO 8601 format) describing when workflow instances can be created."
-        },
-        "cron": {
-          "$ref": "#/definitions/crondef"
-        },
-        "directInvoke": {
-          "description": "Define if workflow instances can be created outside of the defined interval/cron",
-          "type": "boolean",
-          "default": false
-        },
-        "timezone": {
-          "type": "string",
-          "description": "Timezone name used to evaluate the cron expression. Not used for interval as timezone can be specified there directly. If not specified, should default to local machine timezone."
-        }
-      },
       "oneOf": [
         {
-          "required": [
-            "interval"
-          ]
+          "type": "string",
+          "description": "Time interval (ISO 8601 format) describing when workflow instances can be created.",
+          "minLength": 1
         },
         {
-          "required": [
-            "cron"
+          "type": "object",
+          "description": "Start state schedule definition",
+          "properties": {
+            "interval": {
+              "type": "string",
+              "description": "Time interval (ISO 8601 format) describing when workflow instances can be created.",
+              "minLength": 1
+            },
+            "cron": {
+              "$ref": "#/definitions/crondef"
+            },
+            "directInvoke": {
+              "description": "Define if workflow instances can be created outside of the defined interval/cron",
+              "type": "boolean",
+              "default": false
+            },
+            "timezone": {
+              "type": "string",
+              "description": "Timezone name used to evaluate the cron expression. Not used for interval as timezone can be specified there directly. If not specified, should default to local machine timezone."
+            }
+          },
+          "oneOf": [
+            {
+              "required": [
+                "interval"
+              ]
+            },
+            {
+              "required": [
+                "cron"
+              ]
+            }
           ]
         }
       ]

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -102,18 +102,28 @@
   ],
   "definitions": {
     "crondef": {
-      "type": "object",
-      "properties": {
-        "expression": {
+      "oneOf": [
+        {
           "type": "string",
           "description": "Repeating interval (cron expression) describing when the workflow instance should be created",
           "minLength": 1
         },
-        "validUntil": {
-          "type": "string",
-          "description": "Specific date and time (ISO 8601 format) when the cron expression invocation is no longer valid"
+        {
+          "type": "object",
+          "properties": {
+            "expression": {
+              "type": "string",
+              "description": "Repeating interval (cron expression) describing when the workflow instance should be created",
+              "minLength": 1
+            },
+            "validUntil": {
+              "type": "string",
+              "description": "Specific date and time (ISO 8601 format) when the cron expression invocation is no longer valid"
+            }
+          },
+          "required": ["expression"]
         }
-      }
+      ]
     },
     "exectimeout": {
       "type": "object",

--- a/specification.md
+++ b/specification.md
@@ -3072,9 +3072,7 @@ If the start definition is of type `object`, it has the following structure:
 
 ```json
 {
-  "schedule": {
-    "interval": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
-  }
+  "schedule": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
 }
 ```
 
@@ -3082,8 +3080,7 @@ If the start definition is of type `object`, it has the following structure:
 <td valign="top">
 
 ```yaml
-schedule:
-  interval: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
+schedule: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
 ```
 
 </td>
@@ -3146,6 +3143,17 @@ the needed events at the defined times to trigger workflow instance creation.
 
 #### Schedule Definition
 
+`Schedule` definition can have two types, either `string` or `object`.
+If `string` type, it defines time interval describing when the workflow instance can be created.
+This can be used as a short-cut definition when you don't need to define any other parameters, for example:
+
+```json
+"schedule": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
+```
+
+If you need to define the `cron`, `directInvoke` or the `timezone` parameters in your `schedule` definition, you can define 
+it with its `object` type which has the following properties:
+
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | interval | Time interval describing when the workflow instance can be created (ISO 8601 time interval format). | string | yes if `cron` not defined |
@@ -3175,8 +3183,7 @@ the needed events at the defined times to trigger workflow instance creation.
 <td valign="top">
 
 ```yaml
-cron:
-  expression: 0 0/15 * * * ?
+cron: 0 0/15 * * * ?
 directInvoke: true
 ```
 
@@ -3223,7 +3230,6 @@ This can be used as a short-cut definition when you don't need to define any oth
 
 If you need to define the `validUntil` parameters in your `cron` definition, you can define 
 it with its `object` type which has the following properties:
-
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |

--- a/specification.md
+++ b/specification.md
@@ -3166,9 +3166,7 @@ the needed events at the defined times to trigger workflow instance creation.
 
 ```json
 {
-   "cron": {
-      "expression": "0 0/15 * * * ?"
-   },
+   "cron": "0 0/15 * * * ?",
    "directInvoke": true
 }
 ```
@@ -3214,6 +3212,18 @@ the needed events at the defined times to trigger workflow instance creation.
 The `directInvoke` property defines if workflow instances are allowed to be created outside of the defined interval or cron expression.
 
 #### Cron Definition
+
+`Cron` definition can have two types, either `string` or `object`.
+If `string` type, it defines the repeating interval (cron expression) describing when the workflow instance should be created.
+This can be used as a short-cut definition when you don't need to define any other parameters, for example:
+
+```json
+"cron": "0 15,30,45 * ? * *"
+```
+
+If you need to define the `validUntil` parameters in your `cron` definition, you can define 
+it with its `object` type which has the following properties:
+
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
simplifies the "cron" definition. if you dont need to specify the "validUntil" param you can now use it as a string type, for example;

```json
"cron": "0 15,30,45 * ? * *"
```

simplifies the "schedule' definition. if you dont need to specify cron, directiinvoke and timezone (so only 'interval') you can do:

```json
"schedule": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
```

**Special notes for reviewers**:

**Additional information (if needed):**