### PR TITLE
Move support for sub-flows to actions

### DIFF
--- a/comparisons/comparison-bpmn.md
+++ b/comparisons/comparison-bpmn.md
@@ -317,7 +317,8 @@ states:
   inputCollection: "${ .inputsArray }"
   iterationParam: "${ .inputItem }"
   outputCollection: "${ .outputsArray }"
-  workflowId: doSomethingAndWaitForMessage
+  actions:
+  - subFlowRef: doSomethingAndWaitForMessage
   end: true
 ```
 
@@ -349,11 +350,12 @@ name: SubFlow Loop Workflow
 version: '1.0'
 start: SubflowLoop
 states:
-- name: SubflowLoop
-  type: subflow
-  workflowId: checkAndReplyToEmail
-  repeat:
-    max: 100
+- name: SubflowRepeat
+  type: foreach
+  inputCollection: ${ [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ..., 100 ] }
+  max: 1
+  actions:
+  - subFlow: checkAndReplyToEmail
   end: true
 ```
 
@@ -448,8 +450,9 @@ version: '1.0'
 start: A
 states:
 - name: A
-  type: subflow
-  workflowId: asubflowid
+  type: operation
+  actions:
+    - subFlow: asubflowid
   transition: Event Decision
 - name: Event Decision
   type: switch

--- a/comparisons/comparison-bpmn.md
+++ b/comparisons/comparison-bpmn.md
@@ -348,15 +348,28 @@ a starting "operation" state transitioning to an "event" state which waits for t
 id: subflowloop
 name: SubFlow Loop Workflow
 version: '1.0'
-start: SubflowLoop
+start: StartCount
 states:
+- name: StartCount
+  type: inject
+  data:
+    counter: 0
+  transition: SubflowRepeat
 - name: SubflowRepeat
-  type: foreach
-  inputCollection: ${ [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ..., 100 ] }
-  max: 1
+  type: operation
   actions:
   - subFlow: checkAndReplyToEmail
-  end: true
+  actionDataFilter:
+    fromStateData: ${ .someInput }
+    toStateData: ${ .someInput }
+  transition: CheckCount
+- name: CheckCount
+  type: Switch
+  dataConditions:
+  - condition: ${ .counter < 100 }
+    transition: SubflowRepeat
+  default:
+    end: true
 ```
 
 </td>

--- a/comparisons/comparison-bpmn.md
+++ b/comparisons/comparison-bpmn.md
@@ -348,27 +348,22 @@ a starting "operation" state transitioning to an "event" state which waits for t
 id: subflowloop
 name: SubFlow Loop Workflow
 version: '1.0'
-start: StartCount
+start: SubflowRepeat
 states:
-- name: StartCount
-  type: inject
-  data:
-    counter: 0
-  transition: SubflowRepeat
 - name: SubflowRepeat
   type: operation
   actions:
-  - subFlow: checkAndReplyToEmail
+  - subFlowRef: checkAndReplyToEmail
   actionDataFilter:
     fromStateData: ${ .someInput }
     toStateData: ${ .someInput }
+  stateDataFilter:
+    output: ${ .maxChecks -= 1 }
   transition: CheckCount
 - name: CheckCount
   type: Switch
-  stateDataFilter:
-    input: ${ .counter += 1 }
   dataConditions:
-  - condition: ${ .counter < 100 }
+  - condition: ${ .maxChecks > 0 }
     transition: SubflowRepeat
   default:
     end: true
@@ -377,6 +372,8 @@ states:
 </td>
 </tr>
 </table>
+
+This workflow assumes that the input to the workflow includes a maxChecks attribute set to an integer value.
 
 * Note: We did not include the `checkAndReplyToEmail` workflow in this example, which would include the 
 control-flow logic to check email and make a decision to reply to it or wait an hour.
@@ -467,7 +464,7 @@ states:
 - name: A
   type: operation
   actions:
-    - subFlow: asubflowid
+    - subFlowRef: asubflowid
   transition: Event Decision
 - name: Event Decision
   type: switch

--- a/comparisons/comparison-bpmn.md
+++ b/comparisons/comparison-bpmn.md
@@ -365,6 +365,8 @@ states:
   transition: CheckCount
 - name: CheckCount
   type: Switch
+  stateDataFilter:
+    input: ${ .counter += 1 }
   dataConditions:
   - condition: ${ .counter < 100 }
     transition: SubflowRepeat

--- a/comparisons/comparison-google-cloud-workflows.md
+++ b/comparisons/comparison-google-cloud-workflows.md
@@ -685,7 +685,7 @@ error handlers in the "retry" statement as an expression/variable.
             "type":"operation",
             "actions": [
               {
-                "subFlow": "calledsubflow"
+                "subFlowRef": "calledsubflow"
               }
             ],
             "end": true
@@ -700,7 +700,7 @@ error handlers in the "retry" statement as an expression/variable.
 
 #### Notes
 
-Serverless Workflow has a specific [SubFlow action](../specification.md#SubFlowRef-Definition). By default the current workflow data
+Serverless Workflow has a specific [SubFlow action](../specification.md#SubFlow-Action). By default the current workflow data
 is passed to it, so there is no need to define specific arguments.
 We have omitted the definition of "calledsubflow" as it is pretty straight forward. It would be 
 a separate workflow definition with the "id" parameter set to "calledsubflow" in this example.

--- a/comparisons/comparison-google-cloud-workflows.md
+++ b/comparisons/comparison-google-cloud-workflows.md
@@ -682,8 +682,12 @@ error handlers in the "retry" statement as an expression/variable.
     "states": [
         {
             "name": "CallSub",
-            "type":"subflow",
-            "workflowId": "calledsubflow",
+            "type":"operation",
+            "actions": [
+              {
+                "subFlow": "calledsubflow"
+              }
+            ],
             "end": true
         }
     ]
@@ -696,7 +700,7 @@ error handlers in the "retry" statement as an expression/variable.
 
 #### Notes
 
-Serverless Workflow has a specific [SubFlow state](../specification.md#SubFlow-State). When called the current workflow data
+Serverless Workflow has a specific [SubFlow action](../specification.md#SubFlowRef-Definition). By default the current workflow data
 is passed to it, so there is no need to define specific arguments.
 We have omitted the definition of "calledsubflow" as it is pretty straight forward. It would be 
 a separate workflow definition with the "id" parameter set to "calledsubflow" in this example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ Provides Serverless Workflow language examples
 - [Solving Math Problems (ForEach state)](#Solving-Math-Problems-Example)
 - [Parallel Execution](#Parallel-Execution-Example)
 - [Event Based Transitions (Event-based Switch)](#Event-Based-Transitions-Example)
-- [Applicant Request Decision (Data-based Switch + SubFlow states)](#Applicant-Request-Decision-Example)
+- [Applicant Request Decision (Data-based Switch + SubFlows)](#Applicant-Request-Decision-Example)
 - [Provision Orders (Error Handling)](#Provision-Orders-Example)
 - [Monitor Job for completion (Polling)](#Monitor-Job-Example)
 - [Send CloudEvent on Workflow Completion](#Send-CloudEvent-On-Workfow-Completion-Example)
@@ -24,7 +24,7 @@ Provides Serverless Workflow language examples
 - [New Patient Onboarding (Error checking and Retries)](#New-Patient-Onboarding)
 - [Purchase order deadline (ExecTimeout)](#Purchase-order-deadline)
 - [Accumulate room readings and create timely reports (ExecTimeout and KeepActive)](#Accumulate-room-readings)
-- [Car vitals checks (SubFlow state Repeat)](#Car-Vitals-Checks)
+- [Car vitals checks (SubFlow Repeat)](#Car-Vitals-Checks)
 - [Book Lending Workflow](#Book-Lending)
 - [Filling a glass of water (Expression functions)](#Filling-a-glass-of-water)
 - [Online Food Ordering](#Online-Food-Ordering)
@@ -626,20 +626,32 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
   },
   {
     "name": "HandleApprovedVisa",
-    "type": "subflow",
-    "workflowId": "handleApprovedVisaWorkflowID",
+    "type": "operation",
+    "actions": [
+      {
+        "subFlow": "handleApprovedVisaWorkflowID" 
+      }
+    ],
     "end": true
   },
   {
       "name": "HandleRejectedVisa",
-      "type": "subflow",
-      "workflowId": "handleRejectedVisaWorkflowID",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlow": "handleRejectedVisaWorkflowID" 
+        }
+      ],
       "end": true
   },
   {
       "name": "HandleNoVisaDecision",
-      "type": "subflow",
-      "workflowId": "handleNoVisaDecisionWorkfowId",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlow": "handleNoVisaDecisionWorkfowId" 
+        }
+      ],
       "end": true
   }
 ]
@@ -674,16 +686,19 @@ states:
   default:
     transition: HandleNoVisaDecision
 - name: HandleApprovedVisa
-  type: subflow
-  workflowId: handleApprovedVisaWorkflowID
+  type: operation
+  actions:
+    - subFlow: handleApprovedVisaWorkflowID
   end: true
 - name: HandleRejectedVisa
-  type: subflow
-  workflowId: handleRejectedVisaWorkflowID
+  type: operation
+    actions:
+      - subFlow: handleRejectedVisaWorkflowID
   end: true
 - name: HandleNoVisaDecision
-  type: subflow
-  workflowId: handleNoVisaDecisionWorkfowId
+  type: operation
+    actions:
+      - subFlow: handleNoVisaDecisionWorkfowId
   end: true
 ```
 
