### PR TITLE
Enforced semantic versioning for `version`

### DIFF
--- a/comparisons/comparison-argo.md
+++ b/comparisons/comparison-argo.md
@@ -76,7 +76,7 @@ spec:
 ```yaml
 id: hello-world-parameters
 name: Hello World with parameters
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: whalesay
 functions:
@@ -155,7 +155,7 @@ spec:
 ```yaml
 id: hello-hello-hello
 name: Multi Step Hello
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: hello1
 functions:
@@ -257,7 +257,7 @@ spec:
 ```yaml
 id: dag-diamond-
 name: DAG Diamond Example
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: A
 functions:
@@ -376,7 +376,7 @@ spec:
 ```yaml
 id: scripts-bash-
 name: Scripts and Results Example
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: generate
 functions:
@@ -472,7 +472,7 @@ spec:
 ```yaml
 id: loops-
 name: Loop over data example
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: injectdata
 functions:
@@ -567,7 +567,7 @@ spec:
 ```yaml
 id: coinflip-
 name: Conditionals Example
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: flip-coin
 functions:
@@ -660,7 +660,7 @@ spec:
 ```yaml
 id: retry-backoff-
 name: Retry Example
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: retry-backoff
 functions:
@@ -746,7 +746,7 @@ spec:
 ```yaml
 id: coinflip-recursive-
 name: Recursion Example
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: flip-coin-state
 functions:
@@ -856,7 +856,7 @@ spec:
 ```yaml
 id: exit-handlers-
 name: Exit/Error Handling Example
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 autoRetries: true
 start: intentional-fail-state

--- a/comparisons/comparison-bpmn.md
+++ b/comparisons/comparison-bpmn.md
@@ -51,7 +51,7 @@ For this reason, the event, function, retry, and data mapping defined in the ass
 ```yaml
 id: processfile
 name: Process File Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Process File
 states:
@@ -87,7 +87,7 @@ functions:
 ```yaml
 id: processapplication
 name: Process Application
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: ProcessNewApplication
 states:
@@ -141,7 +141,7 @@ events:
 ```yaml
 id: simplecompensation
 name: Simple Compensation
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Step 1
 states:
@@ -203,7 +203,7 @@ functions:
 ---
 id: errorwithretries
 name: Error Handling With Retries Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Make Coffee
 states:
@@ -267,7 +267,7 @@ functions:
 ```yaml
 id: executiontimeout
 name: Execution Timeout Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Purchase Parts
 timeouts:
@@ -321,7 +321,7 @@ functions:
 ```yaml
 id: foreachWorkflow
 name: ForEach State Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: ForEachItem
 states:
@@ -360,7 +360,7 @@ a starting "operation" state transitioning to an "event" state which waits for t
 ```yaml
 id: subflowloop
 name: SubFlow Loop Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: SubflowRepeat
 states:
@@ -410,7 +410,7 @@ control-flow logic to check email and make a decision to reply to it or wait an 
 ```yaml
 id: approvereport
 name: Approve Report Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Approve Report
 states:
@@ -473,7 +473,7 @@ functions:
 ```yaml
 id: eventdecision
 name: Event Decision workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: A
 states:

--- a/comparisons/comparison-brigade.md
+++ b/comparisons/comparison-brigade.md
@@ -64,7 +64,7 @@ function exec(e, p) {
 ```yaml
 id: greeting
 name: Greeting Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: GreetingState
 events:
