### PR TITLE
Fixing waitForCompletion default value in schema

### DIFF
--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -449,7 +449,7 @@
           "properties": {
             "waitForCompletion": {
               "type": "boolean",
-              "default": false,
+              "default": true,
               "description": "Workflow execution must wait for sub-workflow to finish before continuing"
             },
             "workflowId": {

--- a/specification.md
+++ b/specification.md
@@ -2556,7 +2556,7 @@ to the trigger/produced event.
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| waitForCompletion | If workflow execution must wait for sub-workflow to finish before continuing | boolean | yes |
+| waitForCompletion | If workflow execution must wait for sub-workflow to finish before continuing (default is `true`) | boolean | yes |
 | workflowId |Sub-workflow unique id | boolean | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x ] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
The specification text says that default value of waitForCompletion is "true" (which it should be) but schema had it as "false". Fixing
**Special notes for reviewers**:

**Additional information (if needed):**