### PR TITLE
Simplified inject state, fixed jq filter for stateDataFilter section

### DIFF
--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1471,16 +1471,6 @@
           "type": "object",
           "description": "JSON object which can be set as states data input and can be manipulated via filters"
         },
-        "timeouts": {
-          "type": "object",
-          "description": "State specific timeouts",
-          "properties": {
-            "stateExecTimeout": {
-              "$ref": "timeouts.json#/definitions/stateExecTimeout"
-            }
-          },
-          "required": []
-        },
         "stateDataFilter": {
           "description": "State data filter",
           "$ref": "#/definitions/statedatafilter"

--- a/specification.md
+++ b/specification.md
@@ -407,7 +407,7 @@ The first way would be to use both "input", and "output":
 {
   "stateDataFilter": {
     "input": "${ {vegetables: .vegetables} }",
-    "output": "${ {vegetables: .vegetables[] | select(.veggieLike == true)} }"
+    "output": "${ {vegetables: [.vegetables[] | select(.veggieLike == true)]} }"
   }
 }
 ```
@@ -424,7 +424,7 @@ The second way would be to directly filter only the "veggie like" vegetables wit
 ```json
 {
   "stateDataFilter": {
-    "input": "${ {vegetables: .vegetables[] | select(.veggieLike == true)} }"
+    "input": "${ {vegetables: [.vegetables[] | select(.veggieLike == true)]} }"
   }
 }
 ```

--- a/specification.md
+++ b/specification.md
@@ -2666,8 +2666,6 @@ reference the [Workflow Timeouts](#Workflow-Timeouts) section.
 | data | JSON object which can be set as state's data input and can be manipulated via filter | object | yes |
 | [stateDataFilter](#state-data-filters) | State data filter | object | no |
 | [transition](#Transitions) | Next transition of the workflow after injection has completed | object | yes (if end is set to false) |
-| [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |
-| [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
 | [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
 | [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
 | [metadata](#Workflow-Metadata) | Metadata information| object | no |


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
There are two changes
- `inject state` simplified to remove attributes that do not bring value such as timeouts, errors and state data filter as intended behaviour of `inject state` is to inject static content so there is literally no way it can cause failures for just some instances and by that error handling and timeouts do not apply. Similar for `stateDataFilter` singe the `data` is static there is no need to apply filtering as `data` should be described without filter in the way it is expected to be injected.
- fixed `jq` expression used in state data filter section

**Special notes for reviewers**:

**Additional information (if needed):**