### PR TITLE
Added the possibility to name the default switch condition

### DIFF
--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1204,6 +1204,10 @@
       "type": "object",
       "description": "DefaultCondition definition. Can be either a transition or end definition",
       "properties": {
+        "name":{
+          "type": "string",
+          "description": "The optional name of the default condition, used solely for display purposes"
+        },
         "transition": {
           "$ref": "#/definitions/transition"
         },


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [ ] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

Adds the ability to optionally name the default switch condition, for display purpose.

This would allow a more ubiquitous representation of flows, unlike:

![image](https://user-images.githubusercontent.com/16137162/167620376-5be0b289-6f1a-40b4-8261-7b0b822fb555.png)