### PR TITLE
Fixes #420 - Add http invocation function definition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # They will be requested for
 # review when someone opens a pull request.
-*       @tsurdilo @ricardozanini @manuelstein @cdavernas @antmendoza
+*       @tsurdilo @ricardozanini @cdavernas @antmendoza

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,5 @@
 # Serverless Workflow Org Maintainers
 
-* [Manuel Stein](https://github.com/manuelstein)
 * [Tihomir Surdilovic](https://github.com/tsurdilo)
 * [Ricardo Zanini](https://github.com/ricardozanini)
 * [Charles d'Avernas](https://github.com/cdavernas)

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # See the GOVERNANCE.md document for the definition of the roles and responsibilities
 maintainers:
   - tsurdilo
-  - manuelstein
   - ricardozanini
   - cdavernas
   - antmendoza

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Cloud Native Sandbox level project on July 14, 2020.
 - [Community](#Community)
   - [Communication](#Communication)
   - [Code of Conduct](#Code-of-Conduct)
-  - [Meetings](#Meetings)
-  - [Meeting Minutes](#Meeting-Minutes)
+  - [Weekly Meetings](#Weekly-Meetings)
 - [Repository Structure](#Repository-Structure)
 - [Support](#Support)
 
@@ -121,39 +120,16 @@ religion, or nationality.
 
 See our full project Code of Conduct information [here](code-of-conduct.md).
 
-### Meetings
+### Weekly Meetings
 
-* [CNCF public events calendar](https://www.cncf.io/calendar/)
+The Serverless Workflow team meets weekly, every Monday at 11AM ET (USA Eastern Time).
 
-The Serverless Workflow team meets weekly, every Wednesday at 11AM ET (USA Eastern Time).
-
-Join from PC, Mac, Linux, iOS or Android via [zoom](https://zoom.us/my/cncfserverlesswg?pwd=YjNqYzhOdjRRd01YWFkzS1lHbDZqUT09)
-
-Or iPhone one-tap :
-
-    US: +16465588656,,3361029682#  or +16699006833,,3361029682#
-
-Or Telephone:
-
-    Dial:
-        US: +1 646 558 8656 (US Toll) or +1 669 900 6833 (US Toll)
-        or +1 855 880 1246 (Toll Free) or +1 877 369 0926 (Toll Free)
-
-Meeting ID: 336 102 9682
-
-International numbers available:
-https://zoom.us/zoomconference?m=QpOqQYfTzY_Gbj9_8jPtsplp1pnVUKDr
-
-NOTE: Please use \*6 to mute/un-mute your phone during the call.
+To register for meetings please visit our [website](https://serverlessworkflow.io/) and click on the
+"Register for Weekly Project Meetings" button.
+You can register for individual meetings or for the entire series.
 
 World Time Zone Converter:
 http://www.thetimezoneconverter.com/?t=9:00%20am&tz=San%20Francisco&
-
-### Meeting Minutes
-
-You can find meeting minutes [here](meetingminutes).
-Note that unfortunately we have lost our Google doc which contained meeting info for our prior meetings.
-We will move all meeting info to our github repo so that this never happens again.
 
 ## Repository Structure
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -35,8 +35,8 @@ _Status description:_
 | ✔️| Apply fixes to auth spec schema [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/schema)  |
 | ✔️| Update the `dataInputSchema` top-level property by supporting the assignment of a JSON schema object [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/specification.md#workflow-definition-structure)  |
 | ✔️| Add the new `WORKFLOW` reserved keyword to workflow expressions  |
+| ✔️| Add the new `http` function type [spec doc](https://github.com/serverlessworkflow/specification/tree/main/specification.md#using-functions-for-http-service-invocations) |
 | ✏️️| Add inline state defs in branches |   |
-| ✏️️| Update rest function definition |   |
 | ✏️️| Add "completedBy" functionality |   |
 | ✏️️| Define workflow context |   |
 | ✏️️| Start work on TCK  |   |

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -35,16 +35,15 @@
           "minLength": 1
         },
         "operation": {
-          "type": "string",
-          "description": "If type is `rest`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \\\"mutation\\\" or \\\"query\\\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression. If type is `http`, <HTTP_method>#<request_target>",
-          "minLength": 1
+          "type": "object",
+          "$ref": "#/definitions/operation"
         },
         "type": {
           "type": "string",
-          "description": "Defines the function type. Is either `rest`, `http`,`asyncapi, `rpc`, `graphql`, `odata`, `expression`, or `custom`. Default is `rest`",
+          "description": "Defines the function type. Is either `rest`, `openapi`,`asyncapi, `rpc`, `graphql`, `odata`, `expression`, or `custom`. Default is `openapi`.",
           "enum": [
             "rest",
-            "http",
+            "openapi",
             "asyncapi",
             "rpc",
             "graphql",
@@ -52,7 +51,7 @@
             "expression",
             "custom"
           ],
-          "default": "rest"
+          "default": "openapi"
         },
         "authRef": {
           "oneOf": [
@@ -64,13 +63,13 @@
             {
               "type": "object",
               "description": "Configures both the auth definition used to retrieve the operation's resource and the auth definition used to invoke said operation",
-              "properties":{
-                "resource":{
+              "properties": {
+                "resource": {
                   "type": "string",
                   "description": "References an auth definition to be used to access the resource defined in the operation parameter",
                   "minLength": 1
                 },
-                "invocation":{
+                "invocation": {
                   "type": "string",
                   "description": "References an auth definition to be used to invoke the operation"
                 }
@@ -90,6 +89,25 @@
       "required": [
         "name",
         "operation"
+      ]
+    },
+    "operation": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "If type is `openapi`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \\\"mutation\\\" or \\\"query\\\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression.",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "description": "OpenAPI Path Object definition",
+          "$comment": "https://spec.openapis.org/oas/v3.1.0#paths-object",
+          "patternProperties": {
+            "^/": {
+              "type": "object"
+            }
+          }
+        }
       ]
     }
   }

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -54,9 +54,32 @@
           "default": "rest"
         },
         "authRef": {
-          "type": "string",
-          "description": "References an auth definition name to be used to access to resource defined in the operation parameter",
-          "minLength": 1
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "References the auth definition to be used to invoke the operation",
+              "minLength": 1
+            },
+            {
+              "type": "object",
+              "description": "Configures both the auth definition used to retrieve the operation's resource and the auth definition used to invoke said operation",
+              "properties":{
+                "resource":{
+                  "type": "string",
+                  "description": "References an auth definition to be used to access the resource defined in the operation parameter",
+                  "minLength": 1
+                },
+                "invocation":{
+                  "type": "string",
+                  "description": "References an auth definition to be used to invoke the operation"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "resource"
+              ]
+            }
+          ]
         },
         "metadata": {
           "$ref": "common.json#/definitions/metadata"

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -36,14 +36,15 @@
         },
         "operation": {
           "type": "string",
-          "description": "If type is `rest`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \\\"mutation\\\" or \\\"query\\\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression.",
+          "description": "If type is `rest`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \\\"mutation\\\" or \\\"query\\\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression. If type is `http`, <HTTP_method>#<request_target>",
           "minLength": 1
         },
         "type": {
           "type": "string",
-          "description": "Defines the function type. Is either `rest`, `asyncapi, `rpc`, `graphql`, `odata`, `expression`, or `custom`. Default is `rest`",
+          "description": "Defines the function type. Is either `rest`, `http`,`asyncapi, `rpc`, `graphql`, `odata`, `expression`, or `custom`. Default is `rest`",
           "enum": [
             "rest",
+            "http",
             "asyncapi",
             "rpc",
             "graphql",

--- a/specification.md
+++ b/specification.md
@@ -3698,18 +3698,18 @@ This is visualized in the diagram below:
 
 ##### Action Definition
 
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| name | Unique Action name | string | no |
-| [functionRef](#FunctionRef-Definition) | References a reusable function definition | object | yes if `eventRef` & `subFlowRef` are not defined |
-| [eventRef](#EventRef-Definition) | References a `produce` and `consume` reusable event definitions | object | yes if `functionRef` & `subFlowRef` are not defined |
-| [subFlowRef](#SubFlowRef-Definition) | References a workflow to be invoked | object or string | yes if `eventRef` & `functionRef` are not defined |
-| [retryRef](#retry-definition) | References a defined workflow retry definition. If not defined uses the default runtime retry definition | string | no |
-| nonRetryableErrors | List of references to defined [workflow errors](#Defining Errors) for which the action should not be retried. Used only when `autoRetries` is set to `true` | array | no |
-| retryableErrors | List of references to defined [workflow errors](#Defining Errors) for which the action should be retried. Used only when `autoRetries` is set to `false` | array | no |
-| [actionDataFilter](#Action-data-filters) | Action data filter definition | object | no |
-| sleep | Defines time periods workflow execution should sleep before / after function execution | object | no |
-| [condition](#Workflow-Expressions) | Expression, if defined, must evaluate to true for this action to be performed. If false, action is disregarded | boolean | no |
+| Parameter                                | Description                                                                                                                                                 | Type             | Required                                            |
+|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|-----------------------------------------------------|
+| name                                     | Unique Action name                                                                                                                                          | string           | no                                                  |
+| [functionRef](#FunctionRef-Definition)   | References a reusable function definition                                                                                                                   | object           | yes if `eventRef` & `subFlowRef` are not defined    |
+| [eventRef](#EventRef-Definition)         | References a `produce` and `consume` reusable event definitions                                                                                             | object           | yes if `functionRef` & `subFlowRef` are not defined |
+| [subFlowRef](#SubFlowRef-Definition)     | References a workflow to be invoked                                                                                                                         | object or string | yes if `eventRef` & `functionRef` are not defined   |
+| [retryRef](#retry-definition)            | References a defined workflow retry definition. If not defined uses the default runtime retry definition                                                    | string           | no                                                  |
+| nonRetryableErrors                       | List of references to defined [workflow errors](#Defining-Errors) for which the action should not be retried. Used only when `autoRetries` is set to `true` | array            | no                                                  |
+| retryableErrors                          | List of references to defined [workflow errors](#Defining-Errors) for which the action should be retried. Used only when `autoRetries` is set to `false`    | array            | no                                                  |
+| [actionDataFilter](#Action-data-filters) | Action data filter definition                                                                                                                               | object           | no                                                  |
+| sleep                                    | Defines time periods workflow execution should sleep before / after function execution                                                                      | object           | no                                                  |
+| [condition](#Workflow-Expressions)       | Expression, if defined, must evaluate to true for this action to be performed. If false, action is disregarded                                              | boolean          | no                                                  |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>

--- a/specification.md
+++ b/specification.md
@@ -2275,20 +2275,20 @@ Note that `transition` and `end` properties are mutually exclusive, meaning that
 
 ##### Operation State
 
-| Parameter                                     | Description                                                                         | Type    | Required                    |
-|-----------------------------------------------|-------------------------------------------------------------------------------------|---------|-----------------------------|
-| name                                          | Unique State name                                                                   | string  | yes                         |
-| type                                          | State type                                                                          | string  | yes                         |
-| actionMode                                    | Should actions be performed sequentially or in parallel                             | enum    | no                          |
-| [actions](#Action-Definition)                 | Actions to be performed                                                             | array   | yes                         |
-| [timeouts](#Workflow-Timeouts)                | State specific timeout settings                                                     | object  | no                          |
-| [stateDataFilter](#State-data-filters)        | State data filter                                                                   | object  | no                          |
-| [onErrors](#Error-Definition)                 | States error handling and retries definitions                                       | array   | no                          |
-| [transition](#Transitions)                    | Next transition of the workflow after all the actions have been performed           | object  | yes (if end is not defined) |
-| [compensatedBy](#Workflow-Compensation)       | Unique name of a workflow state which is responsible for compensation of this state | String  | no                          |
-| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false"         | boolean | no                          |
-| [metadata](#Workflow-Metadata)                | Metadata information                                                                | object  | no                          |
-| [end](#End-Definition)                        | Is this state an end state                                                          | object  | no                          |
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| name | Unique State name | string | yes |
+| type | State type | string | yes |
+| actionMode | Should actions be performed sequentially or in parallel | enum | no |
+| [actions](#Action-Definition) | Actions to be performed | array | yes |
+| [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |
+| [stateDataFilter](#State-data-filters) | State data filter | object | no |
+| [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
+| [transition](#Transitions) | Next transition of the workflow after all the actions have been performed | object | yes (if end is not defined) |
+| [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
+| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
+| [metadata](#Workflow-Metadata) | Metadata information| object | no |
+| [end](#End-Definition) | Is this state an end state | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -2843,24 +2843,24 @@ Note that `transition` and `end` properties are mutually exclusive, meaning that
 
 ##### ForEach State
 
-| Parameter                                     | Description                                                                                                                                                                                         | Type             | Required                           |
-|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|------------------------------------|
-| name                                          | Unique State name                                                                                                                                                                                   | string           | yes                                |
-| type                                          | State type                                                                                                                                                                                          | string           | yes                                |
-| inputCollection                               | Workflow expression selecting an array element of the states data                                                                                                                                   | string           | yes                                |
-| outputCollection                              | Workflow expression specifying an array element of the states data to add the results of each iteration                                                                                             | string           | no                                 |
-| iterationParam                                | Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array                   | string           | no                                 |
-| batchSize                                     | Specifies how many iterations may run in parallel at the same time. Used if `mode` property is set to `parallel` (default). If not specified, its value should be the size of the `inputCollection` | string or number | no                                 |
-| mode                                          | Specifies how iterations are to be performed (sequentially or in parallel). Default is `parallel`                                                                                                   | enum             | no                                 |
-| [actions](#Action-Definition)                 | Actions to be executed for each of the elements of inputCollection                                                                                                                                  | array            | yes                                |
-| [timeouts](#Workflow-Timeouts)                | State specific timeout settings                                                                                                                                                                     | object           | no                                 |
-| [stateDataFilter](#State-data-filters)        | State data filter definition                                                                                                                                                                        | object           | no                                 |
-| [onErrors](#Error-Definition)                 | States error handling and retries definitions                                                                                                                                                       | array            | no                                 |
-| [transition](#Transitions)                    | Next transition of the workflow after state has completed                                                                                                                                           | object           | yes if "end" is not defined        |
-| [compensatedBy](#Workflow-Compensation)       | Unique name of a workflow state which is responsible for compensation of this state                                                                                                                 | String           | no                                 |
-| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false"                                                                                                                         | boolean          | no                                 |
-| [metadata](#Workflow-Metadata)                | Metadata information                                                                                                                                                                                | object           | no                                 |
-| [end](#End-Definition)                        | Is this state an end state                                                                                                                                                                          | object           | yes if "transition" is not defined |
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| name | Unique State name | string | yes |
+| type | State type | string | yes |
+| inputCollection | Workflow expression selecting an array element of the states data | string | yes |
+| outputCollection | Workflow expression specifying an array element of the states data to add the results of each iteration | string | no |
+| iterationParam | Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array | string | no |
+| batchSize | Specifies how many iterations may run in parallel at the same time. Used if `mode` property is set to `parallel` (default). If not specified, its value should be the size of the `inputCollection` | string or number | no |
+| mode | Specifies how iterations are to be performed (sequentially or in parallel). Default is `parallel` | enum  | no |
+| [actions](#Action-Definition) | Actions to be executed for each of the elements of inputCollection | array | yes |
+| [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |
+| [stateDataFilter](#State-data-filters) | State data filter definition | object | no |
+| [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
+| [transition](#Transitions) | Next transition of the workflow after state has completed | object | yes if "end" is not defined |
+| [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
+| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
+| [metadata](#Workflow-Metadata) | Metadata information| object | no |
+| [end](#End-Definition) | Is this state an end state | object | yes if "transition" is not defined |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3596,12 +3596,12 @@ The `contextAttributeValue` property defines the value of the defined CloudEvent
 
 ##### OnEvents Definition
 
-| Parameter                              | Description                                                                                     | Type   | Required |
-|----------------------------------------|-------------------------------------------------------------------------------------------------|--------|----------|
-| eventRefs                              | References one or more unique event names in the defined workflow [events](#Event-Definition)   | array  | yes      |
-| actionMode                             | Specifies how actions are to be performed (in sequence or in parallel). Default is `sequential` | enum   | no       |
-| [actions](#Action-Definition)          | Actions to be performed                                                                         | array  | no       |
-| [eventDataFilter](#Event-data-filters) | Event data filter definition                                                                    | object | no       |
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| eventRefs | References one or more unique event names in the defined workflow [events](#Event-Definition) | array | yes |
+| actionMode | Specifies how actions are to be performed (in sequence or in parallel). Default is `sequential` | enum | no |
+| [actions](#Action-Definition) | Actions to be performed | array | no |
+| [eventDataFilter](#Event-data-filters) | Event data filter definition | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3698,18 +3698,18 @@ This is visualized in the diagram below:
 
 ##### Action Definition
 
-| Parameter                                | Description                                                                                                                                                 | Type             | Required                                            |
-|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|-----------------------------------------------------|
-| name                                     | Unique Action name                                                                                                                                          | string           | no                                                  |
-| [functionRef](#FunctionRef-Definition)   | References a reusable function definition                                                                                                                   | object           | yes if `eventRef` & `subFlowRef` are not defined    |
-| [eventRef](#EventRef-Definition)         | References a `produce` and `consume` reusable event definitions                                                                                             | object           | yes if `functionRef` & `subFlowRef` are not defined |
-| [subFlowRef](#SubFlowRef-Definition)     | References a workflow to be invoked                                                                                                                         | object or string | yes if `eventRef` & `functionRef` are not defined   |
-| [retryRef](#retry-definition)            | References a defined workflow retry definition. If not defined uses the default runtime retry definition                                                    | string           | no                                                  |
-| nonRetryableErrors                       | List of references to defined [workflow errors](#Defining-Errors) for which the action should not be retried. Used only when `autoRetries` is set to `true` | array            | no                                                  |
-| retryableErrors                          | List of references to defined [workflow errors](#Defining-Errors) for which the action should be retried. Used only when `autoRetries` is set to `false`    | array            | no                                                  |
-| [actionDataFilter](#Action-data-filters) | Action data filter definition                                                                                                                               | object           | no                                                  |
-| sleep                                    | Defines time periods workflow execution should sleep before / after function execution                                                                      | object           | no                                                  |
-| [condition](#Workflow-Expressions)       | Expression, if defined, must evaluate to true for this action to be performed. If false, action is disregarded                                              | boolean          | no                                                  |
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| name | Unique Action name | string | no |
+| [functionRef](#FunctionRef-Definition) | References a reusable function definition | object | yes if `eventRef` & `subFlowRef` are not defined |
+| [eventRef](#EventRef-Definition) | References a `produce` and `consume` reusable event definitions | object | yes if `functionRef` & `subFlowRef` are not defined |
+| [subFlowRef](#SubFlowRef-Definition) | References a workflow to be invoked | object or string | yes if `eventRef` & `functionRef` are not defined |
+| [retryRef](#retry-definition) | References a defined workflow retry definition. If not defined uses the default runtime retry definition | string | no |
+| nonRetryableErrors | List of references to defined [workflow errors](#Defining-Errors) for which the action should not be retried. Used only when `autoRetries` is set to `true` | array | no |
+| retryableErrors | List of references to defined [workflow errors](#Defining-Errors) for which the action should be retried. Used only when `autoRetries` is set to `false` | array | no |
+| [actionDataFilter](#Action-data-filters) | Action data filter definition | object | no |
+| sleep | Defines time periods workflow execution should sleep before / after function execution | object | no |
+| [condition](#Workflow-Expressions) | Expression, if defined, must evaluate to true for this action to be performed. If false, action is disregarded | boolean | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3825,12 +3825,12 @@ Note that if used with `string` type, the invocation of the function is synchron
 If you need to define parameters in your `functionRef` definition, you can define
 it with its `object` type which has the following properties:
 
-| Parameter    | Description                                                                                                                                  | Type   | Required                                        |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|--------|-------------------------------------------------|
-| refName      | Name of the referenced [function](#Function-Definition)                                                                                      | string | yes                                             |
-| arguments    | Arguments (inputs) to be passed to the referenced function                                                                                   | object | yes if function type is `graphql`, otherwise no |
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| refName | Name of the referenced [function](#Function-Definition) | string | yes |
+| arguments | Arguments (inputs) to be passed to the referenced function | object | yes if function type is `graphql`, otherwise no |
 | selectionSet | Used if function type is `graphql`. String containing a valid GraphQL [selection set](https://spec.graphql.org/June2018/#sec-Selection-Sets) | string | yes if function type is `graphql`, otherwise no |
-| invoke       | Specifies if the function should be invoked `sync` or `async`. Default is `sync`                                                             | enum   | no                                              |
+| invoke | Specifies if the function should be invoked `sync` or `async`. Default is `sync` | enum | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3898,14 +3898,14 @@ onErrors definition. Note that errors raised during functions that are invoked a
 
 Allows defining invocation of a function via event. 
 
-| Parameter                            | Description                                                                                                                                                                                                                                                       | Type             | Required |
-|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------|
-| [produceEventRef](#Event-Definition) | Reference to the unique name of a `produced` event definition                                                                                                                                                                                                     | string           | yes      |
-| [consumeEventRef](#Event-Definition) | Reference to the unique name of a `consumed` event definition                                                                                                                                                                                                     | string           | no       |
-| consumeEventTimeout                  | Maximum amount of time (ISO 8601 format) to wait for the consume event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition)                                                                                                    | string           | no       |
-| data                                 | If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by `produceEventRef`. If object type, a custom object to become the data (payload) of the event referenced by `produceEventRef`. | string or object | no       |
-| contextAttributes                    | Add additional event extension context attributes to the trigger/produced event                                                                                                                                                                                   | object           | no       |
-| invoke                               | Specifies if the function should be invoked `sync` or `async`. Default is `sync`                                                                                                                                                                                  | enum             | no       |
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| [produceEventRef](#Event-Definition) | Reference to the unique name of a `produced` event definition | string | yes |
+| [consumeEventRef](#Event-Definition) | Reference to the unique name of a `consumed` event definition | string | no |
+| consumeEventTimeout | Maximum amount of time (ISO 8601 format) to wait for the consume event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition) | string | no |
+| data | If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by `produceEventRef`. If object type, a custom object to become the data (payload) of the event referenced by `produceEventRef`. | string or object | no |
+| contextAttributes | Add additional event extension context attributes to the trigger/produced event | object | no |
+| invoke | Specifies if the function should be invoked sync or async. Default is sync | enum | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3980,12 +3980,12 @@ property and not its `version` property.
 
 If you need to define the `version` properties, you can use its `object` type:
 
-| Parameter        | Description                                                                                                                                    | Type   | Required |
-|------------------|------------------------------------------------------------------------------------------------------------------------------------------------|--------|----------|
-| workflowId       | Sub-workflow unique id                                                                                                                         | string | yes      |
-| version          | Sub-workflow version                                                                                                                           | string | no       |
-| invoke           | Specifies if the subflow should be invoked `sync` or `async`. Default is `sync`                                                                | enum   | no       |
-| onParentComplete | If `invoke` is `async`, specifies if subflow execution should `terminate` or `continue` when parent workflow completes. Default is `terminate` | enum   | no       |
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| workflowId | Sub-workflow unique id | string | yes |
+| version | Sub-workflow version | string | no |
+| invoke | Specifies if the subflow should be invoked `sync` or `async`. Default is `sync` | enum | no |
+| onParentComplete | If `invoke` is `async`, specifies if subflow execution should `terminate` or `continue` when parent workflow completes. Default is `terminate` | enum | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>

--- a/specification.md
+++ b/specification.md
@@ -3272,8 +3272,11 @@ defined via the `parameters` property in [function definitions](#FunctionRef-Def
 | resource | References an auth definition to be used to access the resource defined in the operation parameter | string | yes |
 | invocation | References an auth definition to be used to invoke the operation | string | no |
 
-The `authRef` property references a name of a defined workflow [auth definition](#Auth-Definition).
-It can be a string, in which case the referenced [auth definition](#Auth-Definition) is used solely for the function's invocation, or an object, in which case it is possible to specify an [auth definition](#Auth-Definition) to use for the function's resource retrieval (as defined by the `operation` property) and another for its invocation.
+The `authRef` property references a name of a defined workflow [auth definition](#Auth-Definition). It can be a string or an object.
+
+If it's a string, the referenced [auth definition](#Auth-Definition) is used solely for the function's invocation.
+
+If it's an object, it is possible to specify an [auth definition](#Auth-Definition) to use for the function's resource retrieval (as defined by the `operation` property) and another for its invocation.
 
 Example of a function definition configured to use an [auth definition](#Auth-Definition) called "My Basic Auth" upon invocation:
 
@@ -3295,7 +3298,7 @@ functions:
     invocation: My OIDC Auth
 ```
 
-Note that if multiple functions share the same `operation` value, and if one of them defines an [auth definition](#Auth-Definition) for resource access, then it should always be used to access said resource.
+Note that if multiple functions share the same `operation` path (*which is the first component of the operation value, located before the first '#' character*), and if one of them defines an [auth definition](#Auth-Definition) for resource access, then it should always be used to access said resource.
 In other words, when retrieving the resource of the function "MySecuredFunction2" defined in the following example, the "My Api Key Auth" [auth definition](#Auth-Definition) should be used, because the "MySecuredFunction1" has defined it for resource access. 
 This is done to avoid unnecessary repetitions of [auth definition](#Auth-Definition) configuration when using the same resource for multiple defined functions.
 

--- a/specification.md
+++ b/specification.md
@@ -3825,12 +3825,12 @@ Note that if used with `string` type, the invocation of the function is synchron
 If you need to define parameters in your `functionRef` definition, you can define
 it with its `object` type which has the following properties:
 
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| refName | Name of the referenced [function](#Function-Definition) | string | yes |
-| arguments | Arguments (inputs) to be passed to the referenced function | object | yes if function type is `graphql`, otherwise no |
+| Parameter    | Description                                                                                                                                  | Type   | Required                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|--------|-------------------------------------------------|
+| refName      | Name of the referenced [function](#Function-Definition)                                                                                      | string | yes                                             |
+| arguments    | Arguments (inputs) to be passed to the referenced function                                                                                   | object | yes if function type is `graphql`, otherwise no |
 | selectionSet | Used if function type is `graphql`. String containing a valid GraphQL [selection set](https://spec.graphql.org/June2018/#sec-Selection-Sets) | string | yes if function type is `graphql`, otherwise no |
-| invoke | Specifies if the function should be invoked sync or async. Default is sync | string | no |
+| invoke       | Specifies if the function should be invoked `sync` or `async`. Default is `sync`                                                             | enum   | no                                              |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>

--- a/specification.md
+++ b/specification.md
@@ -3980,12 +3980,12 @@ property and not its `version` property.
 
 If you need to define the `version` properties, you can use its `object` type:
 
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| workflowId | Sub-workflow unique id | string | yes |
-| version | Sub-workflow version | string | no |
-| invoke | Specifies if the subflow should be invoked sync or async. Default is sync | string | no |
-| onParentComplete | If invoke is 'async', specifies how subflow execution should behave when parent workflow completes. Default is 'terminate' | string | no |
+| Parameter        | Description                                                                                                                                    | Type   | Required |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------|--------|----------|
+| workflowId       | Sub-workflow unique id                                                                                                                         | string | yes      |
+| version          | Sub-workflow version                                                                                                                           | string | no       |
+| invoke           | Specifies if the subflow should be invoked `sync` or `async`. Default is `sync`                                                                | enum   | no       |
+| onParentComplete | If `invoke` is `async`, specifies if subflow execution should `terminate` or `continue` when parent workflow completes. Default is `terminate` | enum   | no       |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>

--- a/specification.md
+++ b/specification.md
@@ -2275,20 +2275,20 @@ Note that `transition` and `end` properties are mutually exclusive, meaning that
 
 ##### Operation State
 
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| name | Unique State name | string | yes |
-| type | State type | string | yes |
-| actionMode | Should actions be performed sequentially or in parallel | string | no |
-| [actions](#Action-Definition) | Actions to be performed | array | yes |
-| [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |
-| [stateDataFilter](#State-data-filters) | State data filter | object | no |
-| [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
-| [transition](#Transitions) | Next transition of the workflow after all the actions have been performed | object | yes (if end is not defined) |
-| [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
-| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
-| [metadata](#Workflow-Metadata) | Metadata information| object | no |
-| [end](#End-Definition) | Is this state an end state | object | no |
+| Parameter                                     | Description                                                                         | Type    | Required                    |
+|-----------------------------------------------|-------------------------------------------------------------------------------------|---------|-----------------------------|
+| name                                          | Unique State name                                                                   | string  | yes                         |
+| type                                          | State type                                                                          | string  | yes                         |
+| actionMode                                    | Should actions be performed sequentially or in parallel                             | enum    | no                          |
+| [actions](#Action-Definition)                 | Actions to be performed                                                             | array   | yes                         |
+| [timeouts](#Workflow-Timeouts)                | State specific timeout settings                                                     | object  | no                          |
+| [stateDataFilter](#State-data-filters)        | State data filter                                                                   | object  | no                          |
+| [onErrors](#Error-Definition)                 | States error handling and retries definitions                                       | array   | no                          |
+| [transition](#Transitions)                    | Next transition of the workflow after all the actions have been performed           | object  | yes (if end is not defined) |
+| [compensatedBy](#Workflow-Compensation)       | Unique name of a workflow state which is responsible for compensation of this state | String  | no                          |
+| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false"         | boolean | no                          |
+| [metadata](#Workflow-Metadata)                | Metadata information                                                                | object  | no                          |
+| [end](#End-Definition)                        | Is this state an end state                                                          | object  | no                          |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -2843,24 +2843,24 @@ Note that `transition` and `end` properties are mutually exclusive, meaning that
 
 ##### ForEach State
 
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| name | Unique State name | string | yes |
-| type | State type | string | yes |
-| inputCollection | Workflow expression selecting an array element of the states data | string | yes |
-| outputCollection | Workflow expression specifying an array element of the states data to add the results of each iteration | string | no |
-| iterationParam | Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array | string | no |
-| batchSize | Specifies how many iterations may run in parallel at the same time. Used if `mode` property is set to `parallel` (default). If not specified, its value should be the size of the `inputCollection` | string or number | no |
-| mode | Specifies how iterations are to be performed (sequentially or in parallel). Default is `parallel` | string  | no |
-| [actions](#Action-Definition) | Actions to be executed for each of the elements of inputCollection | array | yes |
-| [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |
-| [stateDataFilter](#State-data-filters) | State data filter definition | object | no |
-| [onErrors](#Error-Definition) | States error handling and retries definitions | array | no |
-| [transition](#Transitions) | Next transition of the workflow after state has completed | object | yes if "end" is not defined |
-| [compensatedBy](#Workflow-Compensation) | Unique name of a workflow state which is responsible for compensation of this state | String | no |
-| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false" | boolean | no |
-| [metadata](#Workflow-Metadata) | Metadata information| object | no |
-| [end](#End-Definition) | Is this state an end state | object | yes if "transition" is not defined |
+| Parameter                                     | Description                                                                                                                                                                                         | Type             | Required                           |
+|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|------------------------------------|
+| name                                          | Unique State name                                                                                                                                                                                   | string           | yes                                |
+| type                                          | State type                                                                                                                                                                                          | string           | yes                                |
+| inputCollection                               | Workflow expression selecting an array element of the states data                                                                                                                                   | string           | yes                                |
+| outputCollection                              | Workflow expression specifying an array element of the states data to add the results of each iteration                                                                                             | string           | no                                 |
+| iterationParam                                | Name of the iteration parameter that can be referenced in actions/workflow. For each parallel iteration, this param should contain an unique element of the inputCollection array                   | string           | no                                 |
+| batchSize                                     | Specifies how many iterations may run in parallel at the same time. Used if `mode` property is set to `parallel` (default). If not specified, its value should be the size of the `inputCollection` | string or number | no                                 |
+| mode                                          | Specifies how iterations are to be performed (sequentially or in parallel). Default is `parallel`                                                                                                   | enum             | no                                 |
+| [actions](#Action-Definition)                 | Actions to be executed for each of the elements of inputCollection                                                                                                                                  | array            | yes                                |
+| [timeouts](#Workflow-Timeouts)                | State specific timeout settings                                                                                                                                                                     | object           | no                                 |
+| [stateDataFilter](#State-data-filters)        | State data filter definition                                                                                                                                                                        | object           | no                                 |
+| [onErrors](#Error-Definition)                 | States error handling and retries definitions                                                                                                                                                       | array            | no                                 |
+| [transition](#Transitions)                    | Next transition of the workflow after state has completed                                                                                                                                           | object           | yes if "end" is not defined        |
+| [compensatedBy](#Workflow-Compensation)       | Unique name of a workflow state which is responsible for compensation of this state                                                                                                                 | String           | no                                 |
+| [usedForCompensation](#Workflow-Compensation) | If true, this state is used to compensate another state. Default is "false"                                                                                                                         | boolean          | no                                 |
+| [metadata](#Workflow-Metadata)                | Metadata information                                                                                                                                                                                | object           | no                                 |
+| [end](#End-Definition)                        | Is this state an end state                                                                                                                                                                          | object           | yes if "transition" is not defined |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -3596,12 +3596,12 @@ The `contextAttributeValue` property defines the value of the defined CloudEvent
 
 ##### OnEvents Definition
 
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| eventRefs | References one or more unique event names in the defined workflow [events](#Event-Definition) | array | yes |
-| actionMode | Specifies how actions are to be performed (in sequence or in parallel). Default is "sequential" | string | no |
-| [actions](#Action-Definition) | Actions to be performed | array | no |
-| [eventDataFilter](#Event-data-filters) | Event data filter definition | object | no |
+| Parameter                              | Description                                                                                     | Type   | Required |
+|----------------------------------------|-------------------------------------------------------------------------------------------------|--------|----------|
+| eventRefs                              | References one or more unique event names in the defined workflow [events](#Event-Definition)   | array  | yes      |
+| actionMode                             | Specifies how actions are to be performed (in sequence or in parallel). Default is `sequential` | enum   | no       |
+| [actions](#Action-Definition)          | Actions to be performed                                                                         | array  | no       |
+| [eventDataFilter](#Event-data-filters) | Event data filter definition                                                                    | object | no       |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>

--- a/specification.md
+++ b/specification.md
@@ -3312,6 +3312,8 @@ functions:
     operation: https://secure.resources.com/myapi.json#holaMundo
 ```
 
+It's worth noting that if an [auth definition](#Auth-Definition) has been defined for an OpenAPI function which's resource declare an authentication mechanism, the later should be used instead, thus ignoring entirely the [auth definition](#Auth-Definition).
+
 ##### Event Definition
 
 | Parameter | Description | Type | Required |

--- a/specification.md
+++ b/specification.md
@@ -3898,14 +3898,14 @@ onErrors definition. Note that errors raised during functions that are invoked a
 
 Allows defining invocation of a function via event. 
 
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| [produceEventRef](#Event-Definition) | Reference to the unique name of a `produced` event definition | string | yes |
-| [consumeEventRef](#Event-Definition) | Reference to the unique name of a `consumed` event definition | string | no |
-| consumeEventTimeout | Maximum amount of time (ISO 8601 format) to wait for the consume event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition) | string | no |
-| data | If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by `produceEventRef`. If object type, a custom object to become the data (payload) of the event referenced by `produceEventRef`. | string or object | no |
-| contextAttributes | Add additional event extension context attributes to the trigger/produced event | object | no |
-| invoke | Specifies if the function should be invoked sync or async. Default is sync | string | no |
+| Parameter                            | Description                                                                                                                                                                                                                                                       | Type             | Required |
+|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------|
+| [produceEventRef](#Event-Definition) | Reference to the unique name of a `produced` event definition                                                                                                                                                                                                     | string           | yes      |
+| [consumeEventRef](#Event-Definition) | Reference to the unique name of a `consumed` event definition                                                                                                                                                                                                     | string           | no       |
+| consumeEventTimeout                  | Maximum amount of time (ISO 8601 format) to wait for the consume event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition)                                                                                                    | string           | no       |
+| data                                 | If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by `produceEventRef`. If object type, a custom object to become the data (payload) of the event referenced by `produceEventRef`. | string or object | no       |
+| contextAttributes                    | Add additional event extension context attributes to the trigger/produced event                                                                                                                                                                                   | object           | no       |
+| invoke                               | Specifies if the function should be invoked `sync` or `async`. Default is `sync`                                                                                                                                                                                  | enum             | no       |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>

--- a/specification.md
+++ b/specification.md
@@ -660,12 +660,12 @@ a workflow with a single event state and show how data filters can be combined.
                         "functionRef": {
                             "refName": "greetingFunction",
                             "arguments": {
-                                "greeting": "${ .spanish } ",
+                                "greeting": "${ .hello.spanish } ",
                                 "customerName": "${ .customerInfo.name } "
                             }
                         },
                         "actionDataFilter": {
-                            "fromStateData": "${ .hello }",
+                            "fromStateData": "${ { hello, customerInfo } }",
                             "results": "${ .greetingMessageResult }",
                             "toStateData": "${ .finalCustomerGreeting }"
                         }
@@ -767,7 +767,7 @@ At this point our state data contains:
 
 ```json
 {
-  "hello": {
+    "hello": {
       "english": "Hello",
       "spanish": "Hola",
       "german": "Hallo",
@@ -790,7 +790,7 @@ At this point our state data contains:
 **(3) Event state performs its actions**:
 Before the first action is executed, its actionDataFilter is invoked. Its "fromStateData" expression filters
 the current state data to select from its data that should be available to action arguments. In this example
-it selects the "hello" property from the current state data.
+it selects the "hello" and "customerInfo" properties from the current state data.
 At this point the action is executed.
 We assume that for this example "greetingFunction" returns:
 
@@ -899,7 +899,7 @@ After merging the state data should be:
 }
 ```
 
-Merging array types should be done by concatenating them into a larger array including unique elements of both arrays.
+Merging array types should be done by concatenating them into a larger array including unique elements of both arrays.  
 To give an example, merging:
 
 ```json


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**: #420 
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
- Limit the `rest` function to OpenAPI specification descriptors
- Add the new `http` function type for simple use cases that requires an HTTP invocation. REST operations can still be performed if well defined in the function definition. Of course, simple use cases are also supported. 

**Special notes for reviewers**:
This is a WIP.

**Additional information:** Based on https://www.rfc-editor.org/rfc/rfc9110.html 
<!-- Optional -->