### PR TITLE
Make stateName in start def optional

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -28,6 +28,7 @@ _Status description:_
 | ✔️| Update rules of retries increment and multiplier properties | [spec doc](https://github.com/serverlessworkflow/specification/blob/main/specification.md)  |
 | ✔️| Add clarification on mutually exclusive properties | [spec doc](https://github.com/serverlessworkflow/specification/blob/main/specification.md)  |
 | ✔️| Make the `resultEventRef` attribute in `EventRef` definition not required [spec doc](https://github.com/serverlessworkflow/specification/blob/main/specification.md#EventRef-Definition)  |
+| ✔️| Make the `stateName` attribute in `start` definition not required [spec doc](https://github.com/serverlessworkflow/specification/blob/main/specification.md#EventRef-Definition)  |
 | ✏️️| Add inline state defs in branches |   |
 | ✏️️| Update rest function definition |   |
 | ✏️️| Add "completedBy" functionality |   |

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1772,7 +1772,6 @@
           },
           "additionalProperties": false,
           "required": [
-            "stateName",
             "schedule"
           ]
         }

--- a/specification.md
+++ b/specification.md
@@ -4562,7 +4562,7 @@ If the start definition is of type `object`, it has the following structure:
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| stateName | Name of the starting workflow state | object | yes |
+| stateName | Name of the starting workflow state | object | no |
 | [schedule](#Schedule-Definition) | Define the recurring time intervals or cron expressions at which workflow instances should be automatically started. | object | yes |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -4604,6 +4604,9 @@ The start definition can be either `string` or `object` type.
 If `string` type, it defines the name of the workflow starting state.
 
 If `object` type, it provides the ability to set the workflow starting state name, as well as the `schedule` property.
+
+The `stateName` property can be set to define the starting workflow state. If not specified, the first state
+in the [workflow states definition](#Workflow-States) should be used as the starting workflow state.
 
 The `schedule` property allows to define scheduled workflow instance creation.
 Scheduled starts have two different choices. You can define a recurring time interval or cron-based schedule at which a workflow


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ x] Specification
- [ x] Schema
- [ ] Examples
- [ ] Extensions
- [ x] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
we made the start param optional in here: https://github.com/serverlessworkflow/specification/commit/d722692c28a593a0ce4771071304da1e331c28c0

meaning if not specified the first state in states array is picked. this also fixes the start definition to make stateName optional as well, was missed before.


**Special notes for reviewers**:

**Additional information (if needed):**