### PR TITLE
Fix workflow id mention on parallel state branch def

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -4064,7 +4064,8 @@ version: '2.0'
 
 </details>
 
-The `workflowId` property defined the unique ID of the sub-workflow to be invoked.
+The `workflowId` property define the unique ID of the sub-workflow to be invoked.
+The workflow id cannot be the same id of the workflow where the action is defined.
 
 The `version` property defined the unique version of the sub-workflow to be invoked.
 If this property is defined, runtimes should match both the `id` and the `version` properties
@@ -4518,8 +4519,7 @@ actions:
 
 Each branch receives the same copy of the Parallel state's data input.
 
-A branch can define either actions or a workflow id of the workflow that needs to be executed.
-The workflow id defined cannot be the same id of the workflow there the branch is defined.
+A branch can define actions that need to be executed. For the [`SubFlowRef`](#SubFlowRef-Definition) action, the workflow id can't be the same id of the workflow where the branch is defined.
 
 The `timeouts` property can be used to set branch specific timeout settings. Parallel state branches can set the
 `actionExecTimeout` and `branchExecTimeout` timeout properties. For more information on workflow timeouts reference the

--- a/specification.md
+++ b/specification.md
@@ -4065,7 +4065,7 @@ version: '2.0'
 </details>
 
 The `workflowId` property define the unique ID of the sub-workflow to be invoked.
-The workflow id cannot be the same id of the workflow where the action is defined.
+Usually, the workflow id should not be the same id of the workflow where the action is defined. Otherwise, it may occur undesired recurring calls to the same workflow.
 
 The `version` property defined the unique version of the sub-workflow to be invoked.
 If this property is defined, runtimes should match both the `id` and the `version` properties
@@ -4519,7 +4519,8 @@ actions:
 
 Each branch receives the same copy of the Parallel state's data input.
 
-A branch can define actions that need to be executed. For the [`SubFlowRef`](#SubFlowRef-Definition) action, the workflow id can't be the same id of the workflow where the branch is defined.
+A branch can define actions that need to be executed. For the [`SubFlowRef`](#SubFlowRef-Definition) action, the workflow id should not be the same id of the workflow where the branch is defined. Otherwise, it may occur undesired recurring calls to the same workflow.
+
 
 The `timeouts` property can be used to set branch specific timeout settings. Parallel state branches can set the
 `actionExecTimeout` and `branchExecTimeout` timeout properties. For more information on workflow timeouts reference the


### PR DESCRIPTION
There's no workflow ID in the branch definition any more :)