### PR TITLE
Update eventDataFilter to call out that the entire event can be accessed

### DIFF
--- a/comparisons/comparison-brigade.md
+++ b/comparisons/comparison-brigade.md
@@ -398,6 +398,7 @@ start: LogEventData
 events:
 - name: execEvent
   type: exec
+  dataOnly: false
 functions:
 - name: consoleFunction
   type: console
@@ -408,7 +409,7 @@ states:
   - eventRefs:
     - execEvent
     eventDataFilter:
-      results: "${ .event }"
+      toStateData: "${ .event }"
     actions:
     - name: eventInfoAction
       functionRef:
@@ -490,7 +491,7 @@ states:
   - eventRefs:
     - execEvent
     eventDataFilter:
-      data: "${ .event }"
+      toStateData: "${ .event }"
     actions:
     - name: helloAction
       actionDataFilter:
@@ -565,6 +566,7 @@ start: ExecEventState
 events:
 - name: execEvent
   type: exec
+  dataOnly: false
 - name: nextEvent
   type: next
   kind: produced
@@ -579,7 +581,7 @@ states:
     - execEvent
     actions: []
     eventDataFilter:
-      data: "${ .execEvent }"
+      toStateData: "${ .execEvent }"
   transition:
     nextState: NextEventState
     produceEvents:
@@ -597,7 +599,7 @@ states:
   - eventRefs:
     - nextEvent
     eventDataFilter:
-      data: "${ .nextEvent }"
+      toStateData: "${ .nextEvent }"
     actions:
     - name: consoleLogAction
       functionRef:

--- a/examples/README.md
+++ b/examples/README.md
@@ -317,7 +317,8 @@ filters what is selected to be the state data output which then becomes the work
      "onEvents": [{
          "eventRefs": ["GreetingEvent"],
          "eventDataFilter": {
-            "data": "${ .data.greet }"
+            "data": "${ .greet }",
+            "toStateData": "${ .greet }"
          },
          "actions":[  
             {  
@@ -363,7 +364,8 @@ states:
   - eventRefs:
     - GreetingEvent
     eventDataFilter:
-      data: "${ .data.greet }"
+      data: "${ .greet }"
+      toStateData: "${ .greet }"
     actions:
     - functionRef:
         refName: greetingFunction
@@ -3224,7 +3226,7 @@ the data for an hour, send report, and so on.
             }
           ],
           "eventDataFilter": {
-            "data": "${ .readings }"
+            "toStateData": "${ .readings }"
           }
         }
       ],
@@ -3307,7 +3309,7 @@ states:
     - functionRef:
         refName: LogReading
     eventDataFilter:
-      data: "${ .readings }"
+      toStateData: "${ .readings }"
   end: true
 - name: GenerateReport
   type: operation

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -31,6 +31,7 @@ _Status description:_
 | ✔️| Add subflow actions `version` property | [spec doc](../specification.md) |
 | ✔️| Renamed `schemaVersion` to `specVersion` and it is now a required parameter | [spec doc](../specification.md) |
 | ✔️| Add GraphQL support for function definitions | [spec doc](../specification.md) |
+| ✔️| Allow eventDataFilter to access entire event | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -31,7 +31,7 @@ _Status description:_
 | ✔️| Add subflow actions `version` property | [spec doc](../specification.md) |
 | ✔️| Renamed `schemaVersion` to `specVersion` and it is now a required parameter | [spec doc](../specification.md) |
 | ✔️| Add GraphQL support for function definitions | [spec doc](../specification.md) |
-| ✔️| Allow eventDataFilter to access entire event | [spec doc](../specification.md) |
+| ✔️| Added "dataOnly" property to Event Definitions (allow event data filters to access entire event) | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/schema/events.json
+++ b/schema/events.json
@@ -61,6 +61,11 @@
           },
           "additionalItems": false
         },
