### PR TITLE
Fix support for workflow extensions

### DIFF
--- a/extensions/kpi.md
+++ b/extensions/kpi.md
@@ -32,9 +32,7 @@ KPIs can be added for the model:
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| extensionid | Unique extension Id (default is 'workflow-kpi-extension') | string | yes |
-| workflowid | Workflow definition unique identifier (workflow id property) | string | yes |
-| workflowVersions | Workflow versions. If not defined, applies to all workflow instances (regardless of their associated workflow version) | array | no |
+| extensionId | Unique extension Id (default is 'workflow-kpi-extension') | string | yes |
 | [workflow](#Workflow-KPIs-Definition) | Workflow definition KPIs | object | no |
 | [events](#Event-KPIs-Definition) | Workflow event definitions KPIs | array | no |
 | [functions](#Function-KPIs-Definition) | Workflow function definitions KPIs | array | no |
@@ -45,7 +43,6 @@ KPIs can be added for the model:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | [per](#Thresholds-Definition) | Define the kpi thresholds in terms of time and/or num of workflow instances| object | yes |
-| workflowid | Workflow definition unique identifier (workflow id property) | string | yes |
 | maxInvoked | Max number of workflow invocations | string | no |
 | minInvoked | Min number of workflow invocations | string | no |
 | avgInvoked | Average number of workflow invocations | string | no |
@@ -112,7 +109,9 @@ KPIs can be added for the model:
 ## Example
 
 The following example shows a workflow definition on the left and 
-an associated sample KPIs extension definition on the right.
+an associated sample KPIs extension definition on the right. We assume that our
+extensions definition yaml is located in a resource accessible via URI:
+`file://myextensions/kpi.yml`.
 
 <table>
 <tr>
@@ -128,56 +127,59 @@ name: Monitor Patient Vitals
 version: '1.0'
 specVersion: '0.8'
 start: MonitorVitals
+extensions:
+  - extensionId: workflow-kpi-extension
+    path: file://myextensions/kpi.yml
 events:
-- name: HighBodyTemperature
-  type: org.monitor.highBodyTemp
-  source: monitoringSource
-  correlation:
-  - contextAttributeName: patientId
-- name: HighBloodPressure
-  type: org.monitor.highBloodPressure
-  source: monitoringSource
-  correlation:
-  - contextAttributeName: patientId
-- name: HighRespirationRate
-  type: org.monitor.highRespirationRate
-  source: monitoringSource
-  correlation:
-  - contextAttributeName: patientId
+  - name: HighBodyTemperature
+    type: org.monitor.highBodyTemp
+    source: monitoringSource
+    correlation:
+      - contextAttributeName: patientId
+  - name: HighBloodPressure
+    type: org.monitor.highBloodPressure
+    source: monitoringSource
+    correlation:
+      - contextAttributeName: patientId
+  - name: HighRespirationRate
+    type: org.monitor.highRespirationRate
+    source: monitoringSource
+    correlation:
+      - contextAttributeName: patientId
 functions:
-- name: callPulmonologist
-  operation: http://myapi.org/patientapi.json#callPulmonologist
-- name: sendTylenolOrder
-  operation: http://myapi.org/patientapi.json#sendTylenol
-- name: callNurse
-  operation: http://myapi.org/patientapi.json#callNurse
+  - name: callPulmonologist
+    operation: http://myapi.org/patientapi.json#callPulmonologist
+  - name: sendTylenolOrder
+    operation: http://myapi.org/patientapi.json#sendTylenol
+  - name: callNurse
+    operation: http://myapi.org/patientapi.json#callNurse
 states:
-- name: MonitorVitals
-  type: event
-  exclusive: true
-  onEvents:
-  - eventRefs:
-    - HighBodyTemperature
-    actions:
-    - functionRef:
-        refName: sendTylenolOrder
-        arguments:
-          patientid: "${ .patientId }"
-  - eventRefs:
-    - HighBloodPressure
-    actions:
-    - functionRef:
-        refName: callNurse
-        arguments:
-          patientid: "${ .patientId }"
-  - eventRefs:
-    - HighRespirationRate
-    actions:
-    - functionRef:
-        refName: callPulmonologist
-        arguments:
-          patientid: "${ .patientId }"
-  end: true
+  - name: MonitorVitals
+    type: event
+    exclusive: true
+    onEvents:
+      - eventRefs:
+          - HighBodyTemperature
+        actions:
+          - functionRef:
+              refName: sendTylenolOrder
+              arguments:
+                patientid: "${ .patientId }"
+      - eventRefs:
+          - HighBloodPressure
+        actions:
+          - functionRef:
+              refName: callNurse
+              arguments:
+                patientid: "${ .patientId }"
+      - eventRefs:
+          - HighRespirationRate
+        actions:
+          - functionRef:
+              refName: callPulmonologist
+              arguments:
+                patientid: "${ .patientId }"
+    end: true
 ```
 
 </td>
@@ -185,7 +187,6 @@ states:
 
 ```yaml
 extensionid: workflow-kpi-extension
-workflowid: patientVitalsWorkflow
 currency: USD
 workflow:
   per:

--- a/extensions/ratelimiting.md
+++ b/extensions/ratelimiting.md
@@ -18,8 +18,6 @@ at a desired rate in cases where downstream service invocations have an associat
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | extensionid | Unique extension Id (default is 'workflow-kpi-extension') | string | yes |
-| workflowid | Workflow definition unique identifier (workflow id property) | string | yes |
-| workflowVersions | Workflow versions. If not defined, applies to all workflow instances (regardless of their associated workflow version) | array | no |
 | [singleInstance](#Single-Instance-Definition) | Rate limits per single workflow instance | object | no |
 | [allInstances](#All-Instances-Definition) | Rate limits per all workflow instances | object | no |
 
@@ -47,6 +45,9 @@ at a desired rate in cases where downstream service invocations have an associat
 
 The following example shows a workflow definition on the left and
 an associated sample Rate Limiting extension definition on the right.
+We assume that our
+extensions definition yaml is located in a resource accessible via URI:
+`file://myextensions/ratelimiting.yml`.
 
 <table>
 <tr>
@@ -61,6 +62,9 @@ id: processapplication
 name: Process Application
 version: '1.0'
 specVersion: '0.8'
+extensions:
+  - extensionId: workflow-ratelimiting-extension
+    path: file://myextensions/ratelimiting.yml
 start: ProcessNewApplication
 states:
   - name: ProcessNewApplication
@@ -96,7 +100,6 @@ events:
 
 ```yaml
 extensionid: workflow-ratelimiting-extension
-workflowid: processapplication
 singleInstance:
   maxActionsPerSecond: 0.1
   maxConcurrentActions: 200

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -23,6 +23,7 @@ _Status description:_
 
 | Status | Description | Comments |
 | --- | --- |  --- |
+| ✔️| Fix support for workflow extensions | [spec doc](https://github.com/serverlessworkflow/specification/blob/main/specification.md)  |
 | ✏️️| Add inline state defs in branches |   |
 | ✏️️| Update rest function definition |   |
 | ✏️️| Add "completedBy" functionality |   |

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -128,6 +128,9 @@
     "auth": {
       "$ref": "auth.json#/auth"
     },
+    "extensions": {
+      "$ref": "workflowextensions.json#/extensions"
+    },
     "states": {
       "type": "array",
       "description": "State definitions",

--- a/schema/workflowextensions.json
+++ b/schema/workflowextensions.json
@@ -1,0 +1,50 @@
+{
+  "$id": "https://serverlessworkflow.io/schemas/0.8/extensions.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Serverless Workflow specification - extensions schema",
+  "type": "object",
+  "extensions": {
+    "oneOf": [
+      {
+        "type": "string",
+        "format": "uri",
+        "description": "URI to a resource containing workflow extensions definitions (json or yaml)"
+      },
+      {
+        "type": "array",
+        "description": "Workflow extensions definitions",
+        "items": {
+          "type": "object",
+          "$ref": "#/definitions/extension"
+        },
+        "additionalItems": false,
+        "minItems": 1
+      }
+    ]
+  },
+  "required": [
+    "extensions"
+  ],
+  "definitions": {
+    "extension": {
+      "type": "object",
+      "properties": {
+        "extensionId": {
+          "type": "string",
+          "description": "Unique extension id",
+          "minLength": 1
+        },
+        "resource": {
+          "type": "string",
+          "description": "URI to a resource containing this workflow extension definitions (json or yaml)",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "extensionId",
+        "resource"
+      ]
+    }
+  }
+}

--- a/specification.md
+++ b/specification.md
@@ -1841,6 +1841,7 @@ definition "id" must be a constant value.
 | autoRetries | If set to true, [actions](#Action-Definition) should automatically be retried on unchecked errors. Default is false | boolean| no |
 | [retries](#Retry-Definition) | Workflow retries definitions. Can be either inline retries definitions (if array) or URI pointing to a resource containing json/yaml retry definitions (if string) | array or string| no |
 | [states](#Workflow-States) | Workflow states | array | yes |
+| [extensions](#Workflow-Extensions) | Workflow extensions definitions | array or string | no |
 | [metadata](#Workflow-Metadata) | Metadata information | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -2124,6 +2125,27 @@ its [`workflowExecTimeout`](#Workflow-Timeouts) time is reached.
 This allows you to explicitly model workflows where an instance should be kept alive, to collect (event) data for example.
 
 You can reference the [specification examples](#Examples) to see the `keepActive` property in action.
+
+The `extensions` property can be used to define extensions for this workflow definition.
+You can learn more about workflow extensions in the [Extensions](#extensions) section.
+Sample `extensions` property definition could look like this for example:
+
+```json
+{
+  "extensions": [
+    {
+      "extensionId": "workflow-ratelimiting-extension",
+      "path": "file://myextensions/ratelimiting.yml"
+    },
+    {
+      "extensionId": "workflow-kpi-extension",
+      "path": "file://myextensions/kpi.yml"
+    }
+  ]
+}
+```
+
+Here we define two workflow extensions, namely the [rate limiting](extensions/ratelimiting.md) and [kpi](extensions/kpi.md) extensions for our workflow definition.
 
 #### Workflow States
 
@@ -6161,6 +6183,10 @@ They enhance it with extra information that can be consumed by runtime systems o
 evaluated with the end goal being overall workflow improvements in terms of time, cost, efficiency, etc.
 
 Serverless Workflow specification provides extensions which can be found [here](extensions/README.md).
+
+You can define extensions in your workflow definition using its top-level `extensions` property.
+For more information about this property, see the `extensions` property in the 
+[Workflow Definition Structure section](#Workflow-Definition-Structure).
 
 Even tho users can define their own extensions, it is encouraged to use the ones provided by the specification.
 We also encourage users to contribute their extensions to the specification. That way they can be shared


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ x] Extensions
- [ x] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
Currently, each extension definition had to define the workflow id and versions for which it applies for. That made it impossible to reuse extension defs between multiple workflow defs.
This change adds a top-level "extensions" prop (array or path to url, string) which allows in the workflow def to say which extensions you want to apply to that workflow definition.