@@ -695,7 +710,7 @@ states:
 
 #### Description
 
-This example shows off the switch state and the subflow state. The workflow is started with application information data as input:
+This example shows off the switch state and the subflow action. The workflow is started with application information data as input:
 
 ```json
     {
@@ -709,7 +724,7 @@ This example shows off the switch state and the subflow state. The workflow is s
 ```
 
 We use the switch state with two conditions to determine if the application should be made based on the applicants age.
-If the applicants age is over 18 we start the application (subflow state). Otherwise the workflow notifies the
+If the applicants age is over 18 we start the application (subflow action). Otherwise the workflow notifies the
  applicant of the rejection.
 
 #### Workflow Diagram
@@ -761,8 +776,12 @@ If the applicants age is over 18 we start the application (subflow state). Other
       },
       {
         "name": "StartApplication",
-        "type": "subflow",
-        "workflowId": "startApplicationWorkflowId",
+        "type": "operation",
+        "actions": [
+          {
+            "subFlow": "startApplicationWorkflowId" 
+          }
+        ],
         "end": true
       },
       {  
@@ -808,8 +827,9 @@ states:
   default:
     transition: RejectApplication
 - name: StartApplication
-  type: subflow
-  workflowId: startApplicationWorkflowId
+  type: operation
+  actions: 
+    - subFlow: startApplicationWorkflowId
   end: true
 - name: RejectApplication
   type: operation
@@ -914,26 +934,42 @@ The data output of the workflow contains the information of the exception caught
 },
 {
    "name": "MissingId",
-   "type": "subflow",
-   "workflowId": "handleMissingIdExceptionWorkflow",
+   "type": "operation",
+   "actions": [
+     {
+       "subFlow": "handleMissingIdExceptionWorkflow"
+     }
+   ],
    "end": true
 },
 {
    "name": "MissingItem",
-   "type": "subflow",
-   "workflowId": "handleMissingItemExceptionWorkflow",
+   "type": "operation",
+   "actions": [
+     {
+       "subFlow": "handleMissingItemExceptionWorkflow"
+     }
+   ],
    "end": true
 },
 {
    "name": "MissingQuantity",
-   "type": "subflow",
-   "workflowId": "handleMissingQuantityExceptionWorkflow",
+   "type": "operation",
+   "actions": [
+     {
+       "subFlow": "handleMissingQuantityExceptionWorkflow"
+     }
+   ],
    "end": true
 },
 {
    "name": "ApplyOrder",
-   "type": "subflow",
-   "workflowId": "applyOrderWorkflowId",
+   "type": "operation",
+   "actions": [
+     {
+       "subFlow": "applyOrderWorkflowId"
+     }
+   ],
    "end": true
 }
 ]
@@ -972,20 +1008,24 @@ states:
   - error: Missing order quantity
     transition: MissingQuantity
 - name: MissingId
-  type: subflow
-  workflowId: handleMissingIdExceptionWorkflow
+  type: operation
+  actions:
+  - subFlow: handleMissingIdExceptionWorkflow
   end: true
 - name: MissingItem
-  type: subflow
-  workflowId: handleMissingItemExceptionWorkflow
+  type: operation
+  actions:
+  - subFlow: handleMissingItemExceptionWorkflow
   end: true
 - name: MissingQuantity
-  type: subflow
-  workflowId: handleMissingQuantityExceptionWorkflow
+  type: operation
+  actions:
+  - subFlow: handleMissingQuantityExceptionWorkflow
   end: true
 - name: ApplyOrder
