### PR TITLE
Foreach State - adding sequential exec option and batchSize for paral…

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -44,8 +44,6 @@ _Status description:_
 | ✔️| Added 'sleep' property to action definition | [spec doc](../specification.md) |
 | ✔️| Added Rate Limiting extension | [spec doc](../specification.md) |
 | ✔️| Update ForEach state - adding sequential exec option and batch size for parallel option | [spec doc](../specification.md) |
-| ✏️ | AsyncAPI operation support |  |
-| ✏️ | OData function definition support |  |
 | ✏️ | Update to retries - state specific rather than error specific |  |
 | ✏️ | Add batching and sync option for Foreach state |  |
 | 🚩 | Workflow invocation bindings |  |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -43,6 +43,7 @@ _Status description:_
 | ✔️| Rename Delay state to Sleep state | [spec doc](../specification.md) |
 | ✔️| Added 'sleep' property to action definition | [spec doc](../specification.md) |
 | ✔️| Added Rate Limiting extension | [spec doc](../specification.md) |
+| ✔️| Update ForEach state - adding sequential exec option and batch size for parallel option | [spec doc](../specification.md) |
 | ✏️ | AsyncAPI operation support |  |
 | ✏️ | OData function definition support |  |
 | ✏️ | Update to retries - state specific rather than error specific |  |
@@ -56,7 +57,6 @@ _Status description:_
 | 🚩 | JSON schema checks |  |
 | 🚩 | Start discussions on Serverless Workflow Technology Compatibility Kit (TCK) |  |
 | ✏️ | Specification primer | [google doc](https://docs.google.com/document/d/11rD3Azj63G2Si0VpokSpr-1ib3mFRFHSwN6tJb-0LQM/edit#heading=h.paewfy83tetm) continued in [wiki](https://github.com/serverlessworkflow/specification/wiki) |
-
 
 ## <a name="v06"></a> v0.6
 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1447,14 +1447,14 @@
           "type": "string",
           "description": "Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array"
         },
-        "max": {
+        "batchSize": {
           "type": [
             "number",
             "string"
           ],
           "minimum": 0,
           "minLength": 0,
-          "description": "Specifies how upper bound on how many iterations may run in parallel"
+          "description": "Specifies how many iterations may run in parallel at the same time. Used if 'mode' property is set to 'parallel' (default)"
         },
         "actions": {
           "type": "array",
@@ -1504,6 +1504,15 @@
           "type": "boolean",
           "default": false,
           "description": "If true, this state is used to compensate another state. Default is false"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "sequential",
+            "parallel"
+          ],
+          "description": "Specifies how iterations are to be performed (sequentially or in parallel)",
+          "default": "parallel"
         },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"

--- a/specification.md
+++ b/specification.md
@@ -2788,7 +2788,7 @@ The `timeouts` property can be used to define state specific timeout settings. I
 | inputCollection | Workflow expression selecting an array element of the states data | string | yes |
 | outputCollection | Workflow expression specifying an array element of the states data to add the results of each iteration | string | no |
 | iterationParam | Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array | string | yes |
