### PR TITLE
Renamed EventRef Definition

### DIFF
--- a/schema/auth.json
+++ b/schema/auth.json
@@ -71,148 +71,124 @@
       ]
     },
     "basicpropsdef": {
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "Expression referencing a workflow secret that contains all needed basic auth info"
-        },
-        {
-          "type": "object",
-          "description": "Basic auth information",
-          "properties": {
-            "username": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the user name",
-              "minLength": 1
-            },
-            "password": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the user password",
-              "minLength": 1
-            },
-            "metadata": {
-              "$ref": "common.json#/definitions/metadata"
-            }
+        "type": "object",
+        "description": "Basic auth information",
+        "properties": {
+          "username": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the user name",
+            "minLength": 1
           },
-          "required": [
-            "username",
-            "password"
-          ],
-          "additionalProperties": false
-        }
-      ]
+          "password": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the user password",
+            "minLength": 1
+          },
+          "metadata": {
+            "$ref": "common.json#/definitions/metadata"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ],
+        "additionalProperties": false
     },
     "bearerpropsdef": {
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "Expression referencing a workflow secret that contains all needed bearer auth info"
-        },
-        {
-          "type": "object",
-          "description": "Bearer auth information",
-          "properties": {
-            "token": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the token",
-              "minLength": 1
-            },
-            "metadata": {
-              "$ref": "common.json#/definitions/metadata"
-            }
+        "type": "object",
+        "description": "Bearer auth information",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the token",
+            "minLength": 1
           },
-          "required": [
-            "token"
-          ],
-          "additionalProperties": false
-        }
-      ]
+          "metadata": {
+            "$ref": "common.json#/definitions/metadata"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "additionalProperties": false
     },
     "oauth2propsdef": {
-      "oneOf": [
-        {
-          "type": "string",
-          "description": "Expression referencing a workflow secret that contains all needed OAuth2 auth info"
-        },
-        {
-          "type": "object",
-          "description": "OAuth2 information",
-          "properties": {
-            "authority": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the authority information",
-              "minLength": 1
-            },
-            "grantType": {
-              "type": "string",
-              "description": "Defines the grant type",
-              "enum": [
-                "password",
-                "clientCredentials",
-                "tokenExchange"
-              ],
-              "additionalItems": false
-            },
-            "clientId": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the client identifier",
-              "minLength": 1
-            },
-            "clientSecret": {
-              "type": "string",
-              "description": "Workflow secret or a workflow expression. Contains the client secret",
-              "minLength": 1
-            },
-            "scopes": {
-              "type": "array",
-              "description": "Array containing strings or workflow expressions. Contains the OAuth2 scopes",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "additionalItems": false
-            },
-            "username": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the user name. Used only if grantType is 'resourceOwner'",
-              "minLength": 1
-            },
-            "password": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the user password. Used only if grantType is 'resourceOwner'",
-              "minLength": 1
-            },
-            "audiences": {
-              "type": "array",
-              "description": "Array containing strings or workflow expressions. Contains the OAuth2 audiences",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "additionalItems": false
-            },
-            "subjectToken": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the subject token",
-              "minLength": 1
-            },
-            "requestedSubject": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the requested subject",
-              "minLength": 1
-            },
-            "requestedIssuer": {
-              "type": "string",
-              "description": "String or a workflow expression. Contains the requested issuer",
-              "minLength": 1
-            },
-            "metadata": {
-              "$ref": "common.json#/definitions/metadata"
-            }
+        "type": "object",
+        "description": "OAuth2 information",
+        "properties": {
+          "authority": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the authority information",
+            "minLength": 1
           },
