### PR TITLE
Update `dataInputSchema` property to allow for in-line schema def

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -33,6 +33,7 @@ _Status description:_
 | ✔️| Update eventRef props to`produceEventRef` and `consumeEventRef` [spec doc](https://github.com/serverlessworkflow/specification/blob/main/specification.md#EventRef-Definition)  |
 | ✔️| Update eventRef props to`resultEventTimeout` and `consumeEventTimeout` [spec doc](https://github.com/serverlessworkflow/specification/blob/main/specification.md#EventRef-Definition)  |
 | ✔️| Apply fixes to auth spec schema [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/schema)  |
+| ✔️| Update the `dataInputSchema` top-level property by supporting the assignment of a JSON schema object [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/specification.md#workflow-definition-structure)  |
 | ✏️️| Add inline state defs in branches |   |
 | ✏️️| Update rest function definition |   |
 | ✏️️| Add "completedBy" functionality |   |

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -49,9 +49,18 @@
           "description": "Workflow data input schema definition",
           "properties": {
             "schema": {
-              "type": "string",
-              "description": "URI of the JSON Schema used to validate the workflow data input",
-              "minLength": 1
+              "oneof":[
+                {
+                  "type": "string",
+                  "description": "URI of the JSON Schema used to validate the workflow data input",
+                  "minLength": 1
+                },
+                {
+                  "type": "object",
+                  "description": "The JSON Schema object used to validate the workflow data input",
+                  "$schema": "http://json-schema.org/draft-04/schema#"
+                }
+              ]
             },
             "failOnValidationErrors": {
               "type": "boolean",
@@ -61,8 +70,7 @@
           },
           "additionalProperties": false,
           "required": [
-            "schema",
-            "failOnValidationErrors"
+            "schema"
           ]
         }
       ]

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -58,7 +58,7 @@
                 {
                   "type": "object",
                   "description": "The JSON Schema object used to validate the workflow data input",
-                  "$schema": "http://json-schema.org/draft-04/schema#"
+                  "$schema": "http://json-schema.org/draft-07/schema#"
                 }
               ]
             },

--- a/specification.md
+++ b/specification.md
@@ -1928,7 +1928,26 @@ If it is an object type it has the following definition:
 }
 ```
 
-It's `schema` property is an URI which points to the JSON schema used to validate the workflow data input.
+It's `schema` property can be an URI, which points to the JSON schema used to validate the workflow data input, or it can be the JSON schema object.
+If it's a JSON schema object, it has the following definition:
+
+```json
+"dataInputSchema": {
+   "schema": {
+     "title": "MyJSONSchema",
+     "properties":{
+       "firstName":{
+         "type": "string"
+       },
+       "lastName":{
+         "type": "string"
+       }
+     }
+   },
+   "failOnValidationErrors": false
+}
+
+```
 It' `failOnValidationErrors` property  determines if workflow execution should continue in case of validation
 errors. The default value of `failOnValidationErrors` is `true`.
 If `dataInputSchema` has the string type, it has the following definition:


### PR DESCRIPTION
- Updated the `dataInputSchema.schema` property by allowing a Json Schema object value
- Updated the `dataInputSchema`  value object schema by making the `failOnValidationErrors` oprtional

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [x] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

- Allow directly assigning the Json schema object to the `dataInputSchema.schema` property 
- Now that the  `dataInputSchema.schema` object's sole purpose is not the  `dataInputSchema.schema.failOnValidationErrors` property, make the latter optional