### PR TITLE
Remove workflowId from Parallel state

### DIFF
--- a/comparisons/comparison-cadence.md
+++ b/comparisons/comparison-cadence.md
@@ -298,9 +298,11 @@ version: '1.0'
 start: GreetingSubFlow
 states:
 - name: GreetingSubFlow
-  type: subflow
-  workflowId: subflowgreet
-  waitForCompletion: false
+  type: operation
+  actions:
+  - subFlowRef:
+    workflowId: subflowgreet
+    waitForCompletion: false
   end: true
 functions:
 - name: greetingfunction

--- a/examples/README.md
+++ b/examples/README.md
@@ -519,11 +519,15 @@ to finish execution before it can transition (end workflow execution in this cas
      "branches": [
         {
           "name": "ShortDelayBranch",
-          "workflowId": "shortdelayworkflowid"
+          "actions": [{
+            "subFlowRef": "shortdelayworkflowid"
+          }]
         },
         {
           "name": "LongDelayBranch",
-          "workflowId": "longdelayworkflowid"
+          "actions": [{
+            "subFlowRef": "longdelayworkflowid"
+          }]
         }
      ],
      "end": true
@@ -547,9 +551,11 @@ states:
   completionType: allOf
   branches:
   - name: ShortDelayBranch
-    workflowId: shortdelayworkflowid
+    actions: 
+    - subFlowRef: shortdelayworkflowid
   - name: LongDelayBranch
-    workflowId: longdelayworkflowid
+    actions:
+    - subFlowRef: longdelayworkflowid
   end: true
 ```
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -27,7 +27,7 @@ _Status description:_
 | ✔️| Rename switch state `default` to `defaultCondition` to avoid keyword conflicts for SDK's | [spec doc](../specification.md) |
 | ✔️| Add description of additional properties | [spec doc](../specification.md) |
 | ✔️| Rename Parallel `completionType` values | [spec doc](../specification.md) |
-| ✔️| Rename `workflowId` from ParallelState (use subFlow action instead) | [spec doc](../specification.md) |
+| ✔️| Removed `workflowId` from ParallelState and ForEach states (use subFlow action instead) | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -27,6 +27,7 @@ _Status description:_
 | ✔️| Rename switch state `default` to `defaultCondition` to avoid keyword conflicts for SDK's | [spec doc](../specification.md) |
 | ✔️| Add description of additional properties | [spec doc](../specification.md) |
 | ✔️| Rename Parallel `completionType` values | [spec doc](../specification.md) |
+| ✔️| Rename `workflowId` from ParallelState (use subFlow action instead) | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -449,7 +449,7 @@
           "properties": {
             "waitForCompletion": {
               "type": "boolean",
-              "default": false,
+              "default": true,
               "description": "Workflow execution must wait for sub-workflow to finish before continuing"
             },
             "workflowId": {
@@ -479,26 +479,12 @@
             "$ref": "#/definitions/action"
           },
           "additionalItems": false
-        },
-        "workflowId": {
-          "type": "string",
-          "description": "Unique Id of a workflow to be executed in this branch"
         }
       },
       "additionalProperties": false,
-      "oneOf": [
-        {
-          "required": [
-            "name",
-            "workflowId"
-          ]
-        },
-        {
-          "required": [
-            "name",
-            "actions"
-          ]
-        }
+      "required": [
+        "name",
+        "actions"
       ]
     },
     "delaystate": {
@@ -1408,31 +1394,11 @@
           "type",
           "inputCollection",
           "iterationParam",
-          "workflowId"
+          "actions"
         ]
       },
       "else": {
         "oneOf": [
-          {
-            "required": [
-              "name",
-              "type",
-              "inputCollection",
-              "iterationParam",
-              "workflowId",
-              "end"
-            ]
-          },
-          {
-            "required": [
-              "name",
-              "type",
-              "inputCollection",
-              "iterationParam",
-              "workflowId",
-              "transition"
-            ]
-          },
           {
             "required": [
               "name",

--- a/specification.md
+++ b/specification.md
@@ -2556,7 +2556,7 @@ to the trigger/produced event.
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| waitForCompletion | If workflow execution must wait for sub-workflow to finish before continuing | boolean | yes |
+| waitForCompletion | If workflow execution must wait for sub-workflow to finish before continuing (default is `true`) | boolean | yes |
 | workflowId |Sub-workflow unique id | boolean | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -3276,8 +3276,7 @@ Exceptions may occur during execution of branches of the Parallel state, this is
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name | Branch name | string | yes |
-| [actions](#Action-Definition) | Actions to be executed in this branch | array | yes if workflowId is not defined |
-| workflowId | Unique Id of a workflow to be executed in this branch | string | yes if actions is not defined |
+| [actions](#Action-Definition) | Actions to be executed in this branch | array | yes |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3352,7 +3351,7 @@ If the parallel states branch defines actions, all exceptions that arise from ex
  are propagated to the parallel state 
 and can be handled with the parallel states `onErrors` definition.
 
-If the parallel states defines a `workflowId`, exceptions that occur during execution of the called workflow
+If the parallel states defines a subflow action, exceptions that occur during execution of the called workflow
 can chose to handle exceptions on their own. All unhandled exceptions from the called workflow
 execution however are propagated back to the parallel state and can be handled with the parallel states
 `onErrors` definition.
@@ -3681,10 +3680,6 @@ It should contain the unique element of the `inputCollection` array and passed a
 `iterationParam` should be created for each iteration, so it can be referenced/used in defined actions / workflow data input.
 
 The `actions` property defines actions to be executed in each state iteration.
-
-If actions are not defined, you can specify the `workflowid` to reference a workflow id which needs to be executed
-for each iteration. Note that `workflowid` should not be the same as the workflow id of the workflow where the ForEach state
-is defined.
 
 Let's take a look at an example:
 


### PR DESCRIPTION
Remove workflowId from Parallel state (use subFlow actions instead).

Signed-off-by: Jorgen Johnson <jorgenj@gmail.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ✅  ] Specification
- [ ✅  ] Schema
- [ ✅  ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

I found some updates that I missed in the recent subFlowRef change that should be cleaned up.  Apologies for missing this in the previous PR.

**Special notes for reviewers**:

**Additional information (if needed):**