### PR TITLE
fix(spec): update operation state actionMode defaults to sequential

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2278,7 +2278,7 @@ Note that `transition` and `end` properties are mutually exclusive, meaning that
 | --- | --- | --- | --- |
 | name | Unique State name | string | yes |
 | type | State type | string | yes |
-| actionMode | Should actions be performed sequentially or in parallel | enum | no |
+| actionMode | Should actions be performed sequentially or in parallel. Default is `sequential`  | enum | no |
 | [actions](#Action-Definition) | Actions to be performed | array | yes |
 | [timeouts](#Workflow-Timeouts) | State specific timeout settings | object | no |
 | [stateDataFilter](#State-data-filters) | State data filter | object | no |


### PR DESCRIPTION
Signed-off-by: lsytj0413 <511121939@qq.com>

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

In specification, OperationState's actionMode is an ENUM and optional field, it must have a defaults value. 

**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->