### PR TITLE
Clarification on usage of authDef on function definitions

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -35,6 +35,7 @@ _Status description:_
 | ✔️| Apply fixes to auth spec schema [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/schema)  |
 | ✔️| Update the `dataInputSchema` top-level property by supporting the assignment of a JSON schema object [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/specification.md#workflow-definition-structure)  |
 | ✔️| Add the new `WORKFLOW` reserved keyword to workflow expressions  |
+| ✔️| Clarification regarding the usage of [`authDef`](https://github.com/serverlessworkflow/specification/blob/main/specification.md#Auth-Definition) in function definitions  |
 | ✏️️| Add inline state defs in branches |   |
 | ✏️️| Update rest function definition |   |
 | ✏️️| Add "completedBy" functionality |   |

--- a/specification.md
+++ b/specification.md
@@ -2045,7 +2045,7 @@ If we have the following function definition:
 ```
 
 The `authRef` property is used to reference an authentication definition in
-the `auth` property and should be applied to access the `https://secure.resources.com/myapi.json`
+the workflow `auth` property. It can also be used to access the `https://secure.resources.com/myapi.json`
 OpenApi definition file.
 
 The `functions` property can be either an in-line [function](#Function-Definition) definition array, or an URI reference to

--- a/specification.md
+++ b/specification.md
@@ -3248,7 +3248,7 @@ Note that `transition` and `end` properties are mutually exclusive, meaning that
 | name | Unique function name | string | yes |
 | operation | If type is `rest`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \"mutation\" or \"query\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression. | string | no |
 | type | Defines the function type. Can be either `rest`, `asyncapi`, `rpc`, `graphql`, `odata`, `expression`, or [`custom`](#defining-custom-function-types). Default is `rest` | enum | no |
-| authRef | References an [auth definition](#Auth-Definition) name to be used to access to resource defined in the operation parameter | string | no |
+| authRef | References an [auth definition](#Auth-Definition) name to be used to access the resource defined in the operation parameter | string | no |
 | [metadata](#Workflow-Metadata) | Metadata information. Can be used to define custom function information | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -3539,10 +3539,10 @@ If `false`, both Event payload and context attributes should be accessible.
 
 ##### Auth Definition
 
-Auth definitions can be used to define authentication information that should be applied
+Auth definitions can be used to define authentication information that is applied
 to resources defined in the operation property of [function definitions](#Function-Definition).
-It is not used as authentication information for the function invocation, but just to access
-the resource containing the function invocation information.
+
+If defined, it will replace the [security scheme]() described in the OpenAPI file.
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:
There's a small lack of clarity in the usage of the `authDef` in the function defintions.

**Special notes for reviewers**:
Please see #612 for more context.

**Additional information (if needed):**