### PR TITLE
Adding sleep object type prop to action definitions

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -41,7 +41,7 @@ _Status description:_
 | ✔️| Added function definition support for OData | [spec doc](../specification.md) |
 | ✔️| Added function definition support for AsyncAPI | [spec doc](../specification.md) |
 | ✔️| Rename Delay state to Sleep state | [spec doc](../specification.md) |
-| ✔️| Added 'sleepBefore' and 'sleepAfter' properties to function definitions | [spec doc](../specification.md) |
+| ✔️| Added 'sleepBefore' and 'sleepAfter' properties to action definition | [spec doc](../specification.md) |
 | ✏️ | AsyncAPI operation support |  |
 | ✏️ | OData function definition support |  |
 | ✏️ | Update to retries - state specific rather than error specific |  |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -41,7 +41,7 @@ _Status description:_
 | ✔️| Added function definition support for OData | [spec doc](../specification.md) |
 | ✔️| Added function definition support for AsyncAPI | [spec doc](../specification.md) |
 | ✔️| Rename Delay state to Sleep state | [spec doc](../specification.md) |
-| ✔️| Added 'sleepBefore' and 'sleepAfter' properties to action definition | [spec doc](../specification.md) |
+| ✔️| Added 'sleep' property to action definition | [spec doc](../specification.md) |
 | ✏️ | AsyncAPI operation support |  |
 | ✏️ | OData function definition support |  |
 | ✏️ | Update to retries - state specific rather than error specific |  |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -41,6 +41,7 @@ _Status description:_
 | ✔️| Added function definition support for OData | [spec doc](../specification.md) |
 | ✔️| Added function definition support for AsyncAPI | [spec doc](../specification.md) |
 | ✔️| Rename Delay state to Sleep state | [spec doc](../specification.md) |
+| ✔️| Added 'sleepBefore' and 'sleepAfter' properties to function definitions | [spec doc](../specification.md) |
 | ✏️ | AsyncAPI operation support |  |
 | ✏️ | OData function definition support |  |
 | ✏️ | Update to retries - state specific rather than error specific |  |
@@ -54,7 +55,7 @@ _Status description:_
 | 🚩 | JSON schema checks |  |
 | 🚩 | Start discussions on Serverless Workflow Technology Compatibility Kit (TCK) |  |
 | ✏️ | Specification primer | [google doc](https://docs.google.com/document/d/11rD3Azj63G2Si0VpokSpr-1ib3mFRFHSwN6tJb-0LQM/edit#heading=h.paewfy83tetm) continued in [wiki](https://github.com/serverlessworkflow/specification/wiki) |
->>>>>>> Rename Delay state to Sleep state and rename timeDelay to duration property
+
 
 ## <a name="v06"></a> v0.6
 

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -57,14 +57,6 @@
           "description": "References an auth definition name to be used to access to resource defined in the operation parameter",
           "minLength": 1
         },
-        "sleepBefore": {
-          "type": "string",
-          "description": "Amount of time (ISO 8601 duration format) to sleep before function invocation"
-        },
-        "sleepAfter": {
-          "type": "string",
-          "description": "Amount of time (ISO 8601 duration format) to sleep after function invocation"
-        },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"
         }

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -57,6 +57,14 @@
           "description": "References an auth definition name to be used to access to resource defined in the operation parameter",
           "minLength": 1
         },
+        "sleepBefore": {
+          "type": "string",
+          "description": "Amount of time (ISO 8601 duration format) to sleep before function invocation"
+        },
+        "sleepAfter": {
+          "type": "string",
+          "description": "Amount of time (ISO 8601 duration format) to sleep after function invocation"
+        },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"
         }

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -351,6 +351,14 @@
           "description": "References a sub-workflow to invoke",
           "$ref": "#/definitions/subflowref"
         },
