### PR TITLE
adding copyright info for contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ workflow ecosystem. Community contributions are welcome and much needed to foste
 See [here](community/contributors.md) for the list of community members that have contributed to the specification.
 
 To learn how to contribute to the specification reference the ['how to contribute'](contributing.md) doc.
+
+If you have any copyright questions when contributing to a CNCF project like this one,
+reference the [Ownership of Copyrights in CNCF Project Contributions](https://github.com/cncf/foundation/blob/master/copyright-notices.md) doc.
   
 ### Communication
 


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [x ] Other

**What this PR does / why we need it**:
adds the cncf copyright doc to main readme. contributors can reference it if they have any copyright questions 
**Special notes for reviewers**:

**Additional information (if needed):**