### PR TITLE
Adding Antonio Mendoza Pérez to list of project maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # They will be requested for
 # review when someone opens a pull request.
-*       @tsurdilo @ricardozanini @manuelstein @cdavernas
+*       @tsurdilo @ricardozanini @manuelstein @cdavernas @antmendoza

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,7 @@
 * [Tihomir Surdilovic](https://github.com/tsurdilo)
 * [Ricardo Zanini](https://github.com/ricardozanini)
 * [Charles d'Avernas](https://github.com/cdavernas)
+* [Antonio Mendoza Pérez](https://github.com/antmendoza)
 
 # Maintainers Mailing list
 [cncf-serverlessws-maintainers](mailto:cncf-serverlessws-maintainers@lists.cncf.io)

--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,7 @@ maintainers:
   - manuelstein
   - ricardozanini
   - cdavernas
+  - antmendoza
 reviewers:
   - singhkays
   - jorgenj


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ x] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Serverless Workflow maintainers voted to add Antonio as part of the project maintainer group.

Antonio has been a great addition to our project. He is leading the TypeScript SDK.

Thanks Antonio!

**Special notes for reviewers**:

**Additional information (if needed):**