### PR TITLE
Resource and invocation authentication definition

### DIFF
--- a/schema/functions.json
+++ b/schema/functions.json
@@ -54,9 +54,32 @@
           "default": "rest"
         },
         "authRef": {
-          "type": "string",
-          "description": "References an auth definition name to be used to access to resource defined in the operation parameter",
-          "minLength": 1
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "References the auth definition to be used to invoke the operation",
+              "minLength": 1
+            },
+            {
+              "type": "object",
+              "description": "Configures both the auth definition used to retrieve the operation's resource and the auth definition used to invoke said operation",
+              "properties":{
+                "resource":{
+                  "type": "string",
+                  "description": "References an auth definition to be used to access the resource defined in the operation parameter",
+                  "minLength": 1
+                },
+                "invocation":{
+                  "type": "string",
+                  "description": "References an auth definition to be used to invoke the operation"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "resource"
+              ]
+            }
+          ]
         },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"

--- a/specification.md
+++ b/specification.md
@@ -3272,8 +3272,11 @@ defined via the `parameters` property in [function definitions](#FunctionRef-Def
 | resource | References an auth definition to be used to access the resource defined in the operation parameter | string | yes |
 | invocation | References an auth definition to be used to invoke the operation | string | no |
 
-The `authRef` property references a name of a defined workflow [auth definition](#Auth-Definition).
-It can be a string, in which case the referenced [auth definition](#Auth-Definition) is used solely for the function's invocation, or an object, in which case it is possible to specify an [auth definition](#Auth-Definition) to use for the function's resource retrieval (as defined by the `operation` property) and another for its invocation.
+The `authRef` property references a name of a defined workflow [auth definition](#Auth-Definition). It can be a string or an object.
+
+If it's a string, the referenced [auth definition](#Auth-Definition) is used solely for the function's invocation.
+
+If it's an object, it is possible to specify an [auth definition](#Auth-Definition) to use for the function's resource retrieval (as defined by the `operation` property) and another for its invocation.
 
 Example of a function definition configured to use an [auth definition](#Auth-Definition) called "My Basic Auth" upon invocation:
 
@@ -3295,7 +3298,7 @@ functions:
     invocation: My OIDC Auth
 ```
 
-Note that if multiple functions share the same `operation` value, and if one of them defines an [auth definition](#Auth-Definition) for resource access, then it should always be used to access said resource.
+Note that if multiple functions share the same `operation` path (*which is the first component of the operation value, located before the first '#' character*), and if one of them defines an [auth definition](#Auth-Definition) for resource access, then it should always be used to access said resource.
 In other words, when retrieving the resource of the function "MySecuredFunction2" defined in the following example, the "My Api Key Auth" [auth definition](#Auth-Definition) should be used, because the "MySecuredFunction1" has defined it for resource access. 
 This is done to avoid unnecessary repetitions of [auth definition](#Auth-Definition) configuration when using the same resource for multiple defined functions.
 

--- a/specification.md
+++ b/specification.md
@@ -3312,6 +3312,8 @@ functions:
     operation: https://secure.resources.com/myapi.json#holaMundo
 ```
 
+It's worth noting that if an [auth definition](#Auth-Definition) has been defined for an OpenAPI function which's resource declare an authentication mechanism, the later should be used instead, thus ignoring entirely the [auth definition](#Auth-Definition).
+
 ##### Event Definition
 
 | Parameter | Description | Type | Required |


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
#612 

**What this PR does / why we need it**:
Adds the possibility to configure the `authDefinition` to use for both function's resource access and function invocation.

**Special notes for reviewers**:
As discussed in #612, using a string-based `authRef` defines the `authDefinition` to use to invoke the configured function.

Also, as proposed by @ricardozanini, if the `resource` auth of a function has been defined, all other functions using the same resource (as defined by the `operation` property) must implicitly used the configured authDefinition. In other words, a resource auth definition is tightly coupled to its resource, even if it is omitted by other functions using the same resource.