### PR TITLE
Move start definition to top-level workflow properties

### DIFF
--- a/comparisons/comparison-argo.md
+++ b/comparisons/comparison-argo.md
@@ -77,6 +77,7 @@ spec:
 id: hello-world-parameters
 name: Hello World with parameters
 version: '1.0'
+start: whalesay
 functions:
 - name: whalesayimage
   metadata:
@@ -85,7 +86,6 @@ functions:
 states:
 - name: whalesay
   type: operation
-  start: true
   actions:
   - functionRef:
       refName: whalesayimage
@@ -155,6 +155,7 @@ spec:
 id: hello-hello-hello
 name: Multi Step Hello
 version: '1.0'
+start: hello1
 functions:
 - name: whalesayimage
   metadata:
@@ -163,7 +164,6 @@ functions:
 states:
 - name: hello1
   type: operation
-  start: true
   actions:
   - functionRef:
       refName: whalesayimage
@@ -256,6 +256,7 @@ spec:
 id: dag-diamond-
 name: DAG Diamond Example
 version: '1.0'
+start: A
 functions:
 - name: echo
   metadata:
@@ -264,7 +265,6 @@ functions:
 states:
 - name: A
   type: operation
-  start: true
   actions:
   - functionRef:
       refName: echo
@@ -290,7 +290,6 @@ states:
   transition: D
 - name: D
   type: operation
-  start: true
   actions:
   - functionRef:
       refName: echo
@@ -375,6 +374,7 @@ spec:
 id: scripts-bash-
 name: Scripts and Results Example
 version: '1.0'
+start: generate
 functions:
 - name: gen-random-int-bash
   metadata:
@@ -401,7 +401,6 @@ functions:
 states:
 - name: generate
   type: operation
-  start: true
   actions:
   - functionRef: gen-random-int-bash
     actionDataFilter:
@@ -470,6 +469,7 @@ spec:
 id: loops-
 name: Loop over data example
 version: '1.0'
+start: injectdata
 functions:
 - name: whalesay
   metadata:
@@ -478,7 +478,6 @@ functions:
 states:
 - name: injectdata
   type: inject
-  start: true
   data:
     greetings:
     - hello world
@@ -564,6 +563,7 @@ spec:
 id: coinflip-
 name: Conditionals Example
 version: '1.0'
+start: flip-coin
 functions:
 - name: flip-coin-function
   metadata:
@@ -578,7 +578,6 @@ functions:
 states:
 - name: flip-coin
   type: operation
-  start: true
   actions:
   - functionRef: flip-coin-function
     actionDataFilter:
@@ -656,6 +655,7 @@ spec:
 id: retry-backoff-
 name: Retry Example
 version: '1.0'
+start: retry-backoff
 functions:
 - name: fail-function
   metadata:
@@ -670,7 +670,6 @@ retries:
 states:
 - name: retry-backoff
   type: operation
-  start: true
   actions:
   - functionRef:
       refName: flip-coin-function
@@ -745,6 +744,7 @@ spec:
 id: coinflip-recursive-
 name: Recursion Example
 version: '1.0'
+start: flip-coin-state
 functions:
 - name: heads-function
   metadata:
@@ -758,7 +758,6 @@ functions:
 states:
 - name: flip-coin-state
   type: operation
-  start: true
   actions:
   - functionRef: flip-coin-function
     actionDataFilter:
@@ -854,6 +853,7 @@ spec:
 id: exit-handlers-
 name: Exit/Error Handling Example
 version: '1.0'
+start: intentional-fail-state
 functions:
 - name: intentional-fail-function
   metadata:
@@ -870,7 +870,6 @@ functions:
 states:
 - name: intentional-fail-state
   type: operation
-  start: true
   actions:
   - functionRef:
       refName: intentional-fail-function

--- a/comparisons/comparison-bpmn.md
+++ b/comparisons/comparison-bpmn.md
@@ -52,10 +52,10 @@ For this reason, the event, function, retry, and data mapping defined in the ass
 id: processfile
 name: Process File Workflow
 version: '1.0'
+start: Process File
 states:
 - name: Process File
   type: operation
-  start: true
   actions:
   - functionRef: processFile
   end: true
@@ -87,10 +87,10 @@ functions:
 id: processapplication
 name: Process Application
 version: '1.0'
+start: ProcessNewApplication
 states:
 - name: ProcessNewApplication
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - ApplicationReceivedEvent
@@ -140,9 +140,9 @@ events:
 id: simplecompensation
 name: Simple Compensation
 version: '1.0'
+start: Step 1
 states:
 - name: Step 1
-  start: true
   type: operation
   actions:
   - functionRef: step1function
@@ -200,9 +200,9 @@ functions:
 id: errorwithretries
 name: Error Handling With Retries Workflow
 version: '1.0'
+start: Make Coffee
 states:
 - name: Make Coffee
-  start: true
   type: operation
   actions:
   - functionRef: makeCoffee
@@ -257,13 +257,13 @@ functions:
 id: executiontimeout
 name: Execution Timeout Workflow
 version: '1.0'
+start: Purchase Parts
 execTimeout:
   interval: PT7D
   interrupt: true
   runBefore: Handle timeout
 states:
 - name: Purchase Parts
-  start: true
   type: operation
   actions:
   - functionRef: purchasePartsFunction
@@ -309,10 +309,10 @@ functions:
 id: subflowloop
 name: SubFlow Repeat workflow
 version: '1.0'