+        "dataOnly": {
+          "type": "boolean",
+          "default": true,
+          "description": "If `true`, only the Event payload is accessible to consuming Workflow states. If `false`, both event payload and context attributes should be accessible "
+        },
         "metadata": {
           "$ref": "common.json#/definitions/metadata",
           "description": "Metadata information"

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1679,11 +1679,11 @@
       "properties": {
         "data": {
           "type": "string",
-          "description": "Workflow expression that filters of the event data (payload)"
+          "description": "Workflow expression that filters the received event/payload (default: '${ . }')"
         },
         "toStateData": {
           "type": "string",
-          "description": " Workflow expression that selects a state data element to which the event payload should be added/merged into. If not specified, denotes, the top-level state data element."
+          "description": " Workflow expression that selects a state data element to which the filtered event should be added/merged into. If not specified, denotes, the top-level state data element."
         }
       },
       "additionalProperties": false,

--- a/specification.md
+++ b/specification.md
@@ -536,9 +536,9 @@ Here is an example using an event filter:
 <img src="media/spec/event-data-filter-example1.png" height="400px" alt="Event Data Filter Example"/>
 </p>
 
-Note that the data input to the Event data filters depends on `dataOnly` of the associated [Event definition](#Event-Definition).
-If this property is set to `true`, expressions are evaluated against the event payload (the `data` only). If it is set to 
-false the expressions should be evaluated against the entire CloudEvent data (including its context attributes).
+Note that the data input to the Event data filters depends on the `dataOnly` property of the associated [Event definition](#Event-Definition).
+If this property is not defined (has default value of `true`), Event data filter expressions are evaluated against the event payload (the CloudEvents `data` attribute only). If it is set to
+`false`, the expressions should be evaluated against the entire CloudEvent (including its context attributes).
 
 #### Using multiple data filters
 

--- a/specification.md
+++ b/specification.md
@@ -536,6 +536,10 @@ Here is an example using an event filter:
 <img src="media/spec/event-data-filter-example1.png" height="400px" alt="Event Data Filter Example"/>
 </p>
 
+Note that the data input to the Event data filters depends on `dataOnly` of the associated [Event definition](#Event-Definition).
+If this property is set to `true`, expressions are evaluated against the event payload (the `data` only). If it is set to 
+false the expressions should be evaluated against the entire CloudEvent data (including its context attributes).
+
 #### Using multiple data filters
 
 As [Event states](#Event-State) can take advantage of all defined data filters. In the example below, we define
@@ -1934,6 +1938,7 @@ defined via the `parameters` property in [function definitions](#FunctionRef-Def
 | type | CloudEvent type | string | yes |
 | kind | Defines the event is either `consumed` or `produced` by the workflow. Default is `consumed` | enum | no |
 | [correlation](#Correlation-Definition) | Define event correlation rules for this event. Only used for consumed events | array | no |
+| dataOnly | If `true` (default value), only the Event payload is accessible to consuming Workflow states. If `false`, both event payload and context attributes should be accessible | boolean | no |
 | [metadata](#Workflow-Metadata) | Metadata information | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -2137,6 +2142,10 @@ says that these events must all have a context attribute named "department" with
 
 This allows developers to write orchestration workflows that are specifically targeted to patients that are in the hospital urgent care unit, 
 for example.
+
+The `dataOnly` property deals with what Event data is accessible by the consuming Workflow states.
+If its value is `true` (default value), only the Event payload is accessible to consuming Workflow states. 
+If `false`, both Event payload and context attributes should be accessible.
 
 #### Correlation Definition
 


### PR DESCRIPTION
Signed-off-by: Jorgen Johnson <jorgen.johnson@oracle.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ✅  ] Specification
- [ ✅  ] Schema
- [ ✅  ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

Add some clarity on what eventDataFilter can access from the event. 

**Special notes for reviewers**:

If you look at the examples that were updated, there were several that were already assuming that the whole event was being added to stateData, hence why there are several examples where I added `data: ${ . }`.

It seems that a good number of the examples were already acting as if this was the case that the whole event would be filtered (not just the payload).  I think, given the number of examples that were assuming this, that we should reconsider whether the default 'data' value should be `${.data}` or just `${ . }`.

**Additional information (if needed):**