-| batchSize | Specifies how many iterations may run in parallel at the same time. Used if `mode` property is set to `parallel` (default). If not specified, it's value should be the size of the `inputCollection` | string or number | no |
+| batchSize | Specifies how many iterations may run in parallel at the same time. Used if `mode` property is set to `parallel` (default). If not specified, its value should be the size of the `inputCollection` | string or number | no |
 | mode | Specifies how iterations are to be performed (sequentially or in parallel). Default is `parallel` | string  | no |
 | [actions](#Action-Definition) | Actions to be executed for each of the elements of inputCollection | array | yes |
 | [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |

--- a/specification.md
+++ b/specification.md
@@ -2788,7 +2788,8 @@ The `timeouts` property can be used to define state specific timeout settings. I
 | inputCollection | Workflow expression selecting an array element of the states data | string | yes |
 | outputCollection | Workflow expression specifying an array element of the states data to add the results of each iteration | string | no |
 | iterationParam | Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array | string | yes |
-| max | Specifies how upper bound on how many iterations may run in parallel | string or number | no |
+| batchSize | Specifies how many iterations may run in parallel at the same time. Used if `mode` property is set to `parallel` (default). If not specified, it's value should be the size of the `inputCollection` | string or number | no |
+| mode | Specifies how iterations are to be performed (sequentially or in parallel). Default is `parallel` | string  | no |
 | [actions](#Action-Definition) | Actions to be executed for each of the elements of inputCollection | array | yes |
 | [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |
 | [stateDataFilter](#State-data-filters) | State data filter definition | object | no |
@@ -2854,10 +2855,18 @@ actions:
 
 ForEach states can be used to execute [actions](#Action-Definition) for each element of a data set.
 
-Each iteration of the ForEach state should be executed in parallel.
+Each iteration of the ForEach state is by default executed in parallel by default.
+Executing iterations sequentially is also possible by setting the value of the `mode` property to
+`sequential`.
 
-You can use the `max` property to set the upper bound on how many iterations may run in parallel. The default
-of the `max` property is zero, which places no limit on number of parallel executions.
+The `mode` property defines if iterations should be done sequentially or in parallel. By default 
+(if `mode` is not specified) iterations should be done in parallel.
+
+If the default `parallel` iteration mode is used, the `batchSize` property to the number of iterations (batch) 
+that can be executed at a time. To give an example, if the number of iterations is 55 and `batchSize`
+is set to `10`, 10 iterations are to be executed at a time, meaning that the state would execute 10 iterations in parallel,
+then execute the next batch of 10 iterations. After 5 such executions, the remaining 5 iterations are to be executed in the last batch.
+Batch size value must be greater than 1. If not specified, it's value should be the size of the `inputCollection` (all iterations).
 
 The `inputCollection` property is a workflow expression which selects an array in the states data. All iterations
 are performed against data elements of this array. If this array does not exist, the runtime should throw

--- a/specification.md
+++ b/specification.md
@@ -2866,7 +2866,7 @@ If the default `parallel` iteration mode is used, the `batchSize` property to th
 that can be executed at a time. To give an example, if the number of iterations is 55 and `batchSize`
 is set to `10`, 10 iterations are to be executed at a time, meaning that the state would execute 10 iterations in parallel,
 then execute the next batch of 10 iterations. After 5 such executions, the remaining 5 iterations are to be executed in the last batch.
-Batch size value must be greater than 1. If not specified, it's value should be the size of the `inputCollection` (all iterations).
+The batch size value must be greater than 1. If not specified, its value should be the size of the `inputCollection` (all iterations).
 
 The `inputCollection` property is a workflow expression which selects an array in the states data. All iterations
 are performed against data elements of this array. If this array does not exist, the runtime should throw

--- a/specification.md
+++ b/specification.md
@@ -2856,7 +2856,7 @@ actions:
 ForEach states can be used to execute [actions](#Action-Definition) for each element of a data set.
 
 Each iteration of the ForEach state is by default executed in parallel by default.
-Executing iterations sequentially is also possible by setting the value of the `mode` property to
+However, executing iterations sequentially is also possible by setting the value of the `mode` property to
 `sequential`.
 
 The `mode` property defines if iterations should be done sequentially or in parallel. By default 


### PR DESCRIPTION
…lel exec option

Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x ] Specification
- [ x] Schema
- [ ] Examples
- [ ] Extensions
- [ x] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Currently foreach state could execute all iterations in parallel.
1. Adding mode property where users can define sequential execution of state iterations
2. Adding batchSize property which is used when exec mode is parallel (default still). 
3. Removed the "max" property which wasnt really useful and is now replaced with more powerful batchSize property.


**Special notes for reviewers**:

**Additional information (if needed):**