@@ -144,7 +144,7 @@ async function exec(e, p) {
 ```yaml
 id: greetingwitherrorcheck
 name: Greeting Workflow With Error Check
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 autoRetries: true
 start: GreetingState
@@ -239,7 +239,7 @@ events.on("push", () => {
 ```yaml
 id: multieventworkflow
 name: Multiple Events Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: GreetingState
 events:
@@ -324,7 +324,7 @@ events.on("exec", () => {
 ```yaml
 id: groupActionsWorkflow
 name: Group Actions Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: FirstGreetGroup
 events:
@@ -403,7 +403,7 @@ events.on("exec", (e, p) => {
 ```yaml
 id: eventDataWorkflow
 name: Event Data Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: LogEventData
 events:
@@ -480,7 +480,7 @@ events.on("exec", (e, p) => {
 ```yaml
 id: actionResultsWorkflow
 name: Action Results Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: ExecActionsAndStoreResults
 events:
@@ -571,7 +571,7 @@ events.on("next", (e) => {
 ```yaml
 id: eventDataWorkflow
 name: Event Data Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: ExecEventState
 events:

--- a/comparisons/comparison-temporal.md
+++ b/comparisons/comparison-temporal.md
@@ -82,7 +82,7 @@ public static class GreetingWorkflowImpl implements GreetingWorkflow {
 {
   "id": "greetingworkflow",
   "name": "Greeting Workflow",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "autoRetries": true,
   "states": [
@@ -164,7 +164,7 @@ WorkflowOptions workflowOptions =
 {
   "id": "greetingworkflow",
   "name": "Greeting Workflow",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "autoRetries": true,
   "timeouts": {
@@ -268,7 +268,7 @@ WorkflowOptions workflowOptions =
 {
   "id": "HelloSaga",
   "name": "Hello SAGA compensation Workflow",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "states": [
     {
@@ -392,7 +392,7 @@ static class GreetingActivitiesImpl implements GreetingActivities {
 {
   "id": "HelloActivityRetry",
   "name": "Hello Activity with Retries Workflow",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "autoRetries": true,
   "start": "GreetingState",

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,7 +67,7 @@ data output, which is:
 ```json
 {
 "id": "helloworld",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "name": "Hello World Workflow",
 "description": "Inject Hello World",
@@ -90,7 +90,7 @@ data output, which is:
 
 ```yaml
 id: helloworld
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Hello World Workflow
 description: Inject Hello World
@@ -151,7 +151,7 @@ Which is added to the states data and becomes the workflow data output.
 ```json
 {
 "id": "greeting",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "name": "Greeting Workflow",
 "description": "Greet Someone",
@@ -190,7 +190,7 @@ Which is added to the states data and becomes the workflow data output.
 
 ```yaml
 id: greeting
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Greeting Workflow
 description: Greet Someone
@@ -296,7 +296,7 @@ filters what is selected to be the state data output which then becomes the work
 ```json
 {
 "id": "eventbasedgreeting",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "name": "Event Based Greeting Workflow",
 "description": "Event Based Greeting",
@@ -349,7 +349,7 @@ filters what is selected to be the state data output which then becomes the work
 
 ```yaml
 id: eventbasedgreeting
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Event Based Greeting Workflow
 description: Event Based Greeting
@@ -424,7 +424,7 @@ result of the workflow execution.
 ```json
 {
 "id": "solvemathproblems",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "name": "Solve Math Problems Workflow",
 "description": "Solve math problems",
@@ -466,7 +466,7 @@ result of the workflow execution.
 
 ```yaml
 id: solvemathproblems
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Solve Math Problems Workflow
 description: Solve math problems
@@ -521,7 +521,7 @@ to finish execution before it can transition (end workflow execution in this cas
 ```json
 {
 "id": "parallelexec",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "name": "Parallel Execution Workflow",
 "description": "Executes two branches in parallel",
@@ -556,7 +556,7 @@ to finish execution before it can transition (end workflow execution in this cas
 
 ```yaml
 id: parallelexec
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Parallel Execution Workflow
 description: Executes two branches in parallel
@@ -611,7 +611,7 @@ does not wait for its results.
 ```json
 {
  "id": "sendcustomeremail",
- "version": "1.0",
+ "version": "1.0.0"
  "specVersion": "0.8",
  "name": "Send customer email workflow",
  "description": "Send email to a customer",
@@ -648,7 +648,7 @@ does not wait for its results.
 
 ```yaml
 id: sendcustomeremail
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Send customer email workflow
 description: Send email to a customer
@@ -702,7 +702,7 @@ property to `continue`.
 ```json
 {
  "id": "onboardcustomer",
- "version": "1.0",
+ "version": "1.0.0"
  "specVersion": "0.8",
  "name": "Onboard Customer",
  "description": "Onboard a Customer",
@@ -732,7 +732,7 @@ property to `continue`.
 
 ```yaml
 id: onboardcustomer
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Onboard Customer
 description: Onboard a Customer
@@ -745,7 +745,7 @@ states:
        invoke: async
        onParentComplete: continue
        workflowId: customeronboardingworkflow
-       version: '1.0'
+       version: '1.0.0'
    end: true
 ```
 
@@ -784,7 +784,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
 ```json
 {
 "id": "eventbasedswitchstate",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "name": "Event Based Switch Transitions",
 "description": "Event Based Switch Transitions",
@@ -861,7 +861,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
 
 ```yaml
 id: eventbasedswitchstate
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Event Based Switch Transitions
 description: Event Based Switch Transitions
@@ -946,7 +946,7 @@ If the applicants age is over 18 we start the application (subflow action). Othe
 ```json
 {
    "id": "applicantrequest",
-   "version": "1.0",
+   "version": "1.0.0"
    "specVersion": "0.8",
    "name": "Applicant Request Decision Workflow",
    "description": "Determine if applicant request is valid",
@@ -1010,7 +1010,7 @@ If the applicants age is over 18 we start the application (subflow action). Othe
 
 ```yaml
 id: applicantrequest
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Applicant Request Decision Workflow
 description: Determine if applicant request is valid
@@ -1090,7 +1090,7 @@ The data output of the workflow contains the information of the exception caught
 ```json
 {
 "id": "provisionorders",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "name": "Provision Orders",
 "description": "Provision Orders and handle errors thrown",
@@ -1195,7 +1195,7 @@ The data output of the workflow contains the information of the exception caught
 
 ```yaml
 id: provisionorders
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Provision Orders
 description: Provision Orders and handle errors thrown
@@ -1286,7 +1286,7 @@ In the case job submission raises a runtime error, we transition to an Operation
 ```json
 {
   "id": "jobmonitoring",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "name": "Job Monitoring",
   "description": "Monitor finished execution of a submitted job",
@@ -1418,7 +1418,7 @@ In the case job submission raises a runtime error, we transition to an Operation
 
 ```yaml
 id: jobmonitoring
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Job Monitoring
 description: Monitor finished execution of a submitted job
@@ -1577,7 +1577,7 @@ CloudEvent upon completion of the workflow could look like:
 ```json
 {
 "id": "sendcloudeventonprovision",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "name": "Send CloudEvent on provision completion",
 "start": "ProvisionOrdersState",
@@ -1627,7 +1627,7 @@ CloudEvent upon completion of the workflow could look like:
 
 ```yaml
 id: sendcloudeventonprovision
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Send CloudEvent on provision completion
 start: ProvisionOrdersState
@@ -1711,7 +1711,7 @@ have the matching patient id.
 {
 "id": "patientVitalsWorkflow",
 "name": "Monitor Patient Vitals",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "start": "MonitorVitals",
 "events": [
@@ -1812,7 +1812,7 @@ have the matching patient id.
 ```yaml
 id: patientVitalsWorkflow
 name: Monitor Patient Vitals
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: MonitorVitals
 events:
@@ -1906,7 +1906,7 @@ when all three of these events happened (in no particular order).
 {
 "id": "finalizeCollegeApplication",
 "name": "Finalize College Application",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "start": "FinalizeApplication",
 "events": [
@@ -1985,7 +1985,7 @@ when all three of these events happened (in no particular order).
 ```yaml
 id: finalizeCollegeApplication
 name: Finalize College Application
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: FinalizeApplication
 events:
@@ -2117,7 +2117,7 @@ And for denied credit check, for example:
 ```json
 {
     "id": "customercreditcheck",
-    "version": "1.0",
+    "version": "1.0.0"
     "specVersion": "0.8",
     "name": "Customer Credit Check Workflow",
     "description": "Perform Customer Credit Check",
@@ -2214,7 +2214,7 @@ And for denied credit check, for example:
 
 ```yaml
 id: customercreditcheck
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Customer Credit Check Workflow
 description: Perform Customer Credit Check
@@ -2322,7 +2322,7 @@ Bidding is done via an online application and bids are received as events are as
 ```json
 {
     "id": "handleCarAuctionBid",
-    "version": "1.0",
+    "version": "1.0.0"
     "specVersion": "0.8",
     "name": "Car Auction Bidding Workflow",
     "description": "Store a single bid whole the car auction is active",
@@ -2372,7 +2372,7 @@ Bidding is done via an online application and bids are received as events are as
 
 ```yaml
 id: handleCarAuctionBid
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Car Auction Bidding Workflow
 description: Store a single bid whole the car auction is active
@@ -2452,7 +2452,7 @@ The results of the inbox service called is expected to be for example:
 {
 "id": "checkInbox",
 "name": "Check Inbox Workflow",
-"version": "1.0",
+"version": "1.0.0"
 "specVersion": "0.8",
 "description": "Periodically Check Inbox",
 "start": {
@@ -2511,7 +2511,7 @@ The results of the inbox service called is expected to be for example:
 id: checkInbox
 name: Check Inbox Workflow
 description: Periodically Check Inbox
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start:
   stateName: CheckInbox
@@ -2596,7 +2596,7 @@ For this example we assume that the workflow instance is started given the follo
     "id": "VetAppointmentWorkflow",
     "name": "Vet Appointment Workflow",
     "description": "Vet service call via events",
-    "version": "1.0",
+    "version": "1.0.0"
     "specVersion": "0.8",
     "start": "MakeVetAppointmentState",
     "events": [
@@ -2646,7 +2646,7 @@ For this example we assume that the workflow instance is started given the follo
 id: VetAppointmentWorkflow
 name: Vet Appointment Workflow
 description: Vet service call via events
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: MakeVetAppointmentState
 events:
@@ -2747,7 +2747,7 @@ In our workflow definition then we can reference these files rather than definin
 ```json
 {
   "id": "paymentconfirmation",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "name": "Payment Confirmation Workflow",
   "description": "Performs Payment Confirmation",
@@ -2848,7 +2848,7 @@ In our workflow definition then we can reference these files rather than definin
 
 ```yaml
 id: paymentconfirmation
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Payment Confirmation Workflow
 description: Performs Payment Confirmation
@@ -2951,7 +2951,7 @@ If the retries are not successful, we want to just gracefully end workflow execu
 {
   "id": "patientonboarding",
   "name": "Patient Onboarding Workflow",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "start": "Onboard",
   "states": [
@@ -3034,7 +3034,7 @@ If the retries are not successful, we want to just gracefully end workflow execu
 ```yaml
 id: patientonboarding
 name: Patient Onboarding Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Onboard
 states:
@@ -3123,7 +3123,7 @@ This example shows the use of the workflow [execTimeout definition](../specifica
 {
   "id": "order",
   "name": "Purchase Order Workflow",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "start": "StartNewOrder",
   "timeouts": {
@@ -3284,7 +3284,7 @@ This example shows the use of the workflow [execTimeout definition](../specifica
 ```yaml
 id: order
 name: Purchase Order Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: StartNewOrder
 
@@ -3407,7 +3407,7 @@ the data for an hour, send report, and so on.
 {
   "id": "roomreadings",
   "name": "Room Temp and Humidity Workflow",
-  "version": "1.0",
+  "version": "1.0.0"
   "specVersion": "0.8",
   "start": "ConsumeReading",
   "timeouts": {
@@ -3497,7 +3497,7 @@ the data for an hour, send report, and so on.
 ```yaml
 id: roomreadings
 name: Room Temp and Humidity Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: ConsumeReading
 timeouts:
@@ -3581,7 +3581,7 @@ We fist define our top-level workflow for this example:
 {
  "id": "checkcarvitals",
  "name": "Check Car Vitals Workflow",
- "version": "1.0",
+ "version": "1.0.0"
  "specVersion": "0.8",
  "start": "WhenCarIsOn",
  "states": [
@@ -3644,7 +3644,7 @@ We fist define our top-level workflow for this example:
 ```yaml
 id: checkcarvitals
 name: Check Car Vitals Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: WhenCarIsOn
 states:
@@ -3696,7 +3696,7 @@ And then our reusable sub-workflow which performs the checking of our car vitals
 {
  "id": "vitalscheck",
  "name": "Car Vitals Check",
- "version": "1.0",
+ "version": "1.0.0"
  "specVersion": "0.8",
  "start": "CheckVitals",
  "states": [
@@ -3755,7 +3755,7 @@ And then our reusable sub-workflow which performs the checking of our car vitals
 ```yaml
 id: vitalscheck
 name: Car Vitals Check
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: CheckVitals
 states:
@@ -3836,7 +3836,7 @@ For the sake of the example we assume the functions and event definitions are de
 {
  "id": "booklending",
  "name": "Book Lending Workflow",
- "version": "1.0",
+ "version": "1.0.0"
  "specVersion": "0.8",
  "start": "Book Lending Request",
  "states": [
@@ -3993,7 +3993,7 @@ For the sake of the example we assume the functions and event definitions are de
 ```yaml
 id: booklending
 name: Book Lending Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Book Lending Request
 states:
@@ -4128,7 +4128,7 @@ Its results are then merged back into the state data according to the "toStateDa
 {
  "id": "fillglassofwater",
  "name": "Fill glass of water workflow",
- "version": "1.0",
+ "version": "1.0.0"
  "specVersion": "0.8",
  "start": "Check if full",
  "functions": [
@@ -4181,7 +4181,7 @@ Its results are then merged back into the state data according to the "toStateDa
 ```yaml
 id: fillglassofwater
 name: Fill glass of water workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Check if full
 functions:
@@ -4328,7 +4328,7 @@ With the function and event definitions in place we can now start writing our ma
 ```yaml
 id: foodorderworkflow
 name: Food Order Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Place Order
 functions: file://orderfunctions.yml
@@ -4376,7 +4376,7 @@ With this in place we can start defining our sub-workflows:
 ```yaml
 id: placeorderworkflow
 name: Place Order Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Submit Order
 states:
@@ -4410,7 +4410,7 @@ states:
 ```yaml
 id: deliverorderworkflow
 name: Deliver Order Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: Dispatch Courier
 states:
@@ -4541,7 +4541,7 @@ We assume that our workflow input has the runtime-imposed quota:
      "end":{
       "continueAs": {
        "workflowId": "notifycustomerworkflow",
-       "version": "1.0",
+       "version": "1.0.0"
        "data": "${ del(.customerCount) }"
       }
      }
@@ -4574,7 +4574,7 @@ We assume that our workflow input has the runtime-imposed quota:
 ```yaml
 id: notifycustomerworkflow
 name: Notify Customer
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: WaitForCustomerEvent
 states:
@@ -4602,7 +4602,7 @@ states:
       end:
        continueAs:
         workflowId: notifycustomerworkflow
-        version: '1.0'
+        version: '1.0.0'
         data: "${ del(.customerCount) }"
    defaultCondition:
     transition: WaitForCustomerEvent
@@ -4661,7 +4661,7 @@ decide which activity to perform based on the transaction value.
 {
  "id": "customerbankingtransactions",
  "name": "Customer Banking Transactions Workflow",
- "version": "1.0",
+ "version": "1.0.0"
  "specVersion": "0.8",
  "autoRetries": true,
  "constants": {
@@ -4709,7 +4709,7 @@ decide which activity to perform based on the transaction value.
 ```yaml
 id: bankingtransactions
 name: Customer Banking Transactions Workflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 autoRetries: true
 constants:

--- a/extensions/kpi.md
+++ b/extensions/kpi.md
@@ -124,7 +124,7 @@ extensions definition yaml is located in a resource accessible via URI:
 ```yaml
 id: patientVitalsWorkflow
 name: Monitor Patient Vitals
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: MonitorVitals
 extensions:

--- a/extensions/ratelimiting.md
+++ b/extensions/ratelimiting.md
@@ -60,7 +60,7 @@ extensions definition yaml is located in a resource accessible via URI:
 ```yaml
 id: processapplication
 name: Process Application
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 extensions:
   - extensionId: workflow-ratelimiting-extension

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -44,6 +44,7 @@ _Status description:_
 | ✏️️| Add integration with open-source runtimes  |   |
 | ✏️️| Add SDKs for more languages (Python, PHP, Rust, etc) |   |
 | ✏️️| Add more samples  |   |
+| ✏️️| Enforce SemVer `version`  |   |
 
 ## <a name="v08"></a> Released version v0.8
 

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -26,7 +26,8 @@
     "version": {
       "type": "string",
       "description": "Workflow version",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     },
     "annotations": {
       "type": "array",
@@ -274,7 +275,8 @@
             "version": {
               "type": "string",
               "description": "Version of the workflow to continue execution as",
-              "minLength": 1
+              "minLength": 1,
+              "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
             },
             "data": {
               "type": [
@@ -595,7 +597,8 @@
             "version": {
               "type": "string",
               "description": "Version of the sub-workflow to be invoked",
-              "minLength": 1
+              "minLength": 1,
+              "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
             },
             "onParentComplete": {
               "type": "string",

--- a/specification.md
+++ b/specification.md
@@ -642,7 +642,7 @@ a workflow with a single event state and show how data filters can be combined.
 {
     "id": "GreetCustomersWorkflow",
     "name": "Greet Customers when they arrive",
-    "version": "1.0",
+    "version": "1.0.0",
     "specVersion": "0.8",
     "start": "WaitForCustomerToArrive",
     "states":[
@@ -1766,7 +1766,7 @@ definition "id" must be a constant value.
 | key | Domain-specific workflow identifier | string | yes if `id` not defined |
 | name | Workflow name | string | no |
 | description | Workflow description | string | no |
-| version | Workflow version | string | no |
+| version | Workflow version. MUST respect the [semantic versioning](https://semver.org/) format | string | no |
 | annotations | List of helpful terms describing the workflows intended purpose, subject areas, or other important qualities | array | no |
 | dataInputSchema | Used to validate the workflow data input against a defined JSON Schema| string or object | no |
 | [constants](#Workflow-Constants) | Workflow constants | string or object | no |
@@ -1800,7 +1800,7 @@ definition "id" must be a constant value.
 ```json
 {
    "id": "sampleWorkflow",
-   "version": "1.0",
+   "version": "1.0.0",
    "specVersion": "0.8",
    "name": "Sample Workflow",
    "description": "Sample Workflow",
@@ -1818,7 +1818,7 @@ definition "id" must be a constant value.
 
 ```yaml
 id: sampleWorkflow
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 name: Sample Workflow
 description: Sample Workflow
@@ -1854,7 +1854,7 @@ The `name` property is the workflow logical name.
 
 The `description` property can be used to give further information about the workflow.
 
-The `version` property can be used to provide a specific workflow version.
+The `version` property can be used to provide a specific workflow version. It must use the [semantic versioning](https://semver.org/) format.
 
 The `annotations` property defines a list of helpful terms describing the workflows intended purpose, subject areas, or other important qualities,
 for example "machine learning", "monitoring", "networking", etc
@@ -1999,7 +1999,7 @@ Here is an example of using external resource for function definitions:
 ```json
 {
    "id": "sampleWorkflow",
-   "version": "1.0",
+   "version": "1.0.0",
    "specVersion": "0.8",
    "name": "Sample Workflow",
    "description": "Sample Workflow",
@@ -2036,7 +2036,7 @@ Here is an example of using external resource for event definitions:
 ```json
 {
    "id": "sampleWorkflow",
-   "version": "1.0",
+   "version": "1.0.0",
    "specVersion": "0.8",
    "name": "Sample Workflow",
    "description": "Sample Workflow",
@@ -2984,7 +2984,7 @@ and our workflow is defined as:
 {
   "id": "sendConfirmWorkflow",
   "name": "SendConfirmationForCompletedOrders",
-  "version": "1.0",
+  "version": "1.0.0",
   "specVersion": "0.8",
   "start": "SendConfirmState",
   "functions": [
@@ -3021,7 +3021,7 @@ and our workflow is defined as:
 ```yaml
 id: sendConfirmWorkflow
 name: SendConfirmationForCompletedOrders
-version: '1.0'
+version: '1.0.0'
 specVersion: '0.8'
 start: SendConfirmState
 functions:
@@ -4048,7 +4048,7 @@ If you need to define the `version` properties, you can use its `object` type:
 ```json
 {
     "workflowId": "handleApprovedVisaWorkflowID",
-    "version": "2.0"
+    "version": "2.0.0"
 }
 ```
 
@@ -4057,7 +4057,7 @@ If you need to define the `version` properties, you can use its `object` type:
 
 ```yaml
 workflowId: handleApprovedVisaWorkflowID
-version: '2.0'
+version: '2.0.0'
 ```
 
 </td>
@@ -4970,7 +4970,7 @@ Let's take a look at an example of additional properties:
 ```json
 {
   "id": "myworkflow",
-  "version": "1.0",
+  "version": "1.0.0",
   "specVersion": "0.8",
   "name": "My Test Workflow",
   "start": "My First State",
@@ -4988,7 +4988,7 @@ Note the same can be also specified using workflow metadata, which is the prefer
 ```json
 {
   "id": "myworkflow",
-  "version": "1.0",
+  "version": "1.0.0",
   "specVersion": "0.8",
   "name": "Py Test Workflow",
   "start": "My First State",
@@ -5987,13 +5987,7 @@ There are two places in the [workflow definition](#Workflow-Definition-Structure
 1. Top level workflow definition `version` property.
 2. Actions [subflowRef](#SubFlowRef-Definition) `version` property.
 
-The Serverless Workflow specification does not mandate a specific versioning strategy
-for the top level and actions subflowRef definitions `version` properties. It does not mandate the use
-of a versioning strategy at all. We do recommend however that you do use a versioning strategy
-for your workflow definitions especially in production environments.
-
-To enhance portability when using versioning of your workflow and sub-workflow definitions,
-we recommend using an existing versioning standard such as [SemVer](https://semver.org/) for example.
+The `version` property must respect the [semantic versioning](https://semver.org/) guidelines.
 
 ### Workflow Constants
 
@@ -6140,7 +6134,7 @@ Here is an example of metadata attached to the core workflow definition:
 {
   "id": "processSalesOrders",
   "name": "Process Sales Orders",
-  "version": "1.0",
+  "version": "1.0.0",
   "specVersion": "0.8",
   "start": "MyStartingState",
   "metadata": {
@@ -6176,7 +6170,7 @@ Implementations may use this keyword to give access to any relevant information 
 {
   "id": "processSalesOrders",
   "name": "Process Sales Orders",
-  "version": "1.0",
+  "version": "1.0.0",
   "specVersion": "0.8",
   "start": "MyStartingState",
   "functions": [{


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [x] Roadmap
- [x] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
Related to #688

**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
The version is used to distinguish different iterations of a said workflow. For instance, a user creates a workflow named Beautiful Workflow. After some time, something needs to be changed for whatever reason. The user updates the Beautiful Workflow. There are two versions of the same workflow living side by side, for instance 1.0.0 and 1.1.0.
Currently, a version could be anything, a user could deploy workflows such as { "name": "pokemon", "version": "red" } and { "name": "pokemon", "version": "blue" }. 
We agreed that a version should be iterative and respect the semantic versioning guidelines.

**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->