-  type: subflow
-  workflowId: applyOrderWorkflowId
+  type: operation
+  actions:
+  - subFlow: applyOrderWorkflowId
   end: true
 ```
 
@@ -1079,8 +1119,12 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   },
   {
       "name": "SubmitError",
-      "type": "subflow",
-      "workflowId": "handleJobSubmissionErrorWorkflow",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlow": "handleJobSubmissionErrorWorkflow"
+        }
+      ],
       "end": true
   },
   {
@@ -1200,8 +1244,9 @@ states:
     output: "${ .jobuid }"
   transition: WaitForCompletion
 - name: SubmitError
-  type: subflow
-  workflowId: handleJobSubmissionErrorWorkflow
+  type: operation
+  actions:
+  - subFlow: handleJobSubmissionErrorWorkflow
   end: true
 - name: WaitForCompletion
   type: delay
@@ -1929,8 +1974,12 @@ And for denied credit check, for example:
         },
         {
             "name": "StartApplication",
-            "type": "subflow",
-            "workflowId": "startApplicationWorkflowId",
+            "type": "operation",
+            "actions": [
+              {
+                "subFlow": "startApplicationWorkflowId"
+              }
+            ],
             "end": true
         },
         {
@@ -1994,8 +2043,9 @@ states:
   default:
     transition: RejectApplication
 - name: StartApplication
-  type: subflow
-  workflowId: startApplicationWorkflowId
+  type: operation
+  actions:
+  - subFlow: startApplicationWorkflowId
   end: true
 - name: RejectApplication
   type: operation
@@ -3291,11 +3341,34 @@ We fist define our top-level workflow for this example:
        },
        {
           "name": "DoCarVitalsChecks",
-          "type": "subflow",
+          "type": "operation",
+          "actions": [
+            {
+              "subFlow": {
+                "workflowId": "vitalscheck",
+                "waitForCompletion": false
+              },
+            }
+          ],
+          "transition": "WaitForCarStopped"
+       },
+       {
+          "name": "WaitForCarStopped",
+          "type": "event",
           "workflowId": "vitalscheck",
-          "repeat": {
-             "stopOnEvents": ["CarTurnedOffEvent"]
-          },
+          "onEvents": [
+             {
+                "eventRefs": ["CarTurnedOffEvent"],
+                "actions": [
+                  {
+                    "eventRef": {
+                      "triggerEventRef": "StopVitalsCheck",
+                      "resultEventRef":  "VitalsCheckingStopped"
+                    }
+                  }
+                ]
+             }
+          ],
           "end": true
        }
     ],
@@ -3303,12 +3376,22 @@ We fist define our top-level workflow for this example:
         {
             "name": "CarTurnedOnEvent",
             "type": "car.events",
-            "source": "my/car/start"
+            "source": "my/car"
         },
         {
             "name": "CarTurnedOffEvent",
             "type": "car.events",
-            "source": "my/car/start"
+            "source": "my/car"
+        },
+        {
+            "name": "StopVitalsCheck",
+            "type": "car.events",
+            "source": "my/car"
+        },
+        {
+            "name": "VitalsCheckingStopped",
+            "type": "car.events",
+            "source": "my/car"
         }
     ]
  }
@@ -3330,19 +3413,36 @@ states:
     - CarTurnedOnEvent
   transition: DoCarVitalsChecks
 - name: DoCarVitalsChecks
-  type: subflow
-  workflowId: vitalscheck
-  repeat:
-    stopOnEvents:
+  type: operation
+  actions:
+  - subFlow:
+    workflowId: vitalscheck
+    waitForCompletion: false
+  transition: WaitForCarStopped
+- name: WaitForCarStopped,
+  type: event,
+  workflowId: vitalscheck,
+  onEvents:
+  - eventRefs: 
     - CarTurnedOffEvent
+      actions:
+      - eventRef:
+        triggerEventRef: StopVitalsCheck
+        resultEventRef:  VitalsCheckingStopped
   end: true
 events:
 - name: CarTurnedOnEvent
   type: car.events
-  source: my/car/start
+  source: my/car
 - name: CarTurnedOffEvent
   type: car.events
-  source: my/car/start
+  source: my/car
+- name: StopVitalsCheck
+  type: car.events
+  source: my/car
+- name: VitalsCheckingStopped
+  type: car.events
+  source: my/car
 ```
 
 </td>
