### PR TITLE
Updated interrupt default property value to true

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2926,7 +2926,6 @@ This example shows the use of the workflow [execTimeout definition](../specifica
   "start": "StartNewOrder",
   "execTimeout": {
     "duration": "PT30D",
-    "interrupt": true,
     "runBefore": "CancelOrder"
   },
   "states": [
@@ -3086,7 +3085,6 @@ specVersion: '0.7'
 start: StartNewOrder
 execTimeout:
   duration: PT30D
-  interrupt: true
   runBefore: CancelOrder
 states:
 - name: StartNewOrder

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -33,7 +33,7 @@ _Status description:_
 | ✔️| Add GraphQL support for function definitions | [spec doc](../specification.md) |
 | ✔️| Added "dataOnly" property to Event Definitions (allow event data filters to access entire event) | [spec doc](../specification.md) |
 | ✔️| Added support for Secrets and Constants | [spec doc](../specification.md) |
-| ✔️| Changed default value of execution timeout `interrupt` property | [spec doc](../specification.md) |
+| ✔️| Changed default value of execution timeout `interrupt` property. This is a non-backwards compatible changes. | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -33,6 +33,7 @@ _Status description:_
 | ✔️| Add GraphQL support for function definitions | [spec doc](../specification.md) |
 | ✔️| Added "dataOnly" property to Event Definitions (allow event data filters to access entire event) | [spec doc](../specification.md) |
 | ✔️| Added support for Secrets and Constants | [spec doc](../specification.md) |
+| ✔️| Changed default value of execution timeout `interrupt` property | [spec doc](../specification.md) |
 | 🚩 | Workflow invocation bindings |  |
 | 🚩 | CE Subscriptions & Discovery |  |
 | 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) | 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -211,13 +211,13 @@
       "properties": {
         "duration": {
           "type": "string",
-          "description": "Timeout duration (ISO 8601 duration format)",
+          "description": "T imeout duration (ISO 8601 duration format)",
           "minLength": 1
         },
         "interrupt": {
           "type": "boolean",
-          "description": "If `false`, workflow instance is allowed to finish current execution. If `true`, current workflow execution is abrupted.",
-          "default": false
+          "description": "If `false`, workflow instance is allowed to finish its current execution paths. If `true`, current workflow execution is stopped immediately. Default is `true`",
+          "default": true
         },
         "runBefore": {
           "type": "string",

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -211,7 +211,7 @@
       "properties": {
         "duration": {
           "type": "string",
-          "description": "T imeout duration (ISO 8601 duration format)",
+          "description": "Timeout duration (ISO 8601 duration format)",
           "minLength": 1
         },
         "interrupt": {

--- a/specification.md
+++ b/specification.md
@@ -1852,7 +1852,7 @@ Note the same can be also specified using workflow metadata, which is the prefer
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | duration | Timeout duration (ISO 8601 duration format) | string | yes |
-| interrupt | If `false`, workflow instance is allowed to finish current execution. If `true`, current workflow execution is stopped immediately. Default is `false`  | boolean | no |
+| interrupt | If `false`, workflow instance is allowed to finish its current execution paths. If `true`, current workflow execution is stopped immediately. Default is `true`  | boolean | no |
 | runBefore | Name of a workflow state to be executed before workflow instance is terminated | string | no |
 
 
@@ -1891,8 +1891,11 @@ runBefore: createandsendreport
 The `duration` property defines the time duration of the execution timeout. Once a workflow instance is created,
 and the amount of the defined time is reached, the workflow instance should be terminated.
 
-The `interrupt` property defines if the currently running instance should be allowed to finish its current 
-execution flow before it needs to be terminated. If set to `true`, the current instance execution should stop immediately.
+The `interrupt` property defines if the running workflow instance should be allowed to finish its current 
+execution flow before it needs to be terminated.
+The default value of `interrupt` is `true`, meaning that the currently workflow execution should be terminated.
+If set to `false`, the current execution path of the workflow execution should have a chance to complete (reach 
+an end definition).
 
 The `runBefore` property defines a name of a workflow state to be executed before workflow instance is terminated.
 States referenced by `runBefore` (as well as any other states that they transition to) must obey following rules:


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x ] Specification
- [x ] Schema
- [x ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Updated the default value of "interrupt" to true, for exectimeout definition. 
This makes more sense as user should set this property to false if they want the current exec paths to allow to finish before terminating the workflow instance
**Special notes for reviewers**:

This is a BREAKING CHANGE from 0.6 version. 

**Additional information (if needed):**