### PR TITLE
Remove redundant line in Data Merging Section

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -984,8 +984,6 @@ would produce state data:
 
 Merging string types should be done by overwriting the data from events data/action results into the merging element of the state data.
 
-Merging number types should be done by overwriting the data from events data/action results into the merging element of the state data.
-
 ### Workflow Functions
 
 Workflow [functions](#Function-Definition) are reusable definitions for service invocations and/or expression evaluation.


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
Don't NEED.
**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

the line appears 2 times in L960 & L987 , remove L987.
`Merging number types should be done by overwriting the data from events data/action results into the merging element of the state data.`

**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->