### PR TITLE
Fixes #420 - Add REST invocation function definition based on OpenAPI Path Object

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -36,8 +36,8 @@ _Status description:_
 | ✔️| Update the `dataInputSchema` top-level property by supporting the assignment of a JSON schema object [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/specification.md#workflow-definition-structure)  |
 | ✔️| Add the new `WORKFLOW` reserved keyword to workflow expressions  |
 | ✔️| Update `ForEach` state iteration parameter example. This parameter is an expression variable, not a JSON property  |
+| ✔️| Add the new `rest` function type [spec doc](https://github.com/serverlessworkflow/specification/tree/main/specification.md#using-functions-for-restful-service-invocations) |
 | ✏️️| Add inline state defs in branches |   |
-| ✏️️| Update rest function definition |   |
 | ✏️️| Add "completedBy" functionality |   |
 | ✏️️| Define workflow context |   |
 | ✏️️| Start work on TCK  |   |

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -36,15 +36,15 @@
           "pattern": "^[a-z0-9](-?[a-z0-9])*$"
         },
         "operation": {
-          "type": "string",
-          "description": "If type is `rest`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \\\"mutation\\\" or \\\"query\\\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression.",
-          "minLength": 1
+          "type": "object",
+          "$ref": "#/definitions/operation"
         },
         "type": {
           "type": "string",
-          "description": "Defines the function type. Is either `rest`, `asyncapi, `rpc`, `graphql`, `odata`, `expression`, or `custom`. Default is `rest`",
+          "description": "Defines the function type. Is either `rest`, `openapi`,`asyncapi, `rpc`, `graphql`, `odata`, `expression`, or `custom`. Default is `openapi`.",
           "enum": [
             "rest",
+            "openapi",
             "asyncapi",
             "rpc",
             "graphql",
@@ -52,7 +52,7 @@
             "expression",
             "custom"
           ],
-          "default": "rest"
+          "default": "openapi"
         },
         "authRef": {
           "oneOf": [
@@ -65,14 +65,14 @@
             {
               "type": "object",
               "description": "Configures both the auth definition used to retrieve the operation's resource and the auth definition used to invoke said operation",
-              "properties":{
-                "resource":{
+              "properties": {
+                "resource": {
                   "type": "string",
                   "description": "References an auth definition to be used to access the resource defined in the operation parameter",
                   "minLength": 1,
                   "pattern": "^[a-z0-9](-?[a-z0-9])*$"
                 },
-                "invocation":{
+                "invocation": {
                   "type": "string",
                   "description": "References an auth definition to be used to invoke the operation"
                 }
@@ -92,6 +92,25 @@
       "required": [
         "name",
         "operation"
+      ]
+    },
+    "operation": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "If type is `openapi`, <path_to_openapi_definition>#<operation_id>. If type is `asyncapi`, <path_to_asyncapi_definition>#<operation_id>. If type is `rpc`, <path_to_grpc_proto_file>#<service_name>#<service_method>. If type is `graphql`, <url_to_graphql_endpoint>#<literal \\\"mutation\\\" or \\\"query\\\">#<query_or_mutation_name>. If type is `odata`, <URI_to_odata_service>#<Entity_Set_Name>. If type is `expression`, defines the workflow expression.",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "description": "OpenAPI Path Object definition",
+          "$comment": "https://spec.openapis.org/oas/v3.1.0#paths-object",
+          "patternProperties": {
+            "^/": {
+              "type": "object"
+            }
+          }
+        }
       ]
     }
   }

--- a/specification.md
+++ b/specification.md
@@ -1092,7 +1092,7 @@ Here is an example function definition for REST requests with method `GET` and r
 }
 ```
 
-Note that the [Function Definition](#Function-Definition)'s `operation` property must follow the OpenAPI Paths Object specification definition.
+Note that the [Function Definition](#Function-Definition)'s `operation` property must follow the [OpenAPI Paths Object](https://spec.openapis.org/oas/v3.1.0#paths-object) specification definition.
 
 The function can be referenced during workflow execution when the invocation of the REST service is desired. For example:
 
@@ -1123,6 +1123,7 @@ Example of the `POST` request sending the state data as part of the body:
   "functions":[
     {
       "name": "createUser",
+      "type": "rest",
       "operation": {
         "/users": {
           "post": {
@@ -1149,16 +1150,15 @@ Example of the `POST` request sending the state data as part of the body:
             }
           }
         }
-      },
-      "type": "rest"
+      }
     }
   ]
 }
 ```
 
-Note that the `requestBody` content schema is described inline rather than a reference to an external document.
+Note that the `requestBody` [`content` attribute](https://spec.openapis.org/oas/v3.1.0#fixed-fields-10) is described inline rather than a reference to an external document.
 
-You can reference the `createUser` function and filter the input data to invoke it, as shown in the example below:
+You can reference the `createUser` function and filter the input data to invoke it. Given the workflow input data:
 
 ```json
 {
@@ -1220,7 +1220,7 @@ In this case, only the contents of the `user` attribute will be passed to the fu
 }
 ```
 
-The specification does not support the [Security Requirement Object](https://spec.openapis.org/oas/v3.1.0#security-requirement-object). To define authentication for the REST operation, use the [Auth Definition](#Auth-Definition). If provided, this field is ignored.
+The specification does not support the [Security Requirement Object](https://spec.openapis.org/oas/v3.1.0#security-requirement-object) since its redundat to function [Auth Definition](#Auth-Definition). If provided, this field is ignored.
 
 #### Using Functions for Async API Service Invocations
 
@@ -3416,7 +3416,7 @@ operation: https://hellworldservice.api.com/api.json#helloWorld
 
 The `name` property defines an unique name of the function definition.
 
-The `type` property defines the function type. Its value can be either `rest`, `openapi` or `expression`. Default value is `openapi`.
+The `type` enum property defines the function type. Its value can be either `rest`, `openapi` or `expression`. Default value is `openapi`.
 
 Depending on the function `type`, the `operation` property can be:
 


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
See #647 

**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
In our latest Community Meeting, we discussed the possibility of adding support for RESTful operation descriptors in the Function definitions based on OpenAPI Path Item object. Here's the PR. The former PR has been closed.

**Special notes for reviewers**:
The "Security Object" will be ignored by the specification since we already have the Auth Definition to fit this role. Two places to define the same information can be troublesome and error prune.

**Additional information:**
<!-- Optional -->
See reference: https://spec.openapis.org/oas/v3.1.0#paths-object