### PR TITLE
Fix start parameter type

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1771,7 +1771,7 @@ definition "id" must be a constant value.
 | dataInputSchema | Used to validate the workflow data input against a defined JSON Schema| string or object | no |
 | [constants](#Workflow-Constants) | Workflow constants | string or object | no |
 | [secrets](#Workflow-Secrets) | Workflow secrets | string or array | no |
-| [start](#Start-Definition) | Workflow start definition | string | no |
+| [start](#Start-Definition) | Workflow start definition | string or object | no |
 | specVersion | Serverless Workflow specification release version | string | yes |
 | expressionLang | Identifies the expression language used for workflow expressions. Default value is "jq" | string | no |
 | [timeouts](#Workflow-Timeouts) | Defines the workflow default timeout settings | string or object | no |


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
This PR fixes start type in Workflow Definition Structure section. According to [Start definition](https://github.com/serverlessworkflow/specification/blob/0.8.x/specification.md#Start-Definition), start state could be `string` or `object`. [Workflow Definition Structure section](https://github.com/serverlessworkflow/specification/blob/0.8.x/specification.md#workflow-definition-structure) mentions only `string`.

**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->