### PR TITLE
Rename switch state `default` to `defaultCondition` to avoid keyword …

### DIFF
--- a/comparisons/comparison-bpmn.md
+++ b/comparisons/comparison-bpmn.md
@@ -365,7 +365,7 @@ states:
   dataConditions:
   - condition: ${ .maxChecks > 0 }
     transition: SubflowRepeat
-  default:
+  defaultCondition:
     end: true
 ```
 

--- a/comparisons/comparison-google-cloud-workflows.md
+++ b/comparisons/comparison-google-cloud-workflows.md
@@ -807,7 +807,7 @@ a separate workflow definition with the "id" parameter set to "calledsubflow" in
                     "transition": "CallMedium"
                 }
             ],
-            "default": {
+            "defaultCondition": {
                 "transition": "CallLarge"
             }
         },

--- a/examples/README.md
+++ b/examples/README.md
@@ -620,7 +620,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
         }
      ],
      "eventTimeout": "PT1H",
-     "default": {
+     "defaultCondition": {
         "transition": "HandleNoVisaDecision"
      }
   },
@@ -683,7 +683,7 @@ states:
   - eventRef: visaRejectedEvent
     transition: HandleRejectedVisa
   eventTimeout: PT1H
-  default:
+  defaultCondition:
     transition: HandleNoVisaDecision
 - name: HandleApprovedVisa
   type: operation
@@ -770,7 +770,7 @@ If the applicants age is over 18 we start the application (subflow action). Othe
               "transition": "RejectApplication"
             }
          ],
-         "default": {
+         "defaultCondition": {
             "transition": "RejectApplication"
          }
       },
@@ -824,7 +824,7 @@ states:
     transition: StartApplication
   - condition: "${ .applicants | .age < 18 }"
     transition: RejectApplication
-  default:
+  defaultCondition:
     transition: RejectApplication
 - name: StartApplication
   type: operation
@@ -1169,7 +1169,7 @@ In the case job submission raises a runtime error, we transition to an Operation
         "transition": "JobFailed"
       }
     ],
-    "default": {
+    "defaultCondition": {
       "transition": "WaitForCompletion"
     }
   },
@@ -1273,7 +1273,7 @@ states:
     transition: JobSucceeded
   - condition: "${ .jobstatus == \"FAILED\" }"
     transition: JobFailed
-  default:
+  defaultCondition:
     transition: WaitForCompletion
 - name: JobSucceeded
   type: operation
@@ -1969,7 +1969,7 @@ And for denied credit check, for example:
                     "transition": "RejectApplication"
                 }
             ],
-            "default": {
+            "defaultCondition": {
                "transition": "RejectApplication"
             }
         },
@@ -2041,7 +2041,7 @@ states:
     transition: StartApplication
   - condition: "${ .creditCheck | .decision == \"Denied\" }"
     transition: RejectApplication
-  default:
+  defaultCondition:
     transition: RejectApplication
 - name: StartApplication
   type: operation
@@ -2567,7 +2567,7 @@ In our workflow definition then we can reference these files rather than definin
           "transition": "SendInsufficientResults"
         }
       ],
-      "default": {
+      "defaultCondition": {
         "transition": "SendPaymentSuccess"
       }
     },
@@ -2650,7 +2650,7 @@ states:
     transition: SendPaymentSuccess
   - condition: "${ .funds | .available == \"false\" }"
     transition: SendInsufficientResults
-  default:
+  defaultCondition:
     transition: SendPaymentSuccess
 - name: SendPaymentSuccess
   type: operation
@@ -3502,7 +3502,7 @@ And then our reusable sub-workflow which performs the checking of our car vitals
                }
             }
          ],
-         "default": {
+         "defaultCondition": {
             "transition": "WaitTwoMinutes"
          }
       },
@@ -3537,7 +3537,7 @@ And then our reusable sub-workflow which performs the checking of our car vitals
                }
             }
          ],
-         "default": {
+         "defaultCondition": {
             "transition": "CheckVitals"
          }
       }
@@ -3606,7 +3606,7 @@ states:
       produceEvents:
       - eventRef: DisplayFailedChecksOnDashboard
         data: "${ .evaluations }"
-  default:
+  defaultCondition:
     transition: WaitTwoMinutes
 - name: WaitTwoMinutes
   type: event
@@ -3625,7 +3625,7 @@ states:
     end:
       produceEvents:
       - eventRef: VitalsCheckingStopped
-  default:
+  defaultCondition:
     transition: CheckVitals
 events:
 - name: DisplayFailedChecksOnDashboard

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -24,6 +24,7 @@ _Status description:_
 | ✔️| Add workflow `key` and `annotations` properties | [spec doc](../specification.md) |
 | ✔️| Replaced SubFlow state with subflow action type | [spec doc](../specification.md) |
 | ✔️| Add workflow `dataInputSchema` property | [spec doc](../specification.md) |
+| ✔️| Rename switch state `default` to `defaultCondition` to avoid keyword conflicts for SDK's | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -981,9 +981,9 @@
           "type": "string",
           "description": "If eventConditions is used, defines the time period to wait for events (ISO 8601 format)"
         },
-        "default": {
+        "defaultCondition": {
           "description": "Default transition of the workflow if there is no matching data conditions. Can include a transition or end definition",
-          "$ref": "#/definitions/defaultdef"
+          "$ref": "#/definitions/defaultconditiondef"
         },
         "compensatedBy": {
           "type": "string",
@@ -1046,9 +1046,9 @@
           },
           "additionalItems": false
         },
-        "default": {
+        "defaultCondition": {
           "description": "Default transition of the workflow if there is no matching data conditions. Can include a transition or end definition",
-          "$ref": "#/definitions/defaultdef"
+          "$ref": "#/definitions/defaultconditiondef"
         },
         "compensatedBy": {
           "type": "string",
@@ -1071,9 +1071,9 @@
         "dataConditions"
       ]
     },
-    "defaultdef": {
+    "defaultconditiondef": {
       "type": "object",
-      "description": "Default definition. Can be either a transition or end definition",
+      "description": "DefaultCondition definition. Can be either a transition or end definition",
       "properties": {
         "transition": {
           "$ref": "#/definitions/transition"

--- a/specification.md
+++ b/specification.md
@@ -1129,7 +1129,7 @@ Our expression function definitions can now be referenced by workflow states whe
           "transition": "RejectApplication"
         }
      ],
-     "default": {
+     "defaultCondition": {
         "transition": "RejectApplication"
      }
   }
@@ -2881,7 +2881,7 @@ Once all actions have been performed, a transition to another state can occur.
 | [stateDataFilter](#State-data-filters) | State data filter | object | no |
 | [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
 | eventTimeout | If eventConditions is used, defines the time period to wait for events (ISO 8601 format). For example: "PT15M" (15 minutes), or "P2DT3H4M" (2 days, 3 hours and 4 minutes)| string | yes only if eventConditions is defined |
-| default | Default transition of the workflow if there is no matching data conditions or event timeout is reached. Can be a transition or end definition | object | yes |
+| defaultCondition | Default transition of the workflow if there is no matching data conditions or event timeout is reached. Can be a transition or end definition | object | yes |
 | [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
 | [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
 | [metadata](#Workflow-Metadata) | Metadata information| object | no |
@@ -2912,7 +2912,7 @@ Once all actions have been performed, a transition to another state can occur.
         }
      ],
      "eventTimeout": "PT1H",
-     "default": {
+     "defaultCondition": {
         "transition": "HandleNoVisaDecision"
      }
 }
@@ -2930,7 +2930,7 @@ eventConditions:
 - eventRef: visaRejectedEvent
   transition: HandleRejectedVisa
 eventTimeout: PT1H
-default:
+defaultCondition:
   transition: HandleNoVisaDecision
 ```
 
