### PR TITLE
Update the specification.md and events.json to make both `source` and `type` eventDef properties optional

### DIFF
--- a/schema/events.json
+++ b/schema/events.json
@@ -74,22 +74,21 @@
       "additionalProperties": false,
       "if": {
         "properties": {
-          "kind": {
-            "const": "consumed"
+          "source": {
+            "type": "null"
           }
         }
       },
       "then": {
         "required": [
           "name",
-          "source",
           "type"
         ]
       },
       "else": {
         "required": [
           "name",
-          "type"
+          "source"
         ]
       }
     },

--- a/specification.md
+++ b/specification.md
@@ -3271,8 +3271,8 @@ defined via the `parameters` property in [function definitions](#FunctionRef-Def
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name | Unique event name | string | yes |
-| source | CloudEvent source | string | yes if kind is set to "consumed", otherwise no |
-| type | CloudEvent type | string | yes |
+| source | CloudEvent source | string | no if `type` is set, otherwise yes. If not set when `kind` is `produced`, runtimes are expected to use a default value, such as https://serverlessworkflow.io in order to comply with the [CloudEvent spec constraints](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1) |
+| type | CloudEvent type | string | no if `source` is set, otherwise yes  |
 | kind | Defines the event is either `consumed` or `produced` by the workflow. Default is `consumed` | enum | no |
 | [correlation](#Correlation-Definition) | Define event correlation rules for this event. Only used for consumed events | array | no |
 | dataOnly | If `true` (default value), only the Event payload is accessible to consuming Workflow states. If `false`, both event payload and context attributes should be accessible | boolean | no |


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
https://github.com/serverlessworkflow/specification/issues/677#issuecomment-1246874381
https://github.com/serverlessworkflow/specification/issues/677#issuecomment-1246915553

**What this PR does / why we need it**:
Updates the specification.md and events.json to make both `source` and `type` eventDef properties optional