### PR TITLE
[0.7.x] Adding continueAs prop to end definitions (#446)

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -45,6 +45,7 @@ _Status description:_
 | ✔️| Added Rate Limiting extension | [spec doc](../specification.md) |
 | ✔️| Update ForEach state - adding sequential exec option and batch size for parallel option | [spec doc](../specification.md) |
 | ✔️| Update to error handling and retries. Retries are now per action rather than per state. Added option of automatic retries for actions | [spec doc](../specification.md) |
+| ✔️| Added "continueAs" property to end definitions | [spec doc](https://github.com/serverlessworkflow/specification/blob/0.6.x/specification.md) |
 
 ## Release Version 0.6
 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -250,6 +250,43 @@
         }
       ]
     },
+    "continueasdef": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Unique id of the workflow to be continue execution as. Entire state data is passed as data input to next execution",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "properties": {
+            "workflowId": {
+              "type": "string",
+              "description": "Unique id of the workflow to continue execution as"
+            },
+            "version": {
+              "type": "string",
+              "description": "Version of the workflow to continue execution as",
+              "minLength": 1
+            },
+            "data": {
+              "type": [
+                "string",
+                "object"
+              ],
+              "description": "If string type, an expression which selects parts of the states data output to become the workflow data input of continued execution. If object type, a custom object to become the workflow data input of the continued execution"
+            },
+            "workflowExecTimeout": {
+              "$ref": "timeouts.json#/definitions/workflowExecTimeout",
+              "description": "Workflow execution timeout to be used by the workflow continuing execution. Overwrites any specific settings set by that workflow"
+            }
+          },
+          "required": [
+            "workflowId"
+          ]
+        }
+      ]
+    },
     "transition": {
       "oneOf": [
         {
@@ -1825,6 +1862,9 @@
               "type": "boolean",
               "default": false,
               "description": "If set to true, triggers workflow compensation. Default is false"
+            },
+            "continueAs": {
+              "$ref": "#/definitions/continueasdef"
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
* Adding continueAs prop to end definitions

Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

* fix link

Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

* updated roadmap

Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

* added section on sub-workflows and continueAs

Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

**Special notes for reviewers**:

**Additional information (if needed):**