### PR TITLE
add required usedForCompensation for subflowstate (branch 0.6.x)

### DIFF
--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1196,7 +1196,10 @@
           "usedForCompensation": {
             "const": true
           }
-        }
+        },
+        "required": [
+          "usedForCompensation"
+        ]
       },
       "then": {
         "required": [


### PR DESCRIPTION

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [X] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
add required usedForCompensation for subflowstate, 

[in the previous PR](https://github.com/serverlessworkflow/specification/pull/405) I cherry-picked the commit from the main branch but subflowstate is not part of the specification on 0.7 version.

Added here required usedForCompensation for subflowstate


**Special notes for reviewers**:

**Additional information (if needed):**