### PR TITLE
Changed the `$CONST` keyword into `$CONSTANTS` for ubiquity purpose

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4649,12 +4649,12 @@ decide which activity to perform based on the transaction value.
     {
      "name": "Process Larger Transaction",
      "functionRef": "Banking Service - Larger Tx",
-     "condition": "${ .tx >= $CONST.largetxamount }"
+     "condition": "${ .tx >= $CONSTANTS.largetxamount }"
     },
     {
      "name": "Process Smaller Transaction",
      "functionRef": "Banking Service - Smaller Tx",
-     "condition": "${ .tx < $CONST.largetxamount }"
+     "condition": "${ .tx < $CONSTANTS.largetxamount }"
     }
    ],
    "end": true
@@ -4694,10 +4694,10 @@ states:
    actions:
     - name: Process Larger Transaction
       functionRef: Banking Service - Larger Tx
-      condition: "${ .tx >= $CONST.largetxamount }"
+      condition: "${ .tx >= $CONSTANTS.largetxamount }"
     - name: Process Smaller Transaction
       functionRef: Banking Service - Smaller Tx
-      condition: "${ .tx < $CONST.largetxamount }"
+      condition: "${ .tx < $CONSTANTS.largetxamount }"
    end: true
 functions:
  - name: Banking Service - Larger Tx

--- a/specification.md
+++ b/specification.md
@@ -5963,8 +5963,8 @@ for example:
 }
 ```
 
-Constants can only be accessed inside Workflow expressions via the `$CONST` variable.
-Runtimes must make `$CONST` available to expressions as a predefined variable.
+Constants can only be accessed inside Workflow expressions via the `$CONSTANTS` variable.
+Runtimes must make `$CONSTANTS` available to expressions as a predefined variable.
 
 Here is an example of using constants in Workflow expressions:
 
@@ -5984,12 +5984,12 @@ Here is an example of using constants in Workflow expressions:
      "dataConditions": [
         {
           "name": "Applicant is adult",
-          "condition": "${ .applicant | .age >= $CONST.AGE.MIN_ADULT }",
+          "condition": "${ .applicant | .age >= $CONSTANTS.AGE.MIN_ADULT }",
           "transition": "ApproveApplication"
         },
         {
           "name": "Applicant is minor",
-          "condition": "${ .applicant | .age < $CONST.AGE.MIN_ADULT }",
+          "condition": "${ .applicant | .age < $CONSTANTS.AGE.MIN_ADULT }",
           "transition": "RejectApplication"
         }
      ],
@@ -6008,12 +6008,12 @@ for example:
 "functions": [
   {
     "name": "isAdult",
-    "operation": ".applicant | .age >= $CONST.AGE.MIN_ADULT",
+    "operation": ".applicant | .age >= $CONSTANTS.AGE.MIN_ADULT",
     "type": "expression"
   },
   {
     "name": "isMinor",
-    "operation": ".applicant | .age < $CONST.AGE.MIN_ADULT",
+    "operation": ".applicant | .age < $CONSTANTS.AGE.MIN_ADULT",
     "type": "expression"
   }
 ]


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

Changes the `$CONST` keyword into `$CONSTANTS` for ubiquity purpose