### PR TITLE
[0.6.x] Moves functionref to its own definition (#384)

### DIFF
--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -290,31 +290,8 @@
           "description": "Unique action definition name"
         },
         "functionRef": {
-          "oneOf": [
-            {
-              "type": "string",
-              "description": "Name of the referenced function",
-              "minLength": 1
-            },
-            {
-              "type": "object",
-              "description": "Function Reference",
-              "properties": {
-                "refName": {
-                  "type": "string",
-                  "description": "Name of the referenced function"
-                },
-                "arguments": {
-                  "type": "object",
-                  "description": "Function arguments"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "refName"
-              ]
-            }
-          ]
+          "description": "References a function to be invoked",
+          "$ref": "#/definitions/functionref"
         },
         "eventRef": {
           "description": "References a 'trigger' and 'result' reusable event definitions",
@@ -339,6 +316,33 @@
         {
           "required": [
             "eventRef"
+          ]
+        }
+      ]
+    },
+    "functionref": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Name of the referenced function",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "description": "Function Reference",
+          "properties": {
+            "refName": {
+              "type": "string",
+              "description": "Name of the referenced function"
+            },
+            "arguments": {
+              "type": "object",
+              "description": "Function arguments/inputs"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "refName"
           ]
         }
       ]


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [ x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
cherry-pick to 0.6.x
**Special notes for reviewers**:

**Additional information (if needed):**