-          "required": ["grantType", "clientId"]
-        }
-      ]
+          "grantType": {
+            "type": "string",
+            "description": "Defines the grant type",
+            "enum": [
+              "password",
+              "clientCredentials",
+              "tokenExchange"
+            ],
+            "additionalItems": false
+          },
+          "clientId": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the client identifier",
+            "minLength": 1
+          },
+          "clientSecret": {
+            "type": "string",
+            "description": "Workflow secret or a workflow expression. Contains the client secret",
+            "minLength": 1
+          },
+          "scopes": {
+            "type": "array",
+            "description": "Array containing strings or workflow expressions. Contains the OAuth2 scopes",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "additionalItems": false
+          },
+          "username": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the user name. Used only if grantType is 'resourceOwner'",
+            "minLength": 1
+          },
+          "password": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the user password. Used only if grantType is 'resourceOwner'",
+            "minLength": 1
+          },
+          "audiences": {
+            "type": "array",
+            "description": "Array containing strings or workflow expressions. Contains the OAuth2 audiences",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "additionalItems": false
+          },
+          "subjectToken": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the subject token",
+            "minLength": 1
+          },
+          "requestedSubject": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the requested subject",
+            "minLength": 1
+          },
+          "requestedIssuer": {
+            "type": "string",
+            "description": "String or a workflow expression. Contains the requested issuer",
+            "minLength": 1
+          },
+          "metadata": {
+            "$ref": "common.json#/definitions/metadata"
+          }
+        },
+        "required": ["grantType", "clientId"]
     }
   }
 }

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -545,7 +545,7 @@
           "type": "string",
           "description": "Reference to the unique name of a 'consumed' event definition"
         },
-        "resultEventTimeout": {
+        "consumeEventTimeout": {
           "type": "string",
           "description": "Maximum amount of time (ISO 8601 format) to wait for the result event. If not defined it should default to the actionExecutionTimeout"
         },

--- a/specification.md
+++ b/specification.md
@@ -3988,9 +3988,9 @@ to be used as payload of the event referenced by `produceEventRef`. If it is of 
 The `contextAttributes` property allows you to add one or more [extension context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
 to the trigger/produced event.
 
-The `resultEventTimeout` property defines the maximum amount of time (ISO 8601 format) to wait for the result event. If not defined it should default to the  [actionExecutionTimeout](#Workflow-Timeout-Definition).
-If the event defined by the `resultEventRef` property is not received in that set time, action invocation should raise an error
-that can be handled in the states `onErrors` definition. In case the `resultEventRef` is not defined, the `resultEventTimeout` property is ignored.
+The `consumeEventTimeout` property defines the maximum amount of time (ISO 8601 format) to wait for the result event. If not defined it should default to the  [actionExecutionTimeout](#Workflow-Timeout-Definition).
+If the event defined by the `consumeEventRef` property is not received in that set time, action invocation should raise an error
+that can be handled in the states `onErrors` definition. In case the `consumeEventRef` is not defined, the `consumeEventTimeout` property is ignored.
 
 The `invoke` property defines how the function is invoked (sync or async). Default value of this property is
 `sync`, meaning that workflow execution should wait until the function completes (the result event is received).

--- a/specification.md
+++ b/specification.md
@@ -3938,7 +3938,7 @@ Allows defining invocation of a function via event.
 | --- | --- | --- | --- |
 | [produceEventRef](#Event-Definition) | Reference to the unique name of a `produced` event definition | string | yes |
 | [consumeEventRef](#Event-Definition) | Reference to the unique name of a `consumed` event definition | string | no |
-| resultEventTimeout | Maximum amount of time (ISO 8601 format) to wait for the result event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition) | string | no |
+| consumeEventTimeout | Maximum amount of time (ISO 8601 format) to wait for the consume event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition) | string | no |
 | data | If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by `produceEventRef`. If object type, a custom object to become the data (payload) of the event referenced by `produceEventRef`. | string or object | no |
 | contextAttributes | Add additional event extension context attributes to the trigger/produced event | object | no |
 | invoke | Specifies if the function should be invoked sync or async. Default is sync | string | no |


### PR DESCRIPTION
Renamed EventRef Definition's `resultEventTimeout` to `consumeEventTimeout`

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [X] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

The EventRef Definition's `resultEventTimeout` name is an artifact from the time the `consumeEventRef` was named `resultEventRef`. It therefore should be renamed as `consumeEventTimeout` for the sake of consistency.