### PR TITLE
Rename Delay state to Sleep state and rename timeDelay to duration pr…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1155,8 +1155,8 @@ In the case job submission raises a runtime error, we transition to an Operation
   },
   {
       "name": "WaitForCompletion",
-      "type": "delay",
-      "timeDelay": "PT5S",
+      "type": "sleep",
+      "duration": "PT5S",
       "transition": "GetJobStatus"
   },
   {
@@ -1276,8 +1276,8 @@ states:
   - subFlowRef: handleJobSubmissionErrorWorkflow
   end: true
 - name: WaitForCompletion
-  type: delay
-  timeDelay: PT5S
+  type: sleep
+  delay: PT5S
   transition: GetJobStatus
 - name: GetJobStatus
   type: operation
@@ -3856,12 +3856,12 @@ For the sake of the example we assume the functions and event definitions are de
                }
             }
          ],
-         "transition": "Wait two weeks"
+         "transition": "Sleep two weeks"
       },
       {
-         "name": "Wait two weeks",
-         "type": "delay",
-         "timeDelay": "PT2W",
+         "name": "Sleep two weeks",
+         "type": "sleep",
+         "duration": "PT2W",
          "transition": "Get Book Status"
       },
       {
@@ -3953,10 +3953,10 @@ states:
       arguments:
         bookid: "${ .book.id }"
         lender: "${ .lender }"
-  transition: Wait two weeks
-- name: Wait two weeks
-  type: delay
-  timeDelay: PT2W
+  transition: Sleep two weeks
+- name: Sleep two weeks
+  type: sleep
+  duration: PT2W
   transition: Get Book Status
 - name: Check Out Book
   type: operation

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -40,10 +40,21 @@ _Status description:_
 | ✔️| Temporarily removed `waitForCompletion` for subflows | [spec doc](../specification.md) |
 | ✔️| Added function definition support for OData | [spec doc](../specification.md) |
 | ✔️| Added function definition support for AsyncAPI | [spec doc](../specification.md) |
+| ✔️| Rename Delay state to Sleep state | [spec doc](../specification.md) |
 | ✏️ | AsyncAPI operation support |  |
 | ✏️ | OData function definition support |  |
 | ✏️ | Update to retries - state specific rather than error specific |  |
 | ✏️ | Add batching and sync option for Foreach state |  |
+| 🚩 | Workflow invocation bindings |  |
+| 🚩 | CE Subscriptions & Discovery |  |
+| 🚩 | Error types | [issue](https://github.com/serverlessworkflow/specification/issues/200) |
+| 🚩 | Uniqueness constraint for workflows | [issue](https://github.com/serverlessworkflow/specification/issues/146) |
+| 🚩 | OpenAPI endpoint selection |  |
+| 🚩 | Data triggers |  |
+| 🚩 | JSON schema checks |  |
+| 🚩 | Start discussions on Serverless Workflow Technology Compatibility Kit (TCK) |  |
+| ✏️ | Specification primer | [google doc](https://docs.google.com/document/d/11rD3Azj63G2Si0VpokSpr-1ib3mFRFHSwN6tJb-0LQM/edit#heading=h.paewfy83tetm) continued in [wiki](https://github.com/serverlessworkflow/specification/wiki) |
+>>>>>>> Rename Delay state to Sleep state and rename timeDelay to duration property
 
 ## <a name="v06"></a> v0.6
 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -126,8 +126,8 @@
       "items": {
         "anyOf": [
           {
-            "title": "Delay State",
-            "$ref": "#/definitions/delaystate"
+            "title": "Sleep State",
+            "$ref": "#/definitions/sleepstate"
           },
           {
             "title": "Event State",
@@ -503,9 +503,9 @@
         "actions"
       ]
     },
-    "delaystate": {
+    "sleepstate": {
       "type": "object",
-      "description": "Causes the workflow execution to delay for a specified duration",
+      "description": "Causes the workflow execution to sleep for a specified duration",
       "properties": {
         "id": {
           "type": "string",
@@ -518,7 +518,7 @@
         },
         "type": {
           "type": "string",
-          "const": "delay",
+          "const": "sleep",
           "description": "State type"
         },
         "end": {
@@ -529,9 +529,9 @@
           "description": "State data filter",
           "$ref": "#/definitions/statedatafilter"
         },
-        "timeDelay": {
+        "duration": {
           "type": "string",
-          "description": "Amount of time (ISO 8601 format) to delay"
+          "description": "Duration (ISO 8601 duration format) to sleep"
         },
         "timeouts": {
           "type": "object",
@@ -553,7 +553,7 @@
           "additionalItems": false
         },
         "transition": {
-          "description": "Next transition of the workflow after the time delay",
+          "description": "Next transition of the workflow after the workflow sleep",
           "$ref": "#/definitions/transition"
         },
         "compensatedBy": {
@@ -585,7 +585,7 @@
         "required": [
           "name",
           "type",
-          "timeDelay"
+          "duration"
         ]
       },
       "else": {
@@ -594,7 +594,7 @@
             "required": [
               "name",
               "type",
-              "timeDelay",
+              "duration",
               "end"
             ]
           },
@@ -602,7 +602,7 @@
             "required": [
               "name",
               "type",
-              "timeDelay",
+              "duration",
               "transition"
             ]
           }

--- a/specification.md
+++ b/specification.md
@@ -39,7 +39,7 @@
       - [Event State](#event-state)
       - [Operation State](#operation-state)
       - [Switch State](#switch-state)
-      - [Delay State](#delay-state)
+      - [Sleep State](#sleep-state)
       - [Parallel State](#parallel-state)
       - [Inject State](#inject-state)
       - [ForEach State](#foreach-state)
@@ -2049,7 +2049,7 @@ Serverless Workflow defines the following Workflow States:
 | **[Event](#Event-State)** | Define events that trigger action execution | yes | yes | yes | yes | yes | no | yes | yes |
 | **[Operation](#Operation-State)** | Execute one or more actions | no | yes | yes | yes | yes | no | yes | yes |
 | **[Switch](#Switch-State)** | Define data-based or event-based workflow transitions | no | yes | no | yes | no | yes | yes | no |
-| **[Delay](#Delay-State)** | Delay workflow execution | no | yes | no | yes | no | no | yes | yes |
+| **[Sleep](#Sleep-State)** | Sleep workflow execution for a specific time duration | no | yes | no | yes | no | no | yes | yes |
 | **[Parallel](#Parallel-State)** | Causes parallel execution of branches (set of states) | no | yes | no | yes | yes | no | yes | yes |
 | **[Inject](#Inject-State)** | Inject static data into state data | no | yes | no | yes | no | no | yes | yes |
 | **[ForEach](#ForEach-State)** | Parallel execution of states for each element of a data array | no | yes | no | yes | yes | no | yes | yes |
@@ -2374,18 +2374,18 @@ The `timeouts` property can be used to define state specific timeout settings. S
 `stateExecTimeout` setting. If `eventConditions` is defined, the switch state can also define the
 `eventTimeout` property. For more information on workflow timeouts reference the [Workflow Timeouts](#Workflow-Timeouts) section.
 
-##### Delay State
+##### Sleep State
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | id | Unique state id | string | no |
-| name |State name | string | yes |
-| type |State type | string | yes |
-| timeDelay |Amount of time (ISO 8601 format) to delay when in this state. For example: "PT15M" (delay 15 minutes), or "P2DT3H4M" (delay 2 days, 3 hours and 4 minutes) | integer | yes |
+| name | State name | string | yes |
+| type | State type | string | yes |
+| duration | Duration (ISO 8601 duration format) to sleep. For example: "PT15M" (sleep 15 minutes), or "P2DT3H4M" (sleep 2 days, 3 hours and 4 minutes) | integer | yes |
 | [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |
 | [stateDataFilter](#State-data-filters) | State data filter | object | no |
 | [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
-| [transition](#Transitions) | Next transition of the workflow after the delay | object | yes (if end is not defined) |
+| [transition](#Transitions) | Next transition of the workflow after the sleep | object | yes (if end is not defined) |
 | [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
 | [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
 | [end](#End-Definition) |If this state an end state | object | no |
@@ -2403,9 +2403,9 @@ The `timeouts` property can be used to define state specific timeout settings. S
 
 ```json
 {
-      "name": "DelayState",
-      "type": "delay",
-      "timeDelay": "PT5S",
+      "name": "SleepFiveSeconds",
+      "type": "sleep",
+      "duration": "PT5S",
       "transition": "GetJobStatus"
 }
 ```
@@ -2414,9 +2414,9 @@ The `timeouts` property can be used to define state specific timeout settings. S
 <td valign="top">
 
 ```yaml
-name: DelayState
-type: delay
-timeDelay: PT5S
+name: SleepFiveSeconds
+type: sleep
+duration: PT5S
 transition: GetJobStatus
 ```
 
@@ -2426,7 +2426,9 @@ transition: GetJobStatus
 
 </details>
 
-Delay state waits for a certain amount of time before transitioning to a next state. The amount of delay is specified by the `timeDelay` property in ISO 8601 format.
+Sleep state 
+suspends workflow execution for a given time duration. The delay is defined in its `duration` property using the ISO 8601 
+duration format.
 
 The `timeouts` property allows you to define state-specific timeouts.
 It can be used to define the `stateExecTimeout`. For more information on workflow timeouts


### PR DESCRIPTION
…operty

Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x ] Specification
- [x ] Schema
- [ x] Examples
- [ ] Extensions
- [ x] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Renames the Delay state to Sleep state. 
Renames the states timeDelay property to duration

Name of the state does not really depict what it does. Workflow execution is not "delayed". Workflow execution should
sleep until a defined time duration.

**Special notes for reviewers**:

**Additional information (if needed):**