### PR TITLE
Book Lending Example Fix

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3936,6 +3936,22 @@ For the sake of the example we assume the functions and event definitions are de
    "transition": "Sleep two weeks"
   },
   {
+   "name": "Cancel Request",
+   "type": "operation",
+   "actions": [
+    {
+     "functionRef": {
+      "refName": "Cancel hold request for lender",
+      "arguments": {
+       "bookid": "${ .book.id }",
+       "lender": "${ .lender }"
+      }
+     }
+    }
+   ],
+   "transition": "Sleep two weeks"
+  },
+  {
    "name": "Sleep two weeks",
    "type": "sleep",
    "duration": "PT2W",
@@ -4035,6 +4051,15 @@ states:
         bookid: "${ .book.id }"
         lender: "${ .lender }"
    transition: Sleep two weeks
+ - name: Cancel Request
+   type: operation
+   actions:
+    - functionRef:
+       refName: Cancel hold request for lender
+       arguments:
+        bookid: "${ .book.id }"
+        lender: "${ .lender }"
+   end: true
  - name: Sleep two weeks
    type: sleep
    duration: PT2W


### PR DESCRIPTION
The Book Lending Example JSON/YAML Definitions differed from the Workflow Diagram shown above them. Here I just created the missing state so both are in sync.

**Parts of this PR update:**

- [ ] Specification
- [ ] Schema
- [x] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
[Book Lending Example is missing a state.](https://github.com/serverlessworkflow/specification/issues/662)

**What this PR does / why we need it**:
It adds the missing state to the definitions and syncs the definitions and diagram.

**Additional information:**
The missing state is called "Cancel Request". It is referenced by the "Wait for Lender response" state in the "Decline Book Hold" event condition transition.