@@ -2953,13 +2953,13 @@ are ordered in both JSON and YAML. For example, let's say there are two `true` c
 Because A was defined first, its transition will be executed, not B's.
 
 In case of data-based conditions definition, switch state controls workflow transitions based on the states data.
-If no defined conditions can be matched, the state transitions is taken based on the `default` property.
+If no defined conditions can be matched, the state transitions is taken based on the `defaultCondition` property.
 This property can be either a `transition` to another workflow state, or an `end` definition meaning a workflow end.
 
 For event-based conditions, a switch state acts as a workflow wait state. It halts workflow execution 
 until one of the referenced events arrive, then making a transition depending on that event definition.
 If events defined in event-based conditions do not arrive before the states `eventTimeout` property expires, 
- state transitions are based on the defined `default` property.
+ state transitions are based on the defined `defaultCondition` property.
 
 #### <a name="switch-state-dataconditions"></a>Switch State: Data Conditions
 


### PR DESCRIPTION
…conflicts for SDK's

Signed-off-by: Jorgen Johnson <jorgen.johnson@oracle.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ✅  ] Specification
- [ ✅  ] Schema
- [ ✅  ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

The SDK's in several languages will have to do something special for this field (for example in the java sdk I believe it names the field '_default'). This adds extra complexity for maintainers of the SDK's and is a potential cause for some confusion for users of the SDK's.

**Special notes for reviewers**:

#345 

**Additional information (if needed):**