### PR TITLE
ForEach iteration param access

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -35,6 +35,7 @@ _Status description:_
 | ✔️| Apply fixes to auth spec schema [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/schema)  |
 | ✔️| Update the `dataInputSchema` top-level property by supporting the assignment of a JSON schema object [workflow schema](https://github.com/serverlessworkflow/specification/tree/main/specification.md#workflow-definition-structure)  |
 | ✔️| Add the new `WORKFLOW` reserved keyword to workflow expressions  |
+| ✔️| Update `ForEach` state iteration parameter example. This parameter is an expression variable, not a JSON property  |
 | ✏️️| Add inline state defs in branches |   |
 | ✏️️| Update rest function definition |   |
 | ✏️️| Add "completedBy" functionality |   |

--- a/specification.md
+++ b/specification.md
@@ -2884,7 +2884,7 @@ Note that `transition` and `end` properties are mutually exclusive, meaning that
             "functionRef": {
                 "refName": "provisionOrderFunction",
                 "arguments": {
-                    "order": "${ .singleorder }"
+                    "order": "${ $singleorder }"
                 }
             }
         }
@@ -2905,7 +2905,7 @@ actions:
 - functionRef:
     refName: provisionOrderFunction
     arguments:
-      order: "${ .singleorder }"
+      order: "${ $singleorder }"
 ```
 
 </td>
@@ -2938,6 +2938,7 @@ of each iteration should be added to. If this array does not exist, it should be
 
 The `iterationParam` property defines the name of the iteration parameter passed to each iteration of the ForEach state.
 It should contain the unique element of the `inputCollection` array and made available to actions of the ForEach state.
+`iterationParam` can be accessed as an expression variable. In JQ, expression variables are prefixed by $. 
 If `iterationParam` is not explicitly defined, runtimes should create one and populate it with the value of the unique 
 iteration parameter for each iteration of the ForEach state.
 
@@ -3004,8 +3005,8 @@ and our workflow is defined as:
        "functionRef": {
          "refName": "sendConfirmationFunction",
          "arguments": {
-           "orderNumber": "${ .completedorder.orderNumber }",
-           "email": "${ .completedorder.email }"
+           "orderNumber": "${ $completedorder.orderNumber }",
+           "email": "${ $completedorder.email }"
          }
        }
       }],
@@ -3036,8 +3037,8 @@ states:
   - functionRef:
       refName: sendConfirmationFunction
       arguments:
-        orderNumber: "${ .completedorder.orderNumber }"
-        email: "${ .completedorder.email }"
+        orderNumber: "${ $completedorder.orderNumber }"
+        email: "${ $completedorder.email }"
   end: true
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -2938,7 +2938,7 @@ of each iteration should be added to. If this array does not exist, it should be
 
 The `iterationParam` property defines the name of the iteration parameter passed to each iteration of the ForEach state.
 It should contain the unique element of the `inputCollection` array and made available to actions of the ForEach state.
-`iterationParam` can be accessed as an expression variable. In JQ, expression variables are prefixed by $. 
+`iterationParam` can be accessed as an expression variable. [In JQ, expression variables are prefixed by $](https://stedolan.github.io/jq/manual/#Variable/SymbolicBindingOperator:...as$identifier|...). 
 If `iterationParam` is not explicitly defined, runtimes should create one and populate it with the value of the unique 
 iteration parameter for each iteration of the ForEach state.
 


### PR DESCRIPTION

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
https://github.com/serverlessworkflow/specification/issues/682
**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
Replacing . by $. $ is the prefix used by jq for accessing variables. This prevents implementors to have to temporarily add iterationParam to the workflow model in order to evaluate the expression.

**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->