### PR TITLE
fix jq expression in greeting example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -175,7 +175,7 @@ Which is added to the states data and becomes the workflow data output.
               }
            },
            "actionDataFilter": {
-              "results": "${ .greeting }"
+              "results": "${ {greeting: .greeting} }"
            }
         }
      ],
@@ -207,7 +207,7 @@ states:
       arguments:
         name: "${ .person.name }"
     actionDataFilter:
-      results: "${ .greeting }"
+      results: "${ {greeting: .greeting} }"
   end: true
 ```
 


### PR DESCRIPTION
Signed-off-by: Antonio Mendoza Pérez <antonio.mendoza@ikusi.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [ ] Schema
- [X] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

I think that the jq expression is incorrect in greeting example 

According to the text and image, the final workflow output is 

```
{"greeting": "Welcome to Serverless Workflow, John!"}
```

to produce this output we have to apply the following filter to the value returned by the `greetingFunction` function 

```
{greeting: .greeting}
```
see https://jqplay.org/s/a5DHVwWHXN


**Special notes for reviewers**:

**Additional information (if needed):**