+start: SubflowRepeat
 states:
 - name: SubflowRepeat
   type: subflow
-  start: true
   workflowId: dosomethingandwaitformessage
   repeat:
     max: 10
@@ -345,10 +345,10 @@ a starting "operation" state transitioning to an "event" state that waits for th
 id: approvereport
 name: Approve Report Workflow
 version: '1.0'
+start: Approve Report
 states:
 - name: Approve Report
   type: callback
-  start: true
   action:
     functionRef: managerDecideOnReport
   eventRef: ReportDecisionMadeEvent
@@ -407,10 +407,10 @@ functions:
 id: eventdecision
 name: Event Decision workflow
 version: '1.0'
+start: A
 states:
 - name: A
   type: subflow
-  start: true
   workflowId: asubflowid
   transition: Event Decision
 - name: Event Decision

--- a/comparisons/comparison-brigade.md
+++ b/comparisons/comparison-brigade.md
@@ -65,6 +65,7 @@ function exec(e, p) {
 id: greeting
 name: Greeting Workflow
 version: '1.0'
+start: GreetingState
 events:
 - name: execEvent
   type: exec
@@ -78,7 +79,6 @@ functions:
 states:
 - name: GreetingState
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -144,6 +144,7 @@ async function exec(e, p) {
 id: greetingwitherrorcheck
 name: Greeting Workflow With Error Check
 version: '1.0'
+start: GreetingState
 events:
 - name: execEvent
   type: exec
@@ -157,7 +158,6 @@ functions:
 states:
 - name: GreetingState
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -227,6 +227,7 @@ events.on("push", () => {
 id: multieventworkflow
 name: Multiple Events Workflow
 version: '1.0'
+start: GreetingState
 events:
 - name: execEvent
   type: exec
@@ -238,7 +239,6 @@ functions:
 states:
 - name: GreetingState
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -311,6 +311,7 @@ events.on("exec", () => {
 id: groupActionsWorkflow
 name: Group Actions Workflow
 version: '1.0'
+start: FirstGreetGroup
 events:
 - name: execEvent
   type: exec
@@ -322,7 +323,6 @@ functions:
 states:
 - name: FirstGreetGroup
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -389,6 +389,7 @@ events.on("exec", (e, p) => {
 id: eventDataWorkflow
 name: Event Data Workflow
 version: '1.0'
+start: LogEventData
 events:
 - name: execEvent
   type: exec
@@ -398,7 +399,6 @@ functions:
 states:
 - name: LogEventData
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -464,6 +464,7 @@ events.on("exec", (e, p) => {
 id: actionResultsWorkflow
 name: Action Results Workflow
 version: '1.0'
+start: ExecActionsAndStoreResults
 events:
 - name: execEvent
   type: exec
@@ -479,7 +480,6 @@ functions:
 states:
 - name: ExecActionsAndStoreResults
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - execEvent
@@ -554,6 +554,7 @@ events.on("next", (e) => {
 id: eventDataWorkflow
 name: Event Data Workflow
 version: '1.0'
+start: ExecEventState
 events:
 - name: execEvent
   type: exec
@@ -566,7 +567,6 @@ functions:
 states:
 - name: ExecEventState
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - execEvent

--- a/comparisons/comparison-cadence.md
+++ b/comparisons/comparison-cadence.md
@@ -83,10 +83,10 @@ public class TripBookingWorkflowImpl implements TripBookingWorkflow {
 id: tripbookingwithcompensation
 name: Trip Booking With Compensation
 version: '1.0'
+start: BookTrip
 states:
 - name: BookTrip
   type: operation
-  start: true
   compensatedBy: CancelTrip
   actions:
   - functionRef: reservecarfunction
@@ -191,10 +191,10 @@ public class FileProcessingWorkflowImpl implements FileProcessingWorkflow {
 id: fileprocessingwithretries
 name: File Processing Workflow With Retries
 version: '1.0'
+start: ProcessAndUpload
 states:
 - name: ProcessAndUpload
   type: operation
-  start: true
   actions:
   - functionRef:
       refName: processfilefunction
@@ -295,11 +295,11 @@ public static class GreetingWorkflowImpl implements GreetingWorkflow {
 id: subflowgreeting
 name: SubFlow Greeting Workflow
 version: '1.0'
+start: GreetingSubFlow
 states:
 - name: GreetingSubFlow
   type: subflow
   workflowId: subflowgreet
-  start: true
   waitForCompletion: false
   end: true
 functions:

--- a/comparisons/comparison-google-cloud-workflows.md
+++ b/comparisons/comparison-google-cloud-workflows.md
@@ -86,11 +86,11 @@ languages.
 {
     "id": "greetingwithargs",
     "name": "Greeting With Args",
+    "start": "Set Output",
     "states": [
         {
             "name": "Set Output",
             "type": "inject",
-            "start": true,
             "data": {
                 "outputVar": "Hello ${ .firstname + \" \" +  .lastname  }"
             },
@@ -193,11 +193,11 @@ instance is created. See the Serverless Workflow ["Workflow Data"](../specificat
 {
     "id": "concatarray",
     "name": "Concatenating array values",
+    "start": "DoConcat",
     "states": [
         {
             "name": "DoConcat",
             "type": "inject",
-            "start": true,
             "data": {
                 "array": [
                     "foo",
@@ -283,11 +283,11 @@ array values, however it would just unnecessarily complicate things.
 {
     "id": "stopcomputeengine",
     "name": "Stop Compute Engine",
+    "start": "DoStop",
     "states": [
         {
             "name": "DoStop",
             "type": "operation",
-            "start": true,
             "actions": [
                 {
                     "functionRef": {
@@ -413,11 +413,11 @@ as service invocations, where as Google Workflow uses the "call" keyword.
 {
     "id": "publishtotopicwitherrorhandling",
     "name": "Publish To Topic With Error Handling",
+    "start": "DoPublish",
     "states": [
         {
             "name": "DoPublish",
             "type": "operation",
-            "start": true,
             "actions": [
                 {
                     "functionRef": {
@@ -575,11 +575,11 @@ to interested parties via events (CloudEvents specification format), which we ar
 {
     "id": "errorhandlingwithretries",
     "name": "Error Handling with Retries",
+    "start": "ReadItem",
     "states": [
         {
             "name": "ReadItem",
             "type": "operation",
-            "start": true,
             "actions": [
                 {
                     "functionRef": "ReadItemFromApi"
@@ -678,11 +678,11 @@ error handlers in the "retry" statement as an expression/variable.
 {
     "id": "callsubflow",
     "name": "Call SubFlow",
+    "start": "CallSub",
     "states": [
         {
             "name": "CallSub",
             "type":"subflow",
-            "start": true,
             "workflowId": "calledsubflow",
             "end": true
         }
@@ -776,11 +776,11 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
 {
     "id": "databasedconditions",
     "name": "Data Based Conditions",
+    "start": "CallA",
     "states": [
         {
             "name": "CallA",
             "type":"operation",
-            "start": true,
             "actions": [
                 {
                     "functionRef": "callFunctionA"

--- a/comparisons/comparison-temporal.md
+++ b/comparisons/comparison-temporal.md
@@ -133,11 +133,11 @@ public class HelloActivity {
   "id": "HelloActivityRetry",
   "name": "Hello Activity Workflow",
   "version": "1.0",
+  "start": "GreetingState",
   "states": [
     {
       "name": "GreetingState",
       "type": "operation",
-      "start": true,
       "actions": [
         {
           "name": "Greet",
@@ -268,18 +268,19 @@ public class HelloActivity {
   "id": "HelloCron",
   "name": "Hello Activity with Cron Workflow",
   "version": "1.0",
+  "start": {
+    "stateName": "GreetingState",
+    "schedule": {
+      "cron": {
+        "expression": "* * * * *",
+        "validUntil": "PT10M"
+      }
+    }
+  },
   "states": [
     {
       "name": "GreetingState",
       "type": "operation",
-      "start": {
-        "schedule": {
-          "cron": {
-            "expression": "* * * * *",
-            "validUntil": "PT10M"
-          }
-        }
-      },
       "actions": [
         {
           "name": "Greet",
@@ -451,11 +452,11 @@ public class HelloActivity {
   "id": "HelloSaga",
   "name": "Hello SAGA compensation Workflow",
   "version": "1.0",
+  "start": "ExecuteState",
   "states": [
     {
       "name": "ExecuteState",
       "type": "operation",
-      "start": true,
       "compensatedBy": "CompensateState",
       "actions": [
         {
@@ -607,11 +608,11 @@ public class HelloActivityRetry {
   "id": "HelloActivityRetry",
   "name": "Hello Activity with Retries Workflow",
   "version": "1.0",
+  "start": "GreetingState",
   "states": [
     {
       "name": "GreetingState",
       "type": "operation",
-      "start": true,
       "actions": [
         {
           "name": "Greet",

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,11 +63,11 @@ data output, which is:
 "version": "1.0",
 "name": "Hello World Workflow",
 "description": "Inject Hello World",
+"start": "Hello State",
 "states":[  
   {  
      "name":"Hello State",
      "type":"inject",
-     "start": true,
      "data": {
         "result": "Hello World!"
      },
@@ -85,10 +85,10 @@ id: helloworld
 version: '1.0'
 name: Hello World Workflow
 description: Inject Hello World
+start: Hello State
 states:
 - name: Hello State
   type: inject
-  start: true
   data:
     result: Hello World!
   end: true
@@ -145,6 +145,7 @@ Which is added to the states data and becomes the workflow data output.
 "version": "1.0",
 "name": "Greeting Workflow",
 "description": "Greet Someone",
+"start": "Greet",
 "functions": [
   {
      "name": "greetingFunction",
@@ -155,7 +156,6 @@ Which is added to the states data and becomes the workflow data output.
   {  
      "name":"Greet",
      "type":"operation",
-     "start": true,
      "actions":[  
         {  
            "functionRef": {
@@ -183,13 +183,13 @@ id: greeting
 version: '1.0'
 name: Greeting Workflow
 description: Greet Someone
+start: Greet
 functions:
 - name: greetingFunction
   operation: file://myapis/greetingapis.json#greeting
 states:
 - name: Greet
   type: operation
-  start: true
   actions:
   - functionRef:
       refName: greetingFunction
@@ -288,6 +288,7 @@ filters what is selected to be the state data output which then becomes the work
 "version": "1.0",
 "name": "Event Based Greeting Workflow",
 "description": "Event Based Greeting",
+"start": "Greet",
 "events": [
  {
   "name": "GreetingEvent",
@@ -305,7 +306,6 @@ filters what is selected to be the state data output which then becomes the work
   {  
      "name":"Greet",
      "type":"event",
-     "start": true,
      "onEvents": [{
          "eventRefs": ["GreetingEvent"],
          "eventDataFilter": {
@@ -339,6 +339,7 @@ id: eventbasedgreeting
 version: '1.0'
 name: Event Based Greeting Workflow
 description: Event Based Greeting
+start: Greet
 events:
 - name: GreetingEvent
   type: greetingEventType
@@ -349,7 +350,6 @@ functions:
 states:
 - name: Greet
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - GreetingEvent
@@ -412,6 +412,7 @@ result of the workflow execution.
 "version": "1.0",
 "name": "Solve Math Problems Workflow",
 "description": "Solve math problems",
+"start": "Solve",
 "functions": [
 {
   "name": "solveMathExpressionFunction",
@@ -421,7 +422,6 @@ result of the workflow execution.
 "states":[  
 {
  "name":"Solve",
- "start": true,
  "type":"foreach",
  "inputCollection": "${ .expressions }",
  "iterationParam": "singleexpression",
@@ -453,12 +453,12 @@ id: solvemathproblems
 version: '1.0'
 name: Solve Math Problems Workflow
 description: Solve math problems
+start: Solve
 functions:
 - name: solveMathExpressionFunction
   operation: http://myapis.org/mapthapis.json#solveExpression
 states:
 - name: Solve
-  start: true
   type: foreach
   inputCollection: "${ .expressions }"
   iterationParam: singleexpression
@@ -507,11 +507,11 @@ to finish execution before it can transition (end workflow execution in this cas
 "version": "1.0",
 "name": "Parallel Execution Workflow",
 "description": "Executes two branches in parallel",
+"start": "ParallelExec",
 "states":[  
   {  
      "name": "ParallelExec",
      "type": "parallel",
-     "start": true,
      "completionType": "and",
      "branches": [
         {
@@ -537,10 +537,10 @@ id: parallelexec
 version: '1.0'
 name: Parallel Execution Workflow
 description: Executes two branches in parallel
+start: ParallelExec
 states:
 - name: ParallelExec
   type: parallel
-  start: true
   completionType: and
   branches:
   - name: ShortDelayBranch
@@ -589,6 +589,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
 "version": "1.0",
 "name": "Event Based Switch Transitions",
 "description": "Event Based Switch Transitions",
+"start": "CheckVisaStatus",
 "events": [
 {
     "name": "visaApprovedEvent",
@@ -605,7 +606,6 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
   {  
      "name":"CheckVisaStatus",
      "type":"switch",
-     "start": true,
      "eventConditions": [
         {
           "eventRef": "visaApprovedEvent",
@@ -651,6 +651,7 @@ id: eventbasedswitch
 version: '1.0'
 name: Event Based Switch Transitions
 description: Event Based Switch Transitions
+start: CheckVisaStatus
 events:
 - name: visaApprovedEvent
   type: VisaApproved
@@ -661,7 +662,6 @@ events:
 states:
 - name: CheckVisaStatus
   type: switch
-  start: true
   eventConditions:
   - eventRef: visaApprovedEvent
     transition: HandleApprovedVisa
@@ -731,6 +731,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
    "version": "1.0",
    "name": "Applicant Request Decision Workflow",
    "description": "Determine if applicant request is valid",
+   "start": "CheckApplication",
    "functions": [
      {
         "name": "sendRejectionEmailFunction",
@@ -741,7 +742,6 @@ If the applicants age is over 18 we start the application (subflow state). Other
       {  
          "name":"CheckApplication",
          "type":"switch",
-         "start": true,
          "dataConditions": [
             {
               "condition": "${ .applicants | .age >= 18 }",
@@ -790,13 +790,13 @@ id: applicantrequest
 version: '1.0'
 name: Applicant Request Decision Workflow
 description: Determine if applicant request is valid
+start: CheckApplication
 functions:
 - name: sendRejectionEmailFunction
   operation: http://myapis.org/applicationapi.json#emailRejection
 states:
 - name: CheckApplication
   type: switch
-  start: true
   dataConditions:
   - condition: "${ .applicants | .age >= 18 }"
     transition: StartApplication
@@ -868,6 +868,7 @@ The data output of the workflow contains the information of the exception caught
 "version": "1.0",
 "name": "Provision Orders",
 "description": "Provision Orders and handle errors thrown",
+"start": "ProvisionOrder",
 "functions": [
   {
      "name": "provisionOrderFunction",
@@ -878,7 +879,6 @@ The data output of the workflow contains the information of the exception caught
   {  
     "name":"ProvisionOrder",
     "type":"operation",
-    "start": true,
     "actionMode":"sequential",
     "actions":[  
        {  
@@ -945,13 +945,13 @@ id: provisionorders
 version: '1.0'
 name: Provision Orders
 description: Provision Orders and handle errors thrown
+start: ProvisionOrder
 functions:
 - name: provisionOrderFunction
   operation: http://myapis.org/provisioningapi.json#doProvision
 states:
 - name: ProvisionOrder
   type: operation
-  start: true
   actionMode: sequential
   actions:
   - functionRef:
@@ -1026,6 +1026,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   "version": "1.0",
   "name": "Job Monitoring",
   "description": "Monitor finished execution of a submitted job",
+  "start": "SubmitJob",
   "functions": [
     {
       "name": "submitJob",
@@ -1048,7 +1049,6 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
     {  
       "name":"SubmitJob",
       "type":"operation",
-      "start": true,
       "actionMode":"sequential",
       "actions":[  
       {  
@@ -1123,7 +1123,6 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
     ],
     "default": {
       "transition": "WaitForCompletion"
-,
     }
   },
   {  
@@ -1170,6 +1169,7 @@ id: jobmonitoring
 version: '1.0'
 name: Job Monitoring
 description: Monitor finished execution of a submitted job
+start: SubmitJob
 functions:
 - name: submitJob
   operation: http://myapis.org/monitorapi.json#doSubmit
@@ -1182,7 +1182,6 @@ functions:
 states:
 - name: SubmitJob
   type: operation
-  start: true
   actionMode: sequential
   actions:
   - functionRef:
@@ -1334,6 +1333,7 @@ CloudEvent upon completion of the workflow could look like:
 "id": "sendcloudeventonprovision",
 "version": "1.0",
 "name": "Send CloudEvent on provision completion",
+"start": "ProvisionOrdersState",
 "events": [
 {
     "name": "provisioningCompleteEvent",
@@ -1351,7 +1351,6 @@ CloudEvent upon completion of the workflow could look like:
 {
     "name": "ProvisionOrdersState",
     "type": "foreach",
-    "start": true,
     "inputCollection": "${ .orders }",
     "iterationParam": "singleorder",
     "outputCollection": "${ .provisionedOrders }",
@@ -1383,6 +1382,7 @@ CloudEvent upon completion of the workflow could look like:
 id: sendcloudeventonprovision
 version: '1.0'
 name: Send CloudEvent on provision completion
+start: ProvisionOrdersState
 events:
 - name: provisioningCompleteEvent
   type: provisionCompleteType
@@ -1393,7 +1393,6 @@ functions:
 states:
 - name: ProvisionOrdersState
   type: foreach
-  start: true
   inputCollection: "${ .orders }"
   iterationParam: singleorder
   outputCollection: "${ .provisionedOrders }"
@@ -1465,6 +1464,7 @@ have the matching patient id.
 "id": "patientVitalsWorkflow",
 "name": "Monitor Patient Vitals",
 "version": "1.0",
+"start": "MonitorVitals",
 "events": [
 {
     "name": "HighBodyTemperature",
@@ -1515,7 +1515,6 @@ have the matching patient id.
 {
 "name": "MonitorVitals",
 "type": "event",
-"start": true,
 "exclusive": true,
 "onEvents": [{
         "eventRefs": ["HighBodyTemperature"],
@@ -1565,6 +1564,7 @@ have the matching patient id.
 id: patientVitalsWorkflow
 name: Monitor Patient Vitals
 version: '1.0'
+start: MonitorVitals
 events:
 - name: HighBodyTemperature
   type: org.monitor.highBodyTemp
@@ -1591,7 +1591,6 @@ functions:
 states:
 - name: MonitorVitals
   type: event
-  start: true
   exclusive: true
   onEvents:
   - eventRefs:
@@ -1658,6 +1657,7 @@ when all three of these events happened (in no particular order).
 "id": "finalizeCollegeApplication",
 "name": "Finalize College Application",
 "version": "1.0",
+"start": "FinalizeApplication",
 "events": [
 {
     "name": "ApplicationSubmitted",
@@ -1700,7 +1700,6 @@ when all three of these events happened (in no particular order).
 {
     "name": "FinalizeApplication",
     "type": "event",
-    "start": true,
     "exclusive": false,
     "onEvents": [
         {
@@ -1736,6 +1735,7 @@ when all three of these events happened (in no particular order).
 id: finalizeCollegeApplication
 name: Finalize College Application
 version: '1.0'
+start: FinalizeApplication
 events:
 - name: ApplicationSubmitted
   type: org.application.submitted
@@ -1758,7 +1758,6 @@ functions:
 states:
 - name: FinalizeApplication
   type: event
-  start: true
   exclusive: false
   onEvents:
   - eventRefs:
@@ -1869,6 +1868,7 @@ And for denied credit check, for example:
     "version": "1.0",
     "name": "Customer Credit Check Workflow",
     "description": "Perform Customer Credit Check",
+    "start": "CheckCredit",
     "functions": [
         {
             "name": "creditCheckFunction",
@@ -1895,7 +1895,6 @@ And for denied credit check, for example:
         {
             "name": "CheckCredit",
             "type": "callback",
-            "start": true,
             "action": {
                 "functionRef": {
                     "refName": "callCreditCheckMicroservice",
@@ -1959,6 +1958,7 @@ id: customercreditcheck
 version: '1.0'
 name: Customer Credit Check Workflow
 description: Perform Customer Credit Check
+start: CheckCredit
 functions:
 - name: creditCheckFunction
   operation: http://myapis.org/creditcheckapi.json#doCreditCheck
@@ -1973,7 +1973,6 @@ events:
 states:
 - name: CheckCredit
   type: callback
-  start: true
   action:
     functionRef:
       refName: callCreditCheckMicroservice
@@ -2064,6 +2063,10 @@ Bidding is done via an online application and bids are received as events are as
     "version": "1.0",
     "name": "Car Auction Bidding Workflow",
     "description": "Store a single bid whole the car auction is active",
+    "start": {
+      "stateName": "StoreCarAuctionBid",
+      "schedule": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
+    },
     "functions": [
         {
             "name": "StoreBidFunction",
@@ -2081,9 +2084,6 @@ Bidding is done via an online application and bids are received as events are as
         {
           "name": "StoreCarAuctionBid",
           "type": "event",
-          "start": {
-              "schedule": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
-          },
           "exclusive": true,
           "onEvents": [
             {
@@ -2112,6 +2112,9 @@ id: handleCarAuctionBid
 version: '1.0'
 name: Car Auction Bidding Workflow
 description: Store a single bid whole the car auction is active
+start:
+  stateName: StoreCarAuctionBid
+  schedule: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
 functions:
 - name: StoreBidFunction
   operation: http://myapis.org/carauctionapi.json#storeBid
@@ -2122,8 +2125,6 @@ events:
 states:
 - name: StoreCarAuctionBid
   type: event
-  start:
-    schedule: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
   exclusive: true
   onEvents:
   - eventRefs:
@@ -2188,6 +2189,12 @@ The results of the inbox service called is expected to be for example:
 "id": "checkInbox",
 "name": "Check Inbox Workflow",
 "description": "Periodically Check Inbox",
+"start": {
+    "stateName": "CheckInbox",
+    "schedule": {
+        "cron": "0 0/15 * * * ?"
+    }
+},
 "version": "1.0",
 "functions": [
     {
@@ -2203,11 +2210,6 @@ The results of the inbox service called is expected to be for example:
     {
         "name": "CheckInbox",
         "type": "operation",
-        "start": {
-            "schedule": {
-                "cron": "0 0/15 * * * ?"
-            }
-        },
         "actionMode": "sequential",
         "actions": [
             {
@@ -2244,6 +2246,10 @@ The results of the inbox service called is expected to be for example:
 id: checkInbox
 name: Check Inbox Workflow
 description: Periodically Check Inbox
+start:
+  stateName: CheckInbox
+  schedule:
+    cron: 0 0/15 * * * ?
 version: '1.0'
 functions:
 - name: checkInboxFunction
@@ -2253,9 +2259,6 @@ functions:
 states:
 - name: CheckInbox
   type: operation
-  start:
-    schedule:
-      cron: 0 0/15 * * * ?
   actionMode: sequential
   actions:
   - functionRef: checkInboxFunction
@@ -2328,6 +2331,7 @@ For this example we assume that the workflow instance is started given the follo
     "name": "Vet Appointment Workflow",
     "description": "Vet service call via events",
     "version": "1.0",
+    "start": "MakeVetAppointmentState",
     "events": [
         {
             "name": "MakeVetAppointment",
@@ -2344,7 +2348,6 @@ For this example we assume that the workflow instance is started given the follo
         {
             "name": "MakeVetAppointmentState",
             "type": "operation",
-            "start": true,
             "actions": [
                 {
                     "name": "MakeAppointmentAction",
@@ -2373,6 +2376,7 @@ id: VetAppointmentWorkflow
 name: Vet Appointment Workflow
 description: Vet service call via events
 version: '1.0'
+start: MakeVetAppointmentState
 events:
 - name: MakeVetAppointment
   source: VetServiceSoure
@@ -2383,7 +2387,6 @@ events:
 states:
 - name: MakeVetAppointmentState
   type: operation
-  start: true
   actions:
   - name: MakeAppointmentAction
     eventRef:
@@ -2670,11 +2673,11 @@ If the retries are not successful, we want to just gracefully end workflow execu
   "id": "patientonboarding",
   "name": "Patient Onboarding Workflow",
   "version": "1.0",
+  "start": "Onboard",
   "states": [
     {
       "name": "Onboard",
       "type": "event",
-      "start": true,
       "onEvents": [
         {
           "eventRefs": [
@@ -2742,10 +2745,10 @@ If the retries are not successful, we want to just gracefully end workflow execu
 id: patientonboarding
 name: Patient Onboarding Workflow
 version: '1.0'
+start: Onboard
 states:
 - name: Onboard
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - NewPatientEvent
@@ -2821,6 +2824,7 @@ This example shows the use of the workflow [execTimeout definition](../specifica
   "id": "order",
   "name": "Purchase Order Workflow",
   "version": "1.0",
+  "start": "StartNewOrder",
   "execTimeout": {
     "interval": "PT30D",
     "interrupt": true,
@@ -2830,7 +2834,6 @@ This example shows the use of the workflow [execTimeout definition](../specifica
     {
       "name": "StartNewOrder",
       "type": "event",
-      "start": true,
       "onEvents": [
         {
           "eventRefs": ["OrderCreatedEvent"],
@@ -2980,6 +2983,7 @@ This example shows the use of the workflow [execTimeout definition](../specifica
 id: order
 name: Purchase Order Workflow
 version: '1.0'
+start: StartNewOrder
 execTimeout:
   interval: PT30D
   interrupt: true
@@ -2987,7 +2991,6 @@ execTimeout:
 states:
 - name: StartNewOrder
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - OrderCreatedEvent
@@ -3101,6 +3104,7 @@ the data for an hour, send report, and so on.
   "id": "roomreadings",
   "name": "Room Temp and Humidity Workflow",
   "version": "1.0",
+  "start": "ConsumeReading",
   "execTimeout": {
     "interval": "PT1H",
     "runBefore": "GenerateReport"
@@ -3110,7 +3114,6 @@ the data for an hour, send report, and so on.
     {
       "name": "ConsumeReading",
       "type": "event",
-      "start": true,
       "onEvents": [
         {
           "eventRefs": ["TemperatureEvent", "HumidityEvent"],
@@ -3188,6 +3191,7 @@ the data for an hour, send report, and so on.
 id: roomreadings
 name: Room Temp and Humidity Workflow
 version: '1.0'
+start: ConsumeReading
 execTimeout:
   interval: PT1H
   runBefore: GenerateReport
@@ -3195,7 +3199,6 @@ keepActive: true
 states:
 - name: ConsumeReading
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - TemperatureEvent
@@ -3271,11 +3274,11 @@ We fist define our top-level workflow for this example:
     "id": "checkcarvitals",
     "name": "Check Car Vitals Workflow",
     "version": "1.0",
+    "start": "WhenCarIsOn",
     "states": [
        {
           "name": "WhenCarIsOn",
           "type": "event",
-          "start": true,
           "onEvents": [
              {
                 "eventRefs": ["CarTurnedOnEvent"]
@@ -3315,10 +3318,10 @@ We fist define our top-level workflow for this example:
 id: checkcarvitals
 name: Check Car Vitals Workflow
 version: '1.0'
+start: WhenCarIsOn
 states:
 - name: WhenCarIsOn
   type: event
-  start: true
   onEvents:
   - eventRefs:
     - CarTurnedOnEvent
@@ -3358,11 +3361,11 @@ And then our reusable sub-workflow which performs the checking of our car vitals
    "id": "vitalscheck",
    "name": "Car Vitals Check",
    "version": "1.0",
+   "start": "CheckVitals",
    "states": [
       {
          "name": "CheckVitals",
          "type": "operation",
-         "start": true,
          "actions": [
             {
                "functionRef": "checkTirePressure"
@@ -3443,10 +3446,10 @@ And then our reusable sub-workflow which performs the checking of our car vitals
 id: vitalscheck
 name: Car Vitals Check
 version: '1.0'
+start: CheckVitals
 states:
 - name: CheckVitals
   type: operation
-  start: true
   actions:
   - functionRef: checkTirePressure
   - functionRef: checkOilPressure

--- a/extensions/kpi.md
+++ b/extensions/kpi.md
@@ -125,6 +125,7 @@ an associated sample KPIs extension definition on the right.
 id: patientVitalsWorkflow
 name: Monitor Patient Vitals
 version: '1.0'
+start: MonitorVitals
 events:
 - name: HighBodyTemperature
   type: org.monitor.highBodyTemp
@@ -151,7 +152,6 @@ functions:
 states:
 - name: MonitorVitals
   type: event
-  start: true
   exclusive: true
   onEvents:
   - eventRefs:

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -36,6 +36,7 @@ _Status description:_
 | ✔️| Adding RPC type to function definitions (gRPC) | [spec doc](../specification.md) |
 | ✔️| Change function definition 'parameters' to 'arguments' | [spec doc](../specification.md) |
 | ✔️| Replace JsonPath with jq | [spec doc](../specification.md) |
+| ✔️| Update start definition (move to top-level worklow param) | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -23,6 +23,9 @@
       "description": "Workflow version",
       "minLength": 1
     },
+    "start": {
+      "$ref": "#/definitions/startdef"
+    },
     "schemaVersion": {
       "type": "string",
       "description": "Serverless Workflow schema version",
@@ -104,6 +107,7 @@
     "id",
     "name",
     "version",
+    "start",
     "states"
   ],
   "definitions": {
@@ -111,7 +115,7 @@
       "oneOf": [
         {
           "type": "string",
-          "description": "Repeating interval (cron expression) describing when the workflow instance should be created",
+          "description": "Cron expression defining when workflow instances should be created (automatically)",
           "minLength": 1
         },
         {
@@ -413,10 +417,6 @@
           "const": "delay",
           "description": "State type"
         },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
-        },
         "end": {
           "$ref": "#/definitions/end",
           "description": "State end definition"
@@ -485,24 +485,6 @@
               "timeDelay",
               "transition"
             ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "timeDelay",
-              "transition"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "timeDelay",
-              "end"
-            ]
           }
         ]
       }
@@ -557,10 +539,6 @@
           "description": "Next transition of the workflow after all the actions have been performed",
           "$ref": "#/definitions/transition"
         },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
-        },
         "end": {
           "$ref": "#/definitions/end",
           "description": "State end definition"
@@ -593,16 +571,6 @@
         },
         {
           "required": [
-            "start",
-            "name",
-            "type",
-            "onEvents",
-            "transition"
-          ]
-        },
-        {
-          "required": [
-            "start",
             "name",
             "type",
             "onEvents",
@@ -628,10 +596,6 @@
           "type": "string",
           "const": "operation",
           "description": "State type"
-        },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
         },
         "end": {
           "$ref": "#/definitions/end",
@@ -717,16 +681,6 @@
           },
           {
             "required": [
-              "start",
-              "name",
-              "type",
-              "actions",
-              "transition"
-            ]
-          },
-          {
-            "required": [
-              "start",
               "name",
               "type",
               "actions",
@@ -753,10 +707,6 @@
           "type": "string",
           "const": "parallel",
           "description": "State type"
-        },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
         },
         "end": {
           "$ref": "#/definitions/end",
@@ -852,20 +802,9 @@
           },
           {
             "required": [
-              "start",
               "name",
               "type",
               "branches",
-              "transition"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "branches",
-              "transition",
               "end"
             ]
           }
@@ -899,9 +838,6 @@
           "type": "string",
           "const": "switch",
           "description": "State type"
-        },
-        "start": {
-          "$ref": "#/definitions/start"
         },
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
@@ -944,42 +880,12 @@
           "$ref": "common.json#/definitions/metadata"
         }
       },
-      "if": {
-        "properties": {
-          "usedForCompensation": {
-            "const": true
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "name",
-          "type",
-          "eventConditions",
-          "default"
-        ]
-      },
-      "else": {
-        "oneOf": [
-          {
-            "required": [
-              "name",
-              "type",
-              "eventConditions",
-              "default"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "eventConditions",
-              "default"
-            ]
-          }
-        ]
-      }
+      "required": [
+        "name",
+        "type",
+        "eventConditions",
+        "default"
+      ]
     },
     "databasedswitch": {
       "type": "object",
@@ -998,10 +904,6 @@
           "type": "string",
           "const": "switch",
           "description": "State type"
-        },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
         },
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
@@ -1031,28 +933,20 @@
           "minLength": 1,
           "description": "Unique Name of a workflow state which is responsible for compensation of this state"
         },
+        "usedForCompensation": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, this state is used to compensate another state. Default is false"
+        },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"
         }
       },
-      "oneOf": [
-        {
-          "required": [
-            "name",
-            "type",
-            "dataConditions",
-            "default"
-          ]
-        },
-        {
-          "required": [
-            "start",
-            "name",
-            "type",
-            "dataConditions",
-            "default"
-          ]
-        }
+      "required": [
+        "name",
+        "type",
+        "dataConditions",
+        "default"
       ]
     },
     "defaultdef": {
@@ -1225,10 +1119,6 @@
           "const": "subflow",
           "description": "State type"
         },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
-        },
         "end": {
           "$ref": "#/definitions/end",
           "description": "State end definition"
@@ -1306,24 +1196,6 @@
               "workflowId",
               "transition"
             ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "workflowId",
-              "transition"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "workflowId",
-              "end"
-            ]
           }
         ]
       }
@@ -1345,10 +1217,6 @@
           "type": "string",
           "const": "inject",
           "description": "State type"
-        },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
         },
         "end": {
           "$ref": "#/definitions/end",
@@ -1410,24 +1278,6 @@
               "data",
               "transition"
             ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "data",
-              "transition"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "data",
-              "end"
-            ]
           }
         ]
       }
@@ -1449,10 +1299,6 @@
           "type": "string",
           "const": "foreach",
           "description": "State type"
-        },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
         },
         "end": {
           "$ref": "#/definitions/end",
@@ -1560,28 +1406,6 @@
           },
           {
             "required": [
-              "start",
-              "name",
-              "type",
-              "inputCollection",
-              "inputParameter",
-              "workflowId",
-              "end"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "inputCollection",
-              "inputParameter",
-              "workflowId",
-              "transition"
-            ]
-          },
-          {
-            "required": [
               "name",
               "type",
               "inputCollection",
@@ -1592,28 +1416,6 @@
           },
           {
             "required": [
-              "name",
-              "type",
-              "inputCollection",
-              "inputParameter",
-              "actions",
-              "transition"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "inputCollection",
-              "inputParameter",
-              "actions",
-              "end"
-            ]
-          },
-          {
-            "required": [
-              "start",
               "name",
               "type",
               "inputCollection",
@@ -1675,10 +1477,6 @@
           "description": "Next transition of the workflow after all the actions have been performed",
           "$ref": "#/definitions/transition"
         },
-        "start": {
-          "$ref": "#/definitions/start",
-          "description": "State start definition"
-        },
         "end": {
           "$ref": "#/definitions/end",
           "description": "State end definition"
@@ -1734,49 +1532,33 @@
               "timeout",
               "transition"
             ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "action",
-              "eventRef",
-              "timeout",
-              "end"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "action",
-              "eventRef",
-              "timeout",
-              "transition"
-            ]
           }
         ]
       }
     },
-    "start": {
+    "startdef": {
       "oneOf": [
         {
-          "type": "boolean",
-          "description": "State start definition",
-          "default": true
+          "type": "string",
+          "description": "Name of the starting workflow state",
+          "minLength": 1
         },
         {
           "type": "object",
-          "description": "State start definition",
+          "description": "Workflow start definition",
           "properties": {
+            "stateName": {
+              "type": "string",
+              "description": "Name of the starting workflow state",
+              "minLength": 1
+            },
             "schedule": {
-              "description": "Define the time/repeating intervals at which workflow instances can/should be started",
+              "description": "Define the time/repeating intervals or cron at which workflow instances can/should be started",
               "$ref": "#/definitions/schedule"
             }
           },
           "required": [
+            "stateName",
             "schedule"
           ]
         }
@@ -1786,7 +1568,7 @@
       "oneOf": [
         {
           "type": "string",
-          "description": "Time interval (ISO 8601 format) describing when workflow instances can be created.",
+          "description": "Time interval (can be repeating) described with ISO 8601 format. Declares when workflow instances can be created.",
           "minLength": 1
         },
         {


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [x ] Schema
- [x ] Examples
- [x ] Extensions
- [x ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Moves the "start" definition to top level workflow props

With this change you no longer define "start" on the state level. You have to define it as a top level workflow prop.
You can either do for example:

```json
    "start": "WaitForCustomerToArrive",
```
where its a string type and is the name of the starting workflow state

or
```json
    "start": {
    "stateName": "CheckInbox",
    "schedule": {
        "cron": "0 0/15 * * * ?"
    }
}
```
where its an object type and used when you need to define a schedule. in this case you have to define the "stateName" property to denote the workflow starting state name

**Special notes for reviewers**:

**Additional information (if needed):**