### PR TITLE
Update parallel state branches and foreach states 'workflowid' parameter

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -503,30 +503,40 @@ to finish execution before it can transition (end workflow execution in this cas
 
 ```json
 {  
-"id": "parallelexec",
-"version": "1.0",
-"name": "Parallel Execution Workflow",
-"description": "Executes two branches in parallel",
-"states":[  
-  {  
-     "name": "ParallelExec",
-     "type": "parallel",
-     "start": true,
-     "completionType": "and",
-     "branches": [
-        {
-          "name": "ShortDelayBranch",
-          "workflowId": "shortdelayworkflowid"
-        },
-        {
-          "name": "LongDelayBranch",
-          "workflowId": "longdelayworkflowid"
-        }
-     ],
-     "end": true
-  }
-]
-}
+    "id": "parallelexec",
+    "version": "1.0",
+    "name": "Parallel Execution Workflow",
+    "description": "Executes two branches in parallel",
+    "states":[  
+      {  
+         "name": "ParallelExec",
+         "type": "parallel",
+         "start": true,
+         "completionType": "and",
+         "branches": [
+            {
+              "name": "ShortDelayBranch",
+              "subflow": "ShortDelaySubFlow"
+            },
+            {
+              "name": "LongDelayBranch",
+              "subflow": "LongDelaySubFlow"
+            }
+         ],
+         "end": true
+      },
+      {
+        "name": "ShortDelaySubFlow",
+        "type": "subflow",
+        "workflowId": "shortdelayworkflowid"
+      },
+      {
+        "name": "LongDelaySubFlow",
+        "type": "subflow",
+        "workflowId": "longdelayworkflowid"
+      }
+    ]
+    }
 ```
 
 </td>
@@ -544,10 +554,16 @@ states:
   completionType: and
   branches:
   - name: ShortDelayBranch
-    workflowId: shortdelayworkflowid
+    subflow: ShortDelaySubFlow
   - name: LongDelayBranch
-    workflowId: longdelayworkflowid
+    subflow: LongDelaySubFlow
   end: true
+- name: ShortDelaySubFlow
+  type: subflow
+  workflowId: shortdelayworkflowid
+- name: LongDelaySubFlow
+  type: subflow
+  workflowId: longdelayworkflowid
 ```
 
 </td>

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -36,6 +36,7 @@ _Status description:_
 | ✔️| Adding RPC type to function definitions (gRPC) | [spec doc](../specification.md) |
 | ✔️| Change function definition 'parameters' to 'arguments' | [spec doc](../specification.md) |
 | ✔️| Replace JsonPath with jq | [spec doc](../specification.md) |
+| ✔️| Replace Parallel state branches and ForEach states "workflowid" parameter with "subflow" | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -375,16 +375,16 @@
             "$ref": "#/definitions/action"
           }
         },
-        "workflowId": {
+        "subflow": {
           "type": "string",
-          "description": "Unique Id of a workflow to be executed in this branch"
+          "description": "Name of the SubFlow state to be executed in this branch"
         }
       },
       "oneOf": [
         {
           "required": [
             "name",
-            "workflowId"
+            "subflow"
           ]
         },
         {
@@ -1275,58 +1275,11 @@
           "$ref": "common.json#/definitions/metadata"
         }
       },
-      "if": {
-        "properties": {
-          "usedForCompensation": {
-            "const": true
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "name",
-          "type",
-          "workflowId"
-        ]
-      },
-      "else": {
-        "oneOf": [
-          {
-            "required": [
-              "name",
-              "type",
-              "workflowId",
-              "end"
-            ]
-          },
-          {
-            "required": [
-              "name",
-              "type",
-              "workflowId",
-              "transition"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "workflowId",
-              "transition"
-            ]
-          },
-          {
-            "required": [
-              "start",
-              "name",
-              "type",
-              "workflowId",
-              "end"
-            ]
-          }
-        ]
-      }
+      "required": [
+        "name",
+        "type",
+        "workflowId"
+      ]
     },
     "injectstate": {
       "type": "object",
@@ -1487,9 +1440,9 @@
             "$ref": "#/definitions/action"
           }
         },
-        "workflowId": {
+        "subflow": {
           "type": "string",
-          "description": "Unique Id of a workflow to be executed for each of the elements of inputCollection"
+          "description": "Name of a SubFlow state to be executed for each of the elements of inputCollection"
         },
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
@@ -1528,12 +1481,25 @@
         }
       },
       "then": {
-        "required": [
-          "name",
-          "type",
-          "inputCollection",
-          "inputParameter",
-          "workflowId"
+        "oneOf": [
+          {
+            "required": [
+              "name",
+              "type",
+              "inputCollection",
+              "iterationParam",
+              "actions"
+            ]
+          },
+          {
+            "required": [
+              "name",
+              "type",
+              "inputCollection",
+              "iterationParam",
+              "subflow"
+            ]
+          }
         ]
       },
       "else": {
@@ -1543,8 +1509,8 @@
               "name",
               "type",
               "inputCollection",
-              "inputParameter",
-              "workflowId",
+              "iterationParam",
+              "subflow",
               "end"
             ]
           },
@@ -1553,8 +1519,8 @@
               "name",
               "type",
               "inputCollection",
-              "inputParameter",
-              "workflowId",
+              "iterationParam",
+              "subflow",
               "transition"
             ]
           },
@@ -1565,7 +1531,7 @@
               "type",
               "inputCollection",
               "inputParameter",
-              "workflowId",
+              "iterationParam",
               "end"
             ]
           },
@@ -1575,8 +1541,8 @@
               "name",
               "type",
               "inputCollection",
-              "inputParameter",
-              "workflowId",
+              "iterationParam",
+              "subflow",
               "transition"
             ]
           },
@@ -1585,7 +1551,7 @@
               "name",
               "type",
               "inputCollection",
-              "inputParameter",
+              "iterationParam",
               "actions",
               "end"
             ]
@@ -1595,7 +1561,7 @@
               "name",
               "type",
               "inputCollection",
-              "inputParameter",
+              "iterationParam",
               "actions",
               "transition"
             ]
@@ -1606,7 +1572,7 @@
               "name",
               "type",
               "inputCollection",
-              "inputParameter",
+              "iterationParam",
               "actions",
               "end"
             ]
@@ -1617,7 +1583,7 @@
               "name",
               "type",
               "inputCollection",
-              "inputParameter",
+              "iterationParam",
               "actions",
               "transition"
             ]

--- a/specification.md
+++ b/specification.md
@@ -2307,8 +2307,8 @@ Exceptions may occur during execution of branches of the Parallel state, this is
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name | Branch name | string | yes |
-| [actions](#Action-Definition) | Actions to be executed in this branch | array | yes if workflowId is not defined |
-| workflowId | Unique Id of a workflow to be executed in this branch | string | yes if actions is not defined |
+| [actions](#Action-Definition) | Actions to be executed in this branch | array | yes if subflow is not defined |
+| subflow | Name of the SubFlow state to be executed in this branch | string | yes if `actions` is not defined |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -2369,8 +2369,11 @@ actions:
 
 Each branch receives the same copy of the Parallel state's data input.
 
-A branch can define either actions or a workflow id of the workflow that needs to be executed.
-The workflow id defined cannot be the same id of the workflow there the branch is defined.
+A Parallel state branch can either define `actions` to be executed, or define a `subflow` property which
+is the name of a workflow SubFlow state to be executed. 
+Note that the referenced SubFlow state
+ should not be part of the core workflow control flow logic (should not have any incoming or outgoing transitions,
+ and should not be able to end workflow execution).
 
 #### <a name="parallel-state-exceptions"></a>Parallel State: Handling Exceptions
 
@@ -2383,9 +2386,9 @@ If the parallel states branch defines actions, all exceptions that arise from ex
  are propagated to the parallel state 
 and can be handled with the parallel states `onErrors` definition.
 
-If the parallel states defines a `workflowId`, exceptions that occur during execution of the called workflow
-can chose to handle exceptions on their own. All unhandled exceptions from the called workflow
-execution however are propagated back to the parallel state and can be handled with the parallel states
+If the parallel state branch defines a `subflow`, exceptions that occur during execution of the subflow
+can be handlerd by the defined SubFlow state. All unhandled exceptions however should be 
+propagated back to the parallel state and can be handled with the parallel states
 `onErrors` definition.
 
 Note that once an error that is propagated to the parallel state from a branch and handled by the 
@@ -2402,7 +2405,7 @@ For more information, see the [Workflow Error Handling](#Workflow-Error-Handling
 | name |State name | string | yes |
 | type |State type | string | yes |
 | waitForCompletion | If workflow execution must wait for sub-workflow to finish before continuing | boolean | yes |
-| workflowId |Sub-workflow unique id | boolean | no |
+| workflowId | Sub-workflow unique id | boolean | no |
 | [repeat](#Repeat-Definition) | SubFlow state repeat exec definition | object | no |
 | [stateDataFilter](#state-data-filter) | State data filter | object | no |
 | [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
@@ -2456,7 +2459,8 @@ multiple other workflow definitions.
 <img src="media/spec/subflowstateref.png" height="350px" alt="Referencing reusable workflow via SubFlow states"/>
 </p>
 
-Reusable workflow are referenced by their `id` property via the SubFlow states`workflowId` parameter.
+Reusable workflows should be referenced by SubFlow states`workflowId` parameter. The value of the parameter
+should match the `id` parameter of the reusable workflow.
 
 Each referenced workflow receives the SubFlow states data as workflow data input.
 
@@ -2721,7 +2725,7 @@ This allows you to test if your workflow behaves properly for cases when there a
 | iterationParam | Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array | string | yes |
 | max | Specifies how upper bound on how many iterations may run in parallel | string or number | no |
 | [actions](#Action-Definition) | Actions to be executed for each of the elements of inputCollection | array | yes if subflowId is not defined |
-| workflowId | Unique Id of a workflow to be executed for each of the elements of inputCollection | string | yes if actions is not defined |
+| subflow | Name of a SubFlow state to be executed for each of the elements of inputCollection | string | yes if actions is not defined |
 | [stateDataFilter](#state-data-filter) | State data filter definition | object | no |
 | [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
 | [transition](#Transitions) | Next transition of the workflow after state has completed | object | yes (if end is not defined) |
@@ -2807,9 +2811,10 @@ It should contain the unique element of the `inputCollection` array and passed a
 
 The `actions` property defines actions to be executed in each state iteration.
 
-If actions are not defined, you can specify the `workflowid` to reference a workflow id which needs to be executed
-for each iteration. Note that `workflowid` should not be the same as the workflow id of the workflow where the foreach state
-is defined.
+If actions are not defined, you can specify the `subflow` parameter. It's value should be a name of 
+ a SubFlow state which should be invoked for each iteration. Note that the referenced SubFlow state
+ should not be part of the core workflow control flow logic (should not have any incoming or outgoing transitions,
+ and should not be able to end workflow execution).
 
 Let's take a look at an example:
 


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ x] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
While working on a new example I noticed that in parallel state branches and foreach state
the "workflowid" parameter is very weak. It currently references the id of a reusable workflow. 
The problem with this however is that it cannot define things like compensation and the subflow states "repeat" ability.

1) changed the "workflowid" parameter to "subflow"
2) the "subflow" parameter now points to a SubFlow state (via its name), so that all of the SubFlow additional properties can also be used 
in branches and foreach state now
3) added clause that the referenced SubFlow state cannot be part of the main control flow logic (cannot have incoming/outgoing transitions nor can it end workflow execution)
4) updated/fixed required parameters in workflow schema for branches subflow state and foreach state

**Special notes for reviewers**:

**Additional information (if needed):**