+        "sleepBefore": {
+          "type": "string",
+          "description": "Amount of time (ISO 8601 duration format) to sleep before function/subflow invocation. Does not apply if 'eventRef' is defined."
+        },
+        "sleepAfter": {
+          "type": "string",
+          "description": "Amount of time (ISO 8601 duration format) to sleep after function/subflow invocation. Does not apply if 'eventRef' is defined."
+        },
         "actionDataFilter": {
           "description": "Action data filter",
           "$ref": "#/definitions/actiondatafilter"

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -184,6 +184,37 @@
     }
   ],
   "definitions": {
+    "sleep": {
+      "type": "object",
+      "properties": {
+        "before": {
+          "type": "string",
+          "description": "Amount of time (ISO 8601 duration format) to sleep before function/subflow invocation. Does not apply if 'eventRef' is defined."
+        },
+        "after": {
+          "type": "string",
+          "description": "Amount of time (ISO 8601 duration format) to sleep after function/subflow invocation. Does not apply if 'eventRef' is defined."
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "before"
+          ]
+        },
+        {
+          "required": [
+            "after"
+          ]
+        },
+        {
+          "required": [
+            "before",
+            "after"
+          ]
+        }
+      ]
+    },
     "crondef": {
       "oneOf": [
         {
@@ -351,13 +382,9 @@
           "description": "References a sub-workflow to invoke",
           "$ref": "#/definitions/subflowref"
         },
-        "sleepBefore": {
-          "type": "string",
-          "description": "Amount of time (ISO 8601 duration format) to sleep before function/subflow invocation. Does not apply if 'eventRef' is defined."
-        },
-        "sleepAfter": {
-          "type": "string",
-          "description": "Amount of time (ISO 8601 duration format) to sleep after function/subflow invocation. Does not apply if 'eventRef' is defined."
+        "sleep": {
+          "description": "Defines time periods workflow execution should sleep before / after function execution",
+          "$ref": "#/definitions/sleep"
         },
         "actionDataFilter": {
           "description": "Action data filter",

--- a/specification.md
+++ b/specification.md
@@ -3681,8 +3681,8 @@ are not exposed via a specific resource URI for example, but can only be invoked
 The [eventRef](#EventRef-Definition) defines the
 referenced `produced` event via its `triggerEventRef` property and a `consumed` event via its `resultEventRef` property.
 
-The `sleep` property can be used to define time periods that workflow execution should sleep 
-before and/or  after function execution. It can have two properties:
+The `sleep` property can be used to define time periods that workflow execution should sleep
+before and/or after function execution. It can have two properties:
 * `before` -  defines the amount of time (ISO 8601 duration format) to sleep before function invocation.
 * `after` -  defines the amount of time (ISO 8601 duration format) to sleep after function invocation.
 

--- a/specification.md
+++ b/specification.md
@@ -3628,8 +3628,7 @@ This is visualized in the diagram below:
 | [eventRef](#EventRef-Definition) | References a `trigger` and `result` reusable event definitions | object | yes if `functionRef` & `subFlowRef` are not defined |
 | [subFlowRef](#SubFlowRef-Definition) | References a workflow to be invoked | object or string | yes if `eventRef` & `functionRef` are not defined |
 | [actionDataFilter](#Action-data-filters) | Action data filter definition | object | no |
-| sleepBefore | Amount of time (ISO 8601 duration format) to sleep before function invocation. Does not apply if 'eventRef' is defined. | string | no |
-| sleepAfter | Amount of time (ISO 8601 duration format) to sleep after function invocation. Does not apply if 'eventRef' is defined. | string | no |
+| sleep | Defines time periods workflow execution should sleep before / after function execution | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3682,9 +3681,10 @@ are not exposed via a specific resource URI for example, but can only be invoked
 The [eventRef](#EventRef-Definition) defines the
 referenced `produced` event via its `triggerEventRef` property and a `consumed` event via its `resultEventRef` property.
 
-The `sleepBefore` property defines the amount of time (ISO 8601 duration format) to sleep before function invocation.
-
-The `sleepAfter` property defines the amount of time (ISO 8601 duration format) to sleep after function invocation.
+The `sleep` property can be used to define time periods that workflow execution should sleep 
+before and/or  after function execution. It can have two properties:
+* `before` -  defines the amount of time (ISO 8601 duration format) to sleep before function invocation.
+* `after` -  defines the amount of time (ISO 8601 duration format) to sleep after function invocation.
 
 Function invocation timeouts should be handled via the states [timeouts](#Workflow-Timeouts) definition.
 

--- a/specification.md
+++ b/specification.md
@@ -3676,7 +3676,7 @@ Service invocation can be done in two different ways:
 * Reference [functions definitions](#Function-Definition) by its unique name using the `functionRef` property.
 * Reference a `produced` and `consumed` [event definitions](#Event-Definition) via the `eventRef` property.
 
-In some scenarios a service or a set of services which need to be invoked
+In some scenarios a service or a set of services that need to be invoked
 are not exposed via a specific resource URI for example, but can only be invoked via events.
 The [eventRef](#EventRef-Definition) defines the
 referenced `produced` event via its `triggerEventRef` property and a `consumed` event via its `resultEventRef` property.

--- a/specification.md
+++ b/specification.md
@@ -3118,8 +3118,6 @@ section.
 | operation | If type is `rest`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \"mutation\" or \"query\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression. | string | no |
 | type | Defines the function type. Is either `rest`, `asyncapi`, `rpc`, `graphql`, `odata` or `expression`. Default is `rest` | enum | no |
 | authRef | References an [auth definition](#Auth-Definition) name to be used to access to resource defined in the operation parameter | string | no |
-| sleepBefore | Amount of time (ISO 8601 duration format) to sleep before function invocation | string | no |
-| sleepAfter | Amount of time (ISO 8601 duration format) to sleep after function invocation | string | no |
 | [metadata](#Workflow-Metadata) | Metadata information. Can be used to define custom function information | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -3174,10 +3172,6 @@ Depending on the function `type`, the `operation` property can be:
 
 The `authRef` property references a name of a defined workflow [auth definition](#Auth-Definition).
 It is used to provide authentication info to access the resource defined in the `operation` property.
-
-The `sleepBefore` property defines the amount of time (ISO 8601 duration format) to sleep before function invocation.
-
-The `sleepAfter` property defines the amount of time (ISO 8601 duration format) to sleep after function invocation.
 
 The [`metadata`](#Workflow-Metadata) property allows users to define custom information to function definitions.
 This allows you for example to define functions that describe of a command executions on a Docker image:
@@ -3634,6 +3628,8 @@ This is visualized in the diagram below:
 | [eventRef](#EventRef-Definition) | References a `trigger` and `result` reusable event definitions | object | yes if `functionRef` & `subFlowRef` are not defined |
 | [subFlowRef](#SubFlowRef-Definition) | References a workflow to be invoked | object or string | yes if `eventRef` & `functionRef` are not defined |
 | [actionDataFilter](#Action-data-filters) | Action data filter definition | object | no |
+| sleepBefore | Amount of time (ISO 8601 duration format) to sleep before function invocation. Does not apply if 'eventRef' is defined. | string | no |
+| sleepAfter | Amount of time (ISO 8601 duration format) to sleep after function invocation. Does not apply if 'eventRef' is defined. | string | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3681,17 +3677,16 @@ Service invocation can be done in two different ways:
 * Reference [functions definitions](#Function-Definition) by its unique name using the `functionRef` property.
 * Reference a `produced` and `consumed` [event definitions](#Event-Definition) via the `eventRef` property.
 
-In the event-based scenario a service or a set of services we want to invoke
+In some scenarios a service or a set of services which need to be invoked
 are not exposed via a specific resource URI for example, but can only be invoked via events.
 The [eventRef](#EventRef-Definition) defines the
 referenced `produced` event via its `triggerEventRef` property and a `consumed` event via its `resultEventRef` property.
 
-The `timeout` property defines the amount of time to wait for function execution to complete, or the consumed event referenced by the
-`resultEventRef` to become available.
-It is described in ISO 8601 format, so for example "PT2M" would mean the maximum time for the function to complete
-its execution is two minutes.
+The `sleepBefore` property defines the amount of time (ISO 8601 duration format) to sleep before function invocation.
 
-Possible invocation timeouts should be handled via the states [onErrors](#Workflow-Error-Handling) definition.
+The `sleepAfter` property defines the amount of time (ISO 8601 duration format) to sleep after function invocation.
+
+Function invocation timeouts should be handled via the states [timeouts](#Workflow-Timeouts) definition.
 
 ##### Subflow Action
 

--- a/specification.md
+++ b/specification.md
@@ -3118,6 +3118,8 @@ section.
 | operation | If type is `rest`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \"mutation\" or \"query\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression. | string | no |
 | type | Defines the function type. Is either `rest`, `asyncapi`, `rpc`, `graphql`, `odata` or `expression`. Default is `rest` | enum | no |
 | authRef | References an [auth definition](#Auth-Definition) name to be used to access to resource defined in the operation parameter | string | no |
+| sleepBefore | Amount of time (ISO 8601 duration format) to sleep before function invocation | string | no |
+| sleepAfter | Amount of time (ISO 8601 duration format) to sleep after function invocation | string | no |
 | [metadata](#Workflow-Metadata) | Metadata information. Can be used to define custom function information | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -3172,6 +3174,10 @@ Depending on the function `type`, the `operation` property can be:
 
 The `authRef` property references a name of a defined workflow [auth definition](#Auth-Definition).
 It is used to provide authentication info to access the resource defined in the `operation` property.
+
+The `sleepBefore` property defines the amount of time (ISO 8601 duration format) to sleep before function invocation.
+
+The `sleepAfter` property defines the amount of time (ISO 8601 duration format) to sleep after function invocation.
 
 The [`metadata`](#Workflow-Metadata) property allows users to define custom information to function definitions.
 This allows you for example to define functions that describe of a command executions on a Docker image:


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Often you want to add a sleep before/after function invocations. Adding "sleep" property to actiondef that 
allows you to define these sleeps (in action definitions).

**Special notes for reviewers**:

**Additional information (if needed):**