@@ -3409,12 +3509,52 @@ And then our reusable sub-workflow which performs the checking of our car vitals
       },
       {
          "name": "WaitTwoMinutes",
-         "type": "delay",
-         "timeDelay": "PT2M",
-         "end": true
+         "type": "event",
+         "timeout": "PT2M",
+         "onEvents": [
+            {
+              "eventRefs": ["StopVitalsCheck"],
+              "eventDataFilter": {
+                "data": "${ true }",
+                "toStateData": "${ .stopRecieved }"
+              }
+            }
+         ],
+         "transition": "ShouldStopOrContinue"
+      },
+      {
+         "name": "ShouldStopOrContinue",
+         "type": "switch",
+         "dataConditions": [
+            {
+               "name": "Stop Event Received",
+               "condition": "${ .stopRecieved }",
+               "end": {
+                  "produceEvents": [
+                     {
+                        "eventRef": "VitalsCheckingStopped"
+                     }
+                  ]
+                  
+               }
+            }
+         ],
+         "default": {
+            "transition": "CheckVitals"
+         }
       }
    ],
    "events": [
+      {
+          "name": "StopVitalsCheck",
+          "type": "car.events",
+          "source": "my/car"
+      },
+      {
+          "name": "VitalsCheckingStopped",
+          "type": "car.events",
+          "source": "my/car"
+      },
       {
          "name": "DisplayFailedChecksOnDashboard",
          "kind": "produced",
@@ -3471,13 +3611,35 @@ states:
   default:
     transition: WaitTwoMinutes
 - name: WaitTwoMinutes
-  type: delay
-  timeDelay: PT2M
-  end: true
+  type: event
+  timeout: PT2M
+  onEvents:
+  - eventRefs: 
+    - StopVitalsCheck
+    eventDataFilter:
+      data: ${ true }
+      toStateData: ${ .stopRecieved }
+  transition: ShouldStopOrContinue
+- name: ShouldStopOrContinue
+  type: switch
+  dataConditions:
+  - name: Stop Event Received
+    condition: ${ .stopRecieved }
+    end:
+      produceEvents:
+      - eventRef: VitalsCheckingStopped
+  default:
+    transition: CheckVitals
 events:
 - name: DisplayFailedChecksOnDashboard
   kind: produced
   type: my.car.events
+- name: StopVitalsCheck
+  type: car.events
+  source: my/car
+- name: VitalsCheckingStopped
+  type: car.events
+  source: my/car
 functions:
 - name: checkTirePressure
   operation: mycarservices.json#checktirepressure
@@ -3989,7 +4151,7 @@ functions:
 
 With the function and event definitions in place we can now start writing our main workflow definition:
 
-``` yaml
+```yaml
 id: foodorderworkflow
 name: Food Order Workflow
 version: '1.0'
@@ -3998,8 +4160,9 @@ functions: file://orderfunctions.yml
 events: file://orderevents.yml
 states:
 - name: Place Order
-  type: subflow
-  workflowId: placeorderworkflow
+  type: operation
+  actions:
+  - subFlow: placeorderworkflow
   transition: Wait for ETA Deadline
 - name: Wait for ETA Deadline
   type: event
@@ -4011,8 +4174,9 @@ states:
       toStateData: "${ .status }"
   transition: Deliver Order
 - name: Deliver Order
-  type: subflow
-  workflowId: deliverorderworkflow
+  type: operation
+  actions: 
+  - subFlow: deliverorderworkflow
   transition: Charge For Order
 - name: Charge For Order
   type: operation
@@ -4034,7 +4198,7 @@ With this in place we can start defining our sub-workflows:
 
 #### Place Order Sub-Workflow
 
-``` yaml
+```yaml
 id: placeorderworkflow
 name: Place Order Workflow
 version: '1.0'
@@ -4067,7 +4231,7 @@ states:
 
 #### Deliver Order Sub-Workflow
 
-``` yaml
+```yaml
 id: deliverorderworkflow
 name: Deliver Order Workflow
 version: '1.0'
@@ -4104,7 +4268,7 @@ states:
 
 For the example order event, the workflow output for a successful completion would look like for example:
 
-``` json
+```json
 {
   "orderid": "ORDER-12345",
   "orderstatus": [

--- a/examples/README.md
+++ b/examples/README.md
@@ -629,7 +629,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
     "type": "operation",
     "actions": [
       {
-        "subFlow": "handleApprovedVisaWorkflowID" 
+        "subFlowRef": "handleApprovedVisaWorkflowID" 
       }
     ],
     "end": true
@@ -639,7 +639,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
       "type": "operation",
       "actions": [
         {
-          "subFlow": "handleRejectedVisaWorkflowID" 
+          "subFlowRef": "handleRejectedVisaWorkflowID" 
         }
       ],
       "end": true
@@ -649,7 +649,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
       "type": "operation",
       "actions": [
         {
-          "subFlow": "handleNoVisaDecisionWorkfowId" 
+          "subFlowRef": "handleNoVisaDecisionWorkfowId" 
         }
       ],
       "end": true
@@ -688,17 +688,17 @@ states:
 - name: HandleApprovedVisa
   type: operation
   actions:
-    - subFlow: handleApprovedVisaWorkflowID
+    - subFlowRef: handleApprovedVisaWorkflowID
   end: true
 - name: HandleRejectedVisa
   type: operation
     actions:
-      - subFlow: handleRejectedVisaWorkflowID
+      - subFlowRef: handleRejectedVisaWorkflowID
   end: true
 - name: HandleNoVisaDecision
   type: operation
     actions:
-      - subFlow: handleNoVisaDecisionWorkfowId
+      - subFlowRef: handleNoVisaDecisionWorkfowId
   end: true
 ```
 
@@ -779,7 +779,7 @@ If the applicants age is over 18 we start the application (subflow action). Othe
         "type": "operation",
         "actions": [
           {
-            "subFlow": "startApplicationWorkflowId" 
+            "subFlowRef": "startApplicationWorkflowId" 
           }
         ],
         "end": true
@@ -829,7 +829,7 @@ states:
 - name: StartApplication
   type: operation
   actions: 
-    - subFlow: startApplicationWorkflowId
+    - subFlowRef: startApplicationWorkflowId
   end: true
 - name: RejectApplication
   type: operation
@@ -937,7 +937,7 @@ The data output of the workflow contains the information of the exception caught
    "type": "operation",
    "actions": [
      {
-       "subFlow": "handleMissingIdExceptionWorkflow"
+       "subFlowRef": "handleMissingIdExceptionWorkflow"
      }
    ],
    "end": true
@@ -947,7 +947,7 @@ The data output of the workflow contains the information of the exception caught
    "type": "operation",
    "actions": [
      {
-       "subFlow": "handleMissingItemExceptionWorkflow"
+       "subFlowRef": "handleMissingItemExceptionWorkflow"
      }
    ],
    "end": true
@@ -957,7 +957,7 @@ The data output of the workflow contains the information of the exception caught
    "type": "operation",
    "actions": [
      {
-       "subFlow": "handleMissingQuantityExceptionWorkflow"
+       "subFlowRef": "handleMissingQuantityExceptionWorkflow"
      }
    ],
    "end": true
@@ -967,7 +967,7 @@ The data output of the workflow contains the information of the exception caught
    "type": "operation",
    "actions": [
      {
-       "subFlow": "applyOrderWorkflowId"
+       "subFlowRef": "applyOrderWorkflowId"
      }
    ],
    "end": true
@@ -1010,22 +1010,22 @@ states:
 - name: MissingId
   type: operation
   actions:
-  - subFlow: handleMissingIdExceptionWorkflow
+  - subFlowRef: handleMissingIdExceptionWorkflow
   end: true
 - name: MissingItem
   type: operation
   actions:
-  - subFlow: handleMissingItemExceptionWorkflow
+  - subFlowRef: handleMissingItemExceptionWorkflow
   end: true
 - name: MissingQuantity
   type: operation
   actions:
-  - subFlow: handleMissingQuantityExceptionWorkflow
+  - subFlowRef: handleMissingQuantityExceptionWorkflow
   end: true
 - name: ApplyOrder
   type: operation
   actions:
-  - subFlow: applyOrderWorkflowId
+  - subFlowRef: applyOrderWorkflowId
   end: true
 ```
 
@@ -1122,7 +1122,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       "type": "operation",
       "actions": [
         {
-          "subFlow": "handleJobSubmissionErrorWorkflow"
+          "subFlowRef": "handleJobSubmissionErrorWorkflow"
         }
       ],
       "end": true
@@ -1246,7 +1246,7 @@ states:
 - name: SubmitError
   type: operation
   actions:
-  - subFlow: handleJobSubmissionErrorWorkflow
+  - subFlowRef: handleJobSubmissionErrorWorkflow
   end: true
 - name: WaitForCompletion
   type: delay
@@ -1977,7 +1977,7 @@ And for denied credit check, for example:
             "type": "operation",
             "actions": [
               {
-                "subFlow": "startApplicationWorkflowId"
+                "subFlowRef": "startApplicationWorkflowId"
               }
             ],
             "end": true
@@ -2045,7 +2045,7 @@ states:
 - name: StartApplication
   type: operation
   actions:
-  - subFlow: startApplicationWorkflowId
+  - subFlowRef: startApplicationWorkflowId
   end: true
 - name: RejectApplication
   type: operation
@@ -3301,8 +3301,8 @@ In this example we need to check car vital signs while our car is driving.
 The workflow should start when we receive the "carOn" event and stop when the "carOff" event is consumed.
 While the car is driving our workflow should repeatedly check the vitals every 2 minutes.
 
-For this example we use the workflow [SubFlow](../specification.md#SubFlow-State) state and its 
-[repeat definition](../specification.md#Repeat-Definition) to repeat execution of the vitals checks.
+For this example we use the workflow [SubFlow](../specification.md#SubFlow-Action) actions and looping to repeat 
+execution of the vitals checks.
 
 #### Workflow Diagram
 
@@ -3344,7 +3344,7 @@ We fist define our top-level workflow for this example:
           "type": "operation",
           "actions": [
             {
-              "subFlow": {
+              "subFlowRef": {
                 "workflowId": "vitalscheck",
                 "waitForCompletion": false
               },
@@ -3355,7 +3355,6 @@ We fist define our top-level workflow for this example:
        {
           "name": "WaitForCarStopped",
           "type": "event",
-          "workflowId": "vitalscheck",
           "onEvents": [
              {
                 "eventRefs": ["CarTurnedOffEvent"],
@@ -3415,13 +3414,12 @@ states:
 - name: DoCarVitalsChecks
   type: operation
   actions:
-  - subFlow:
+  - subFlowRef:
     workflowId: vitalscheck
     waitForCompletion: false
   transition: WaitForCarStopped
-- name: WaitForCarStopped,
-  type: event,
-  workflowId: vitalscheck,
+- name: WaitForCarStopped
+  type: event
   onEvents:
   - eventRefs: 
     - CarTurnedOffEvent
@@ -3515,8 +3513,7 @@ And then our reusable sub-workflow which performs the checking of our car vitals
             {
               "eventRefs": ["StopVitalsCheck"],
               "eventDataFilter": {
-                "data": "${ true }",
-                "toStateData": "${ .stopRecieved }"
+                "toStateData": "${ .stopReceived }"
               }
             }
          ],
@@ -3528,7 +3525,7 @@ And then our reusable sub-workflow which performs the checking of our car vitals
          "dataConditions": [
             {
                "name": "Stop Event Received",
-               "condition": "${ .stopRecieved }",
+               "condition": "${ has(\"stopReceived\") }",
                "end": {
                   "produceEvents": [
                      {
@@ -3617,14 +3614,13 @@ states:
   - eventRefs: 
     - StopVitalsCheck
     eventDataFilter:
-      data: ${ true }
-      toStateData: ${ .stopRecieved }
+      toStateData: ${ .stopReceived }
   transition: ShouldStopOrContinue
 - name: ShouldStopOrContinue
   type: switch
   dataConditions:
   - name: Stop Event Received
-    condition: ${ .stopRecieved }
+    condition: ${ has("stopReceived") }
     end:
       produceEvents:
       - eventRef: VitalsCheckingStopped
@@ -4050,7 +4046,7 @@ structure and the available services:
 <img src="../media/examples/example-foodorder-outline.png" height="450px" alt="Online Food Ordering Structure"/>
 </p>
 
-Our workflow starts with the "Place Order" [Subflow](../specification.md#SubFlow-State), which is responsible
+Our workflow starts with the "Place Order" [Subflow](../specification.md#SubFlow-Action), which is responsible
 to send the received order to the requested restaurant and the estimated order ETA. 
 We then wait for the ETA time when our workflow should go into the "Deliver Order" SubFlow, responsible
 for dispatching a Courier and sending her/him off to pick up the order. Once the order is picked up, the Courier needs to deliver the order to the customer. 
@@ -4162,7 +4158,7 @@ states:
 - name: Place Order
   type: operation
   actions:
-  - subFlow: placeorderworkflow
+  - subFlowRef: placeorderworkflow
   transition: Wait for ETA Deadline
 - name: Wait for ETA Deadline
   type: event
@@ -4176,7 +4172,7 @@ states:
 - name: Deliver Order
   type: operation
   actions: 
-  - subFlow: deliverorderworkflow
+  - subFlowRef: deliverorderworkflow
   transition: Charge For Order
 - name: Charge For Order
   type: operation

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -97,10 +97,6 @@
             "$ref": "#/definitions/switchstate"
           },
           {
-            "title": "SubFlow State",
-            "$ref": "#/definitions/subflowstate"
-          },
-          {
             "title": "Inject State",
             "$ref": "#/definitions/injectstate"
           },
@@ -345,6 +341,10 @@
           "description": "References a 'trigger' and 'result' reusable event definitions",
           "$ref": "#/definitions/eventref"
         },
+        "subFlow": {
+          "description": "References a sub-workflow to invoke",
+          "$ref": "#/definitions/subflowref"
+        },
         "timeout": {
           "type": "string",
           "description": "Time period to wait for function execution to complete"
@@ -364,6 +364,11 @@
         {
           "required": [
             "eventRef"
+          ]
+        },
+        {
+          "required": [
+            "subFlow"
           ]
         }
       ]
@@ -399,6 +404,33 @@
       "required": [
         "triggerEventRef",
         "resultEventRef"
+      ]
+    },
+    "subflowref": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Unique id of the sub-workflow to be invoked",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "description": "Specifies a sub-workflow to be invoked",
+          "properties": {
+            "waitForCompletion": {
+              "type": "boolean",
+              "default": false,
+              "description": "Workflow execution must wait for sub-workflow to finish before continuing"
+            },
+            "workflowId": {
+              "type": "string",
+              "description": "Unique id of the sub-workflow to be invoked"
+            }
+          },
+          "required": [
+            "workflowId"
+          ]
+        }
       ]
     },
     "branch": {
@@ -1166,108 +1198,6 @@
         "end"
       ]
     },
-    "subflowstate": {
-      "type": "object",
-      "description": "Defines a sub-workflow to be executed",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Unique state id",
-          "minLength": 1
-        },
-        "name": {
-          "type": "string",
-          "description": "State name"
-        },
-        "type": {
-          "type": "string",
-          "const": "subflow",
-          "description": "State type"
-        },
-        "end": {
-          "$ref": "#/definitions/end",
-          "description": "State end definition"
-        },
-        "waitForCompletion": {
-          "type": "boolean",
-          "default": false,
-          "description": "Workflow execution must wait for sub-workflow to finish before continuing"
-        },
-        "workflowId": {
-          "type": "string",
-          "description": "Sub-workflow unique id"
-        },
-        "repeat": {
-          "$ref": "#/definitions/repeat",
-          "description": "SubFlow state repeat exec definition"
-        },
-        "stateDataFilter": {
-          "description": "State data filter",
-          "$ref": "#/definitions/statedatafilter"
-        },
-        "onErrors": {
-          "type": "array",
-          "description": "States error handling and retries definitions",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/error"
-          },
-          "additionalItems": false
-        },
-        "transition": {
-          "description": "Next transition of the workflow after SubFlow has completed execution",
-          "$ref": "#/definitions/transition"
-        },
-        "compensatedBy": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Unique Name of a workflow state which is responsible for compensation of this state"
-        },
-        "usedForCompensation": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, this state is used to compensate another state. Default is false"
-        },
-        "metadata": {
-          "$ref": "common.json#/definitions/metadata"
-        }
-      },
-      "additionalProperties": false,
-      "if": {
-        "properties": {
-          "usedForCompensation": {
-            "const": true
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "name",
-          "type",
-          "workflowId"
-        ]
-      },
-      "else": {
-        "oneOf": [
-          {
-            "required": [
-              "name",
-              "type",
-              "workflowId",
-              "end"
-            ]
-          },
-          {
-            "required": [
-              "name",
-              "type",
-              "workflowId",
-              "transition"
-            ]
-          }
-        ]
-      }
-    },
     "injectstate": {
       "type": "object",
       "description": "Inject static data into state data. Does not perform any actions",
@@ -1299,7 +1229,7 @@
           "$ref": "#/definitions/statedatafilter"
         },
         "transition": {
-          "description": "Next transition of the workflow after subflow has completed",
+          "description": "Next transition of the workflow after injection has completed",
           "$ref": "#/definitions/transition"
         },
         "compensatedBy": {
@@ -1403,10 +1333,6 @@
             "$ref": "#/definitions/action"
           },
           "additionalItems": false
-        },
-        "workflowId": {
-          "type": "string",
-          "description": "Unique Id of a workflow to be executed for each of the elements of inputCollection"
         },
         "stateDataFilter": {
           "description": "State data filter",
@@ -1790,42 +1716,6 @@
         "toStateData": {
           "type": "string",
           "description": "Workflow expression that selects a state data element to which the action results should be added/merged into. If not specified, denote, the top-level state data element"
-        }
-      },
-      "additionalProperties": false,
-      "required": []
-    },
-    "repeat": {
-      "type": "object",
-      "properties": {
-        "expression": {
-          "type": "string",
-          "description": "Expression evaluated against SubFlow state data. SubFlow will repeat execution as long as this expression is true or until the max property count is reached",
-          "minLength": 1
-        },
-        "checkBefore": {
-          "type": "boolean",
-          "description": "If true, the expression is evaluated before each repeat execution, if false the expression is evaluated after each repeat execution",
-          "default": true
-        },
-        "max": {
-          "type": "integer",
-          "description": "Sets the maximum amount of repeat executions",
-          "minimum": 0
-        },
-        "continueOnError": {
-          "type": "boolean",
-          "description": "If true, repeats executions in a case unhandled errors propagate from the sub-workflow to this state",
-          "default": false
-        },
-        "stopOnEvents": {
-          "type": "array",
-          "description": "List referencing defined consumed workflow events. SubFlow will repeat execution until one of the defined events is consumed, or until the max property count is reached",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          },
-          "additionalItems": false
         }
       },
       "additionalProperties": false,

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -341,7 +341,7 @@
           "description": "References a 'trigger' and 'result' reusable event definitions",
           "$ref": "#/definitions/eventref"
         },
-        "subFlow": {
+        "subFlowRef": {
           "description": "References a sub-workflow to invoke",
           "$ref": "#/definitions/subflowref"
         },
@@ -368,7 +368,7 @@
         },
         {
           "required": [
-            "subFlow"
+            "subFlowRef"
           ]
         }
       ]

--- a/specification.md
+++ b/specification.md
@@ -2277,9 +2277,9 @@ instance in case it is an end state without performing any actions.
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name | Unique action name | string | no |
-| [functionRef](#FunctionRef-Definition) | References a reusable function definition | object | yes if `eventRef` & `subFlow` are not defined |
-| [eventRef](#EventRef-Definition) | References a `trigger` and `result` reusable event definitions | object | yes if `functionRef` & `subFlow` are not defined |
-| subFlow | Either string containing the unique id of the sub-workflow to be invoked or a [subFlowRef](#SubFlowRef-Definition) object | object or string | yes if `eventRef` & `functionRef` are not defined |
+| [functionRef](#FunctionRef-Definition) | References a reusable function definition | object | yes if `eventRef` & `subFlowRef` are not defined |
+| [eventRef](#EventRef-Definition) | References a `trigger` and `result` reusable event definitions | object | yes if `functionRef` & `subFlowRef` are not defined |
+| [subFlowRef](#SubFlowRef-Definition) | References a workflow to be invoked | object or string | yes if `eventRef` & `functionRef` are not defined |
 | timeout | Time period to wait for function execution to complete or the resultEventRef to be consumed (ISO 8601 format). For example: "PT15M" (15 minutes), or "P2DT3H4M" (2 days, 3 hours and 4 minutes)| string | no |
 | [actionDataFilter](#Action-data-filters) | Action data filter definition | object | no |
 
@@ -2354,7 +2354,7 @@ multiple other workflow definitions.
 
 Reusable workflows are referenced by their `id` property via the SubFlow action `workflowId` parameter.
 
-For the simple case, `subFlow` can be a string containing the `id` of the sub-workflow to invoke.  
+For the simple case, `subFlowRef` can be a string containing the `id` of the sub-workflow to invoke.  
 If you want to specify other parameters then a [subFlowRef](#SubFlowRef-Definition) should be provided instead.
 
 Each referenced workflow receives the SubFlow actions data as workflow data input.
@@ -4138,7 +4138,7 @@ their execution followed by a transition another workflow state, given their con
 
 The `terminate` property, if set to `true`, completes the workflow instance execution, this any other active 
 execution paths.
-If a terminate end is reached inside a ForEach, or Parallel, the entire workflow instance is terminated.
+If a terminate end is reached inside a ForEach or Parallel state the entire workflow instance is terminated.
 
 The [`produceEvents`](#ProducedEvent-Definition) allows defining events which should be produced
 by the workflow instance before workflow stops its execution.

--- a/specification.md
+++ b/specification.md
@@ -112,7 +112,7 @@ and the [Workflow Model](#Workflow-Model) It defines a blueprint used by runtime
 
 A business solution can be composed of any number of related workflow definitions.
 Their relationships are explicitly modeled with the Serverless Workflow language (for example
-by using [SubFlow](#SubFlow-State) states).
+by using [SubFlow](#SubFlow-Action) actions).
 
 Runtimes can initialize workflow definitions for some particular set of data inputs or events
 which forms [workflow instances](#Workflow-Instance).
@@ -1973,7 +1973,6 @@ States define building blocks of the Serverless Workflow. The specification defi
 | **[Switch](#Switch-State)** | Define data-based or event-based workflow transitions | no | yes | no | yes | no | yes | yes | no |
 | **[Delay](#Delay-State)** | Delay workflow execution | no | yes | no | yes | no | no | yes | yes |
 | **[Parallel](#Parallel-State)** | Causes parallel execution of branches (set of states) | no | yes | no | yes | yes | no | yes | yes |
-| **[SubFlow](#SubFlow-State)** | Represents the invocation of another workflow from within a workflow | no | yes | no | yes | no | no | yes | yes |
 | **[Inject](#Inject-State)** | Inject static data into state data | no | yes | no | yes | no | no | yes | yes |
 | **[ForEach](#ForEach-State)** | Parallel execution of states for each element of a data array | no | yes | no | yes | yes | no | yes | yes |
 | **[Callback](#Callback-State)** | Manual decision step. Executes a function and waits for callback event that indicates completion of the manual decision | yes | yes | yes | yes | no | no | yes | yes |
@@ -2278,8 +2277,9 @@ instance in case it is an end state without performing any actions.
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name | Unique action name | string | no |
-| [functionRef](#FunctionRef-Definition) | References a reusable function definition | object | yes if `eventRef` is not used |
-| [eventRef](#EventRef-Definition) | References a `trigger` and `result` reusable event definitions | object | yes if `functionRef` is not used |
+| [functionRef](#FunctionRef-Definition) | References a reusable function definition | object | yes if `eventRef` & `subFlow` are not defined |
+| [eventRef](#EventRef-Definition) | References a `trigger` and `result` reusable event definitions | object | yes if `functionRef` & `subFlow` are not defined |
+| subFlow | Either string containing the unique id of the sub-workflow to be invoked or a [subFlowRef](#SubFlowRef-Definition) object | object or string | yes if `eventRef` & `functionRef` are not defined |
 | timeout | Time period to wait for function execution to complete or the resultEventRef to be consumed (ISO 8601 format). For example: "PT15M" (15 minutes), or "P2DT3H4M" (2 days, 3 hours and 4 minutes)| string | no |
 | [actionDataFilter](#Action-data-filters) | Action data filter definition | object | no |
 
@@ -2325,12 +2325,13 @@ timeout: PT15M
 
 </details>
 
-Actions specify invocations of services during workflow execution.
+Actions specify invocations of services or other workflows during workflow execution.
 Service invocation can be done in two different ways:
 
 * Reference [functions definitions](#Function-Definition) by its unique name using the `functionRef` property.
-* Reference a `produced` and `consumed` [event definitions](#Event-Definition) via the `eventRef` property. 
-In this scenario a service or a set of services we want to invoke
+* Reference a `produced` and `consumed` [event definitions](#Event-Definition) via the `eventRef` property.
+
+In the event-based scenario a service or a set of services we want to invoke
 are not exposed via a specific resource URI for example, but can only be invoked via events. 
 The [eventRef](#EventRef-Definition) defines the 
 referenced `produced` event via its `triggerEventRef` property and a `consumed` event via its `resultEventRef` property.
@@ -2341,6 +2342,25 @@ It is described in ISO 8601 format, so for example "PT2M" would mean the maximum
 its execution is two minutes. 
 
 Possible invocation timeouts should be handled via the states [onErrors](#Workflow-Error-Handling) definition.
+
+##### Subflow action
+
+Often you want to group your workflows into small logical units that solve a particular business problem and can be reused in 
+multiple other workflow definitions.
+
+<p align="center">
+<img src="media/spec/subflowstateref.png" height="350px" alt="Referencing reusable workflow via SubFlow actions"/>
+</p>
+
+Reusable workflows are referenced by their `id` property via the SubFlow action `workflowId` parameter.
+
+For the simple case, `subFlow` can be a string containing the `id` of the sub-workflow to invoke.  
+If you want to specify other parameters then a [subFlowRef](#SubFlowRef-Definition) should be provided instead.
+
+Each referenced workflow receives the SubFlow actions data as workflow data input.
+
+Referenced sub-workflows must declare their own [function](#Function-Definition) and [event](#Event-Definition) definitions.
+
 
 #### FunctionRef Definition
 
@@ -2463,6 +2483,50 @@ to be used as payload of the event referenced by `triggerEventRef`. If it is of 
 
 The `contextAttributes` property allows you to add one or more [extension context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
 to the trigger/produced event. 
+
+#### SubFlowRef Definition
+
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| waitForCompletion | If workflow execution must wait for sub-workflow to finish before continuing | boolean | yes |
+| workflowId |Sub-workflow unique id | boolean | no |
+
+<details><summary><strong>Click to view example definition</strong></summary>
+<p>
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td valign="top">
+
+```json
+{
+    "workflowId": "handleApprovedVisaWorkflowID"
+}
+```
+
+</td>
+<td valign="top">
+
+```yaml
+workflowId: handleApprovedVisaWorkflowID
+```
+
+</td>
+</tr>
+</table>
+
+</details>
+
+The `waitForCompletion` property defines if the SubFlow action should wait until the referenced reusable workflow
+has completed its execution. If it's set to "true" (default value), SubFlow action execution must wait until the referenced workflow has completed its execution.
+In this case the workflow data output of the referenced workflow will be used as the result data of the action.
+If it is set to "false" the parent workflow can continue its execution as soon as the referenced sub-workflow 
+has been invoked (fire-and-forget). For this case, the referenced (child) workflow data output will be ignored and the result data 
+of the action will be an empty json object (`{}`).
 
 #### Error Definition
 
@@ -3232,91 +3296,6 @@ parallel state should be considered as the workflow control flow logic has alrea
 
 For more information, see the [Workflow Error Handling](#Workflow-Error-Handling) sections.
 
-#### SubFlow State
-
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| id | Unique state id | string | no |
-| name |State name | string | yes |
-| type |State type | string | yes |
-| waitForCompletion | If workflow execution must wait for sub-workflow to finish before continuing | boolean | yes |
-| workflowId |Sub-workflow unique id | string | yes |
-| [repeat](#Repeat-Definition) | SubFlow state repeat exec definition | object | no |
-| [stateDataFilter](#State-data-filters) | State data filter | object | no |
-| [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
-| [transition](#Transitions) | Next transition of the workflow after subflow has completed | object | if usedForCompensation is false: yes if end is not defined. if usedForCompensation is true: no |
-| [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
-| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
-| [metadata](#Workflow-Metadata) | Metadata information| object | no |
-| [end](#End-Definition) | If this state and end state | object | if usedForCompensation is false: yes if transition is not defined. if usedForCompensation is true: no  |
-
-<details><summary><strong>Click to view example definition</strong></summary>
-<p>
-
-<table>
-<tr>
-    <th>JSON</th>
-    <th>YAML</th>
-</tr>
-<tr>
-<td valign="top">
-
-```json
-{
-    "name": "HandleApprovedVisa",
-    "type": "subflow",
-    "workflowId": "handleApprovedVisaWorkflowID",
-    "end": true
-}
-```
-
-</td>
-<td valign="top">
-
-```yaml
-name: HandleApprovedVisa
-type: subflow
-workflowId: handleApprovedVisaWorkflowID
-end: true
-```
-
-</td>
-</tr>
-</table>
-
-</details>
-
-Often you want to group your workflows into small logical units that solve a particular business problem and can be reused in 
-multiple other workflow definitions.
-
-<p align="center">
-<img src="media/spec/subflowstateref.png" height="350px" alt="Referencing reusable workflow via SubFlow states"/>
-</p>
-
-Reusable workflow are referenced by their `id` property via the SubFlow states`workflowId` parameter.
-
-Each referenced workflow receives the SubFlow states data as workflow data input.
-
-The `waitForCompletion` property defines if the SubFlow state should wait until the referenced reusable workflow
-has completed its execution. If it's set to "true" (default value), SubFlow state execution must wait until the referenced workflow has completed its execution.
-In this case the workflow data output of the referenced workflow can and should be merged with the SubFlow states state data.
-If it's set to "false" the parent workflow can continue its execution while the referenced sub-workflow 
-is being executed. For this case, the referenced (child) workflow data output cannot be merged with the SubFlow states
-state data (as by the time its completion the parent workflow execution has already continued).
-
-The `repeat` property defines the SubFlow states repeated execution (looping) behavior. This allows you to specify that 
-the sub-workflow should be executed multiple times repeatedly.
-If the `repeat` property is defined, the `waitForCompletion` should be assumed have the value of `true`.
-If the workflow explicitly triggers [compensation](#Workflow-Compensation) and the SubFlow state 
-was executed and defines its compensation state, it should be compensated once, no matter how many times
-its was executed as defined by the `repeat` property.
-After each execution of the SubFlow state, if `repeat` is defined, the SubFlow state data at the end of the 
-one execution should become the state data of the next execution.
-
-For more information about the `repeat` property see the [Repeat Definition](#Repeat-Definition) section.
-
-Referenced sub-workflows must declare their own [function](#Function-Definition) and [event](#Event-Definition) definitions.
-
 #### Inject State
 
 | Parameter | Description | Type | Required |
@@ -3326,7 +3305,7 @@ Referenced sub-workflows must declare their own [function](#Function-Definition)
 | type | State type | string | yes |
 | data | JSON object which can be set as state's data input and can be manipulated via filter | object | yes |
 | [stateDataFilter](#state-data-filters) | State data filter | object | no |
-| [transition](#Transitions) | Next transition of the workflow after subflow has completed | object | yes (if end is set to false) |
+| [transition](#Transitions) | Next transition of the workflow after injection has completed | object | yes (if end is set to false) |
 | [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
 | [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
 | [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
@@ -3554,8 +3533,7 @@ This allows you to test if your workflow behaves properly for cases when there a
 | outputCollection | Workflow expression specifying an array element of the states data to add the results of each iteration | string | no |
 | iterationParam | Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array | string | yes |
 | max | Specifies how upper bound on how many iterations may run in parallel | string or number | no |
-| [actions](#Action-Definition) | Actions to be executed for each of the elements of inputCollection | array | yes if subflowId is not defined |
-| workflowId | Unique Id of a workflow to be executed for each of the elements of inputCollection | string | yes if actions is not defined |
+| [actions](#Action-Definition) | Actions to be executed for each of the elements of inputCollection | array | yes |
 | [stateDataFilter](#State-data-filters) | State data filter definition | object | no |
 | [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
 | [transition](#Transitions) | Next transition of the workflow after state has completed | object | yes (if end is not defined) |
@@ -3617,8 +3595,7 @@ actions:
 
 </details>
 
-ForEach states can be used to execute [actions](#Action-Definition), or a [sub-workflow](#SubFlow-State) for 
-each element of a data set.
+ForEach states can be used to execute [actions](#Action-Definition) for each element of a data set.
 
 Each iteration of the ForEach state should be executed in parallel.
 
@@ -3865,78 +3842,6 @@ The callback event payload is merged with the Callback state data and can be fil
 The Callback state `timeout` property defines a time period from the action execution until the callback event should be received.
 
 If the defined callback event has not been received during this time period, the state should transition to the next state or end workflow execution if it is an end state.
-
-#### Repeat Definition
-
-| Parameter | Description | Type | Required | 
-| --- | --- | --- | --- |
-| [expression](#Workflow-Expressions) | Workflow expression evaluated against state data. SubFlow will repeat execution as long as this expression is true or until the max property count is reached  | string | no |
-| checkBefore | If set to `true` (default value) the expression is evaluated before each repeat execution, if set to false the expression is evaluated after each repeat execution | boolean | no |
-| max | Sets the maximum amount of repeat executions | integer | no |
-| continueOnError | If set to `true` repeats executions in a case unhandled errors propagate from the sub-workflow to this state | boolean | no |
-| stopOnEvents | List referencing defined consumed workflow events. SubFlow will repeat execution until one of the defined events is consumed, or until the max property count is reached | array | no |
-
-<details><summary><strong>Click to view example definition</strong></summary>
-<p>
-
-<table>
-<tr>
-    <th>JSON</th>
-    <th>YAML</th>
-</tr>
-<tr>
-<td valign="top">
-
-```json
-{
-  "max": 10,
-  "continueOnError": true
-}
-```
-
-</td>
-<td valign="top">
-
-```yaml
-max: 10
-continueOnError: true
-```
-
-</td>
-</tr>
-</table>
-
-</details>
-
-Repeat definition can be used in [SubFlow](#SubFlow-State) states to define repeated execution (looping).
-
-The `expression` parameter is a [workflow expression](#Workflow-Expressions). It is 
-evaluated against SubFlow states data. 
-SubFlow state should repeat its execution as long as this expression evaluates to `true` (the expression returns a non-empty result),
-or until the `max` property limit is reached. This parameter allows you to stop repeat execution based on data.
-
-The `checkBefore` property can be used to decide if the `expression` evaluation should be done before or after 
-each SubFlow state execution. Default value of this property is `true`.
-
-The `max` property sets the maximum count of repeat executions. It should be a positive integer value.
-Runtime implementations must define an internal repeat/loop counter which is incremented for each of the 
-SubFlow state repeated executions. If this counter reaches the max value, repeated executions should end.
-
-The `continueOnError` property defines if repeated executions should continue or not in case unhandled errors are propagated
-by the sub-workflow to the SubFlow state. Default value of this property is `false`.
-Unhandled errors are errors which are not explicitly handled by the sub-workflow, and the SubFlow state 
-via its [`onErrors`](#Error-Definition) definition.
-
-If `continueOnError` is set to `false` (default value), and an unhandled error occurs, it should be handled 
-as any other unhandled workflow error, meaning repeat execution shall stop and workflow should stop its exception.
-
-If an error occurs which propagates to the SubFlow state, and is handled explicitly by the 
-SubFlow states [`onErrors`](#Error-Definition) definition, the control flow must take the path of the error handling definition
-and repeat execution must halt.
-
-An alternative way to limit repeat executions is via the `stopOnEvents` property. It contains a list of one or more 
-defined consumed workflow events (referenced by the unique event name). When `stopOnEvents` is defined,
-SubFlow will repeat execution until one of the defined events is consumed, or until the max property count is reached.
 
 #### Start Definition
 
@@ -4233,7 +4138,7 @@ their execution followed by a transition another workflow state, given their con
 
 The `terminate` property, if set to `true`, completes the workflow instance execution, this any other active 
 execution paths.
-If a terminate end is reached inside a ForEach, Parallel, or SubFlow state, the entire workflow instance is terminated.
+If a terminate end is reached inside a ForEach, or Parallel, the entire workflow instance is terminated.
 
 The [`produceEvents`](#ProducedEvent-Definition) allows defining events which should be produced
 by the workflow instance before workflow stops its execution.


### PR DESCRIPTION
Move support for sub-flows to actions, so we get all the other features of actions for sub-flows (like looping, retries, error-handling, etc)

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [✅ ] Specification
- [✅ ] Schema
- [✅ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

The intent is to unify the experience for using actions & sub-flows, since sub-flow use-cases have many similar needs as actions.

https://github.com/serverlessworkflow/specification/issues/300

> To give an example of what I mean, I think we could do the following and the language would be much more consistent:
>
> Add 'subFlow' as an optional parameter for an Action definition. This would be an object with 2 parameters, one is the sub-workflow ID and the other a waitForCompletion flag.
Drop the SubFlow state from the spec
Drop the 'workflowId' parameter from parallel-state branch definition
With that change, a customer can use sub-flows like they can invoke any other type of action in parallel, operation, & other states. Existing retry behavior could now be reused for sub-workflows, looping constructs that are available for actions are also automatically supported.
>
> Really, I see very little difference in behavior between a sub-workflow & the eventRef/functionRef style of action (under the covers all invoke something and wait for a result back). In the case that a user sets waitForCompletion=false, then the spec should indicate that the parent workflow should behave as if the sub-workflow completed immediately with an output value of an empty json object perhaps.
>
> A good illustration of my point is that if you compare the current description of Operation and SubFlow states, there seems to be very little difference in their features/behavior.


**Special notes for reviewers**:

**Additional information (if needed):**