### PR TITLE
Update Parallel state completionType values/description

### DIFF
--- a/comparisons/comparison-argo.md
+++ b/comparisons/comparison-argo.md
@@ -172,7 +172,7 @@ states:
   transition: parallelhello
 - name: parallelhello
   type: parallel
-  completionType: and
+  completionType: allOf
   branches:
   - name: hello2a-branch
     actions:
@@ -273,7 +273,7 @@ states:
   transition: parallelecho
 - name: parallelecho
   type: parallel
-  completionType: and
+  completionType: allOf
   branches:
   - name: B-branch
     actions:

--- a/examples/README.md
+++ b/examples/README.md
@@ -485,7 +485,7 @@ states:
 #### Description
 
 This example uses a parallel state to execute two branches (simple wait states) at the same time.
-The completionType type is set to "and", which means the parallel state has to wait for both branches
+The completionType type is set to "allOf", which means the parallel state has to wait for both branches
 to finish execution before it can transition (end workflow execution in this case as it is an end state).
 
 #### Workflow Diagram
@@ -515,7 +515,7 @@ to finish execution before it can transition (end workflow execution in this cas
   {  
      "name": "ParallelExec",
      "type": "parallel",
-     "completionType": "and",
+     "completionType": "allOf",
      "branches": [
         {
           "name": "ShortDelayBranch",
@@ -544,7 +544,7 @@ start: ParallelExec
 states:
 - name: ParallelExec
   type: parallel
-  completionType: and
+  completionType: allOf
   branches:
   - name: ShortDelayBranch
     workflowId: shortdelayworkflowid

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -26,6 +26,7 @@ _Status description:_
 | ✔️| Add workflow `dataInputSchema` property | [spec doc](../specification.md) |
 | ✔️| Rename switch state `default` to `defaultCondition` to avoid keyword conflicts for SDK's | [spec doc](../specification.md) |
 | ✔️| Add description of additional properties | [spec doc](../specification.md) |
+| ✔️| Rename Parallel `completionType` values | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -840,21 +840,20 @@
         "completionType": {
           "type": "string",
           "enum": [
-            "and",
-            "xor",
-            "n_of_m"
+            "allOf",
+            "atLeast"
           ],
           "description": "Option types on how to complete branch execution.",
-          "default": "and"
+          "default": "allOf"
         },
-        "n": {
+        "numCompleted": {
           "type": [
             "number",
             "string"
           ],
           "minimum": 0,
           "minLength": 0,
-          "description": "Used when completionType is set to 'n_of_m' to specify the 'N' value"
+          "description": "Used when completionType is set to 'atLeast' to specify the minimum number of branches that must complete before the state will transition."
         },
         "onErrors": {
           "type": "array",

--- a/specification.md
+++ b/specification.md
@@ -3172,8 +3172,8 @@ Delay state waits for a certain amount of time before transitioning to a next st
 | name | State name | string | yes |
 | type | State type | string | yes |
 | [branches](#parallel-state-branch) | List of branches for this parallel state| array | yes |
-| completionType | Option types on how to complete branch execution. Default is "and" | enum | no |
-| n | Used when branchCompletionType is set to `n_of_m` to specify the `n` value. | string or number | no |
+| completionType | Option types on how to complete branch execution. Default is "allOf" | enum | no |
+| numCompleted | Used when branchCompletionType is set to `atLeast` to specify the least number of branches that must complete in order for the state to transition/end. | string or number | no |
 | [stateDataFilter](#State-data-filters) | State data filter | object | no |
 | [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
 | [transition](#Transitions) | Next transition of the workflow after all branches have completed execution | object | yes (if end is not defined) |
@@ -3197,7 +3197,7 @@ Delay state waits for a certain amount of time before transitioning to a next st
  {  
      "name":"ParallelExec",
      "type":"parallel",
-     "completionType": "and",
+     "completionType": "allOf",
      "branches": [
         {
           "name": "Branch1",
@@ -3236,7 +3236,7 @@ Delay state waits for a certain amount of time before transitioning to a next st
 ```yaml
 name: ParallelExec
 type: parallel
-completionType: and
+completionType: allOf
 branches:
 - name: Branch1
   actions:
@@ -3261,14 +3261,13 @@ end: true
 
 Parallel state defines a collection of `branches` that are executed in parallel.
 A parallel state can be seen a state which splits up the current workflow instance execution path
-into multiple ones, one for each of each branch. These execution paths are performed in parallel
+into multiple ones, one for each branch. These execution paths are performed in parallel
 and are joined back into the current execution path depending on the defined `completionType` parameter value.
 
 The "completionType" enum specifies the different ways of completing branch execution:
-* and: All branches must complete execution before state can perform its transition. This is the default value in case this parameter is not defined in the parallel state definition.
-* xor: State can transition when one of the branches completes execution
-* n_of_m: State can transition once `n` number of branches have completed execution. In this case you should also
-specify the `n` property to define this number.
+* allOf: All branches must complete execution before the state can transition/end. This is the default value in case this parameter is not defined in the parallel state definition.
+* atLeast: State can transition/end once at least the specified number of branches have completed execution. In this case you must also
+specify the `numCompleted` property to define this number.
 
 Exceptions may occur during execution of branches of the Parallel state, this is described in detail in [this section](#parallel-state-exceptions).
 


### PR DESCRIPTION
Signed-off-by: Jorgen Johnson <jorgenj@gmail.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ✅  ] Specification
- [ ✅  ] Schema
- [ ✅  ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

Update the values/descriptions related to Parallel state's completionType parameter:

Reasoning:

and & xor are most often encountered as boolean operators between 2 distinct values, so it's a bit confusing in this context where there are N parallel threads (not just 2). n_of_m is a straight-forward choice, but the corresponding n field name is very ambiguous, it gives no clear context to it's meaning on it's own.

https://github.com/serverlessworkflow/specification/issues/346

**Special notes for reviewers**:

**Additional information (if needed):**