### PR TITLE
Adding workflow dataInputSchema property

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -22,6 +22,7 @@ _Status description:_
 | Status | Description | Comments |
 | --- | --- |  --- |
 | ✔️| Add workflow `key` and `annotations` properties | [spec doc](../specification.md) |
+| ✔️| Add workflow `dataInputSchema` property | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -37,6 +37,36 @@
       },
       "additionalItems": false
     },
+    "dataInputSchema": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "URI of the JSON Schema used to validate the workflow data input",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "description": "Workflow data input schema definition",
+          "properties": {
+            "schema": {
+              "type": "string",
+              "description": "URI of the JSON Schema used to validate the workflow data input",
+              "minLength": 1
+            },
+            "failOnValidationErrors": {
+              "type": "boolean",
+              "default": true,
+              "description": "Determines if workfow execution should continue if there are validation errors"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "schema",
+            "failOnValidationErrors"
+          ]
+        }
+      ]
+    },
     "start": {
       "$ref": "#/definitions/startdef"
     },

--- a/specification.md
+++ b/specification.md
@@ -1483,6 +1483,9 @@ If `dataInputSchema` has the string type, it has the following definition:
 ```
 In this case the `failOnValidationErrors` default value of `true` is assumed. 
 
+The `dataInputSchema` property validates the [workflow data input](#Workflow-Data-Input). In case of 
+a starting [Event state](#Event-state), it is not used to validate its event payloads.
+
 The `start` property defines the workflow starting information. For more information see the [start definition](#Start-Definition) section.
 
 The `schemaVersion` property can be used to set the specific Serverless Workflow schema version to use

--- a/specification.md
+++ b/specification.md
@@ -1384,6 +1384,7 @@ definition "id" must be a constant value.
 | description | Workflow description | string | no |
 | version | Workflow version | string | no |
 | annotations | List of helpful terms describing the workflows intended purpose, subject areas, or other important qualities | string | no |
+| dataInputSchema | Used to validate the workflow data input against a defined JSON Schema| string or object | no |
 | [start](#Start-Definition) | Workflow start definition | string | yes |
 | schemaVersion | Workflow schema version | string | no |
 | expressionLang | Identifies the expression language used for workflow expressions. Default value is "jq" | string | no |
@@ -1463,6 +1464,24 @@ The `version` property can be used to provide a specific workflow version.
 
 The `annotations` property defines a list of helpful terms describing the workflows intended purpose, subject areas, or other important qualities,
 for example "machine learning", "monitoring", "networking", etc
+
+The `dataInputSchema` property can be used to validate the workflow data input against a defined JSON Schema.
+This check should be done before any states are executed. `dataInputSchema` can have two different types.
+If it is an object type it has the following definition: 
+```json
+"dataInputSchema": {
+   "schema": "URL_to_json_schema",
+   "failOnValidationErrors": false
+}
+```
+It's `schema` property is an URI which points to the JSON schema used to validate the workflow data input.
+It' `failOnValidationErrors` property  determines if workflow execution should continue in case of validation
+errors. The default value of `failOnValidationErrors` is `true`.
+If `dataInputSchema` has the string type, it has the following definition:
+```json
+"dataInputSchema": "URL_to_json_schema"
+```
+In this case the `failOnValidationErrors` default value of `true` is assumed. 
 
 The `start` property defines the workflow starting information. For more information see the [start definition](#Start-Definition) section.
 


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tsurdilo@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Adds workflow dataInputSchema property. We had this in the past but thought to remove as noone made a request for it. There is one now. This allows users to validate the workflow data input against a JSON schema and to explicitly determine if workflow exec should continue in case of validation errors or now
**Special notes for reviewers**:

**Additional information (if needed):**