### PR TITLE
Fix missing comma after `"version": "1.0.0"`

### DIFF
--- a/comparisons/comparison-temporal.md
+++ b/comparisons/comparison-temporal.md
@@ -82,7 +82,7 @@ public static class GreetingWorkflowImpl implements GreetingWorkflow {
 {
   "id": "greetingworkflow",
   "name": "Greeting Workflow",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "autoRetries": true,
   "states": [
@@ -164,7 +164,7 @@ WorkflowOptions workflowOptions =
 {
   "id": "greetingworkflow",
   "name": "Greeting Workflow",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "autoRetries": true,
   "timeouts": {
@@ -268,7 +268,7 @@ WorkflowOptions workflowOptions =
 {
   "id": "HelloSaga",
   "name": "Hello SAGA compensation Workflow",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "states": [
     {
@@ -392,7 +392,7 @@ static class GreetingActivitiesImpl implements GreetingActivities {
 {
   "id": "HelloActivityRetry",
   "name": "Hello Activity with Retries Workflow",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "autoRetries": true,
   "start": "GreetingState",

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,7 +67,7 @@ data output, which is:
 ```json
 {
 "id": "helloworld",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "name": "Hello World Workflow",
 "description": "Inject Hello World",
@@ -151,7 +151,7 @@ Which is added to the states data and becomes the workflow data output.
 ```json
 {
 "id": "greeting",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "name": "Greeting Workflow",
 "description": "Greet Someone",
@@ -296,7 +296,7 @@ filters what is selected to be the state data output which then becomes the work
 ```json
 {
 "id": "eventbasedgreeting",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "name": "Event Based Greeting Workflow",
 "description": "Event Based Greeting",
@@ -424,7 +424,7 @@ result of the workflow execution.
 ```json
 {
 "id": "solvemathproblems",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "name": "Solve Math Problems Workflow",
 "description": "Solve math problems",
@@ -521,7 +521,7 @@ to finish execution before it can transition (end workflow execution in this cas
 ```json
 {
 "id": "parallelexec",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "name": "Parallel Execution Workflow",
 "description": "Executes two branches in parallel",
@@ -611,7 +611,7 @@ does not wait for its results.
 ```json
 {
  "id": "sendcustomeremail",
- "version": "1.0.0"
+ "version": "1.0.0",
  "specVersion": "0.8",
  "name": "Send customer email workflow",
  "description": "Send email to a customer",
@@ -702,7 +702,7 @@ property to `continue`.
 ```json
 {
  "id": "onboardcustomer",
- "version": "1.0.0"
+ "version": "1.0.0",
  "specVersion": "0.8",
  "name": "Onboard Customer",
  "description": "Onboard a Customer",
@@ -784,7 +784,7 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
 ```json
 {
 "id": "eventbasedswitchstate",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "name": "Event Based Switch Transitions",
 "description": "Event Based Switch Transitions",
@@ -946,7 +946,7 @@ If the applicants age is over 18 we start the application (subflow action). Othe
 ```json
 {
    "id": "applicantrequest",
-   "version": "1.0.0"
+   "version": "1.0.0",
    "specVersion": "0.8",
    "name": "Applicant Request Decision Workflow",
    "description": "Determine if applicant request is valid",
@@ -1090,7 +1090,7 @@ The data output of the workflow contains the information of the exception caught
 ```json
 {
 "id": "provisionorders",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "name": "Provision Orders",
 "description": "Provision Orders and handle errors thrown",
@@ -1286,7 +1286,7 @@ In the case job submission raises a runtime error, we transition to an Operation
 ```json
 {
   "id": "jobmonitoring",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "name": "Job Monitoring",
   "description": "Monitor finished execution of a submitted job",
@@ -1577,7 +1577,7 @@ CloudEvent upon completion of the workflow could look like:
 ```json
 {
 "id": "sendcloudeventonprovision",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "name": "Send CloudEvent on provision completion",
 "start": "ProvisionOrdersState",
@@ -1711,7 +1711,7 @@ have the matching patient id.
 {
 "id": "patientVitalsWorkflow",
 "name": "Monitor Patient Vitals",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "start": "MonitorVitals",
 "events": [
@@ -1906,7 +1906,7 @@ when all three of these events happened (in no particular order).
 {
 "id": "finalizeCollegeApplication",
 "name": "Finalize College Application",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "start": "FinalizeApplication",
 "events": [
@@ -2117,7 +2117,7 @@ And for denied credit check, for example:
 ```json
 {
     "id": "customercreditcheck",
-    "version": "1.0.0"
+    "version": "1.0.0",
     "specVersion": "0.8",
     "name": "Customer Credit Check Workflow",
     "description": "Perform Customer Credit Check",
@@ -2322,7 +2322,7 @@ Bidding is done via an online application and bids are received as events are as
 ```json
 {
     "id": "handleCarAuctionBid",
-    "version": "1.0.0"
+    "version": "1.0.0",
     "specVersion": "0.8",
     "name": "Car Auction Bidding Workflow",
     "description": "Store a single bid whole the car auction is active",
@@ -2452,7 +2452,7 @@ The results of the inbox service called is expected to be for example:
 {
 "id": "checkInbox",
 "name": "Check Inbox Workflow",
-"version": "1.0.0"
+"version": "1.0.0",
 "specVersion": "0.8",
 "description": "Periodically Check Inbox",
 "start": {
@@ -2596,7 +2596,7 @@ For this example we assume that the workflow instance is started given the follo
     "id": "VetAppointmentWorkflow",
     "name": "Vet Appointment Workflow",
     "description": "Vet service call via events",
-    "version": "1.0.0"
+    "version": "1.0.0",
     "specVersion": "0.8",
     "start": "MakeVetAppointmentState",
     "events": [
@@ -2747,7 +2747,7 @@ In our workflow definition then we can reference these files rather than definin
 ```json
 {
   "id": "paymentconfirmation",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "name": "Payment Confirmation Workflow",
   "description": "Performs Payment Confirmation",
@@ -2951,7 +2951,7 @@ If the retries are not successful, we want to just gracefully end workflow execu
 {
   "id": "patientonboarding",
   "name": "Patient Onboarding Workflow",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "start": "Onboard",
   "states": [
@@ -3123,7 +3123,7 @@ This example shows the use of the workflow [execTimeout definition](../specifica
 {
   "id": "order",
   "name": "Purchase Order Workflow",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "start": "StartNewOrder",
   "timeouts": {
@@ -3407,7 +3407,7 @@ the data for an hour, send report, and so on.
 {
   "id": "roomreadings",
   "name": "Room Temp and Humidity Workflow",
-  "version": "1.0.0"
+  "version": "1.0.0",
   "specVersion": "0.8",
   "start": "ConsumeReading",
   "timeouts": {
@@ -3581,7 +3581,7 @@ We fist define our top-level workflow for this example:
 {
  "id": "checkcarvitals",
  "name": "Check Car Vitals Workflow",
- "version": "1.0.0"
+ "version": "1.0.0",
  "specVersion": "0.8",
  "start": "WhenCarIsOn",
  "states": [
@@ -3696,7 +3696,7 @@ And then our reusable sub-workflow which performs the checking of our car vitals
 {
  "id": "vitalscheck",
  "name": "Car Vitals Check",
- "version": "1.0.0"
+ "version": "1.0.0",
  "specVersion": "0.8",
  "start": "CheckVitals",
  "states": [
@@ -3836,7 +3836,7 @@ For the sake of the example we assume the functions and event definitions are de
 {
  "id": "booklending",
  "name": "Book Lending Workflow",
- "version": "1.0.0"
+ "version": "1.0.0",
  "specVersion": "0.8",
  "start": "Book Lending Request",
  "states": [
@@ -4128,7 +4128,7 @@ Its results are then merged back into the state data according to the "toStateDa
 {
  "id": "fillglassofwater",
  "name": "Fill glass of water workflow",
- "version": "1.0.0"
+ "version": "1.0.0",
  "specVersion": "0.8",
  "start": "Check if full",
  "functions": [
@@ -4541,7 +4541,7 @@ We assume that our workflow input has the runtime-imposed quota:
      "end":{
       "continueAs": {
        "workflowId": "notifycustomerworkflow",
-       "version": "1.0.0"
+       "version": "1.0.0",
        "data": "${ del(.customerCount) }"
       }
      }
@@ -4661,7 +4661,7 @@ decide which activity to perform based on the transaction value.
 {
  "id": "customerbankingtransactions",
  "name": "Customer Banking Transactions Workflow",
- "version": "1.0.0"
+ "version": "1.0.0",
  "specVersion": "0.8",
  "autoRetries": true,
  "constants": {


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [ ] Specification
- [ ] Schema
- [x] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [x] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does / why we need it**:
Add a comma after `"version": "1.0.0"`, which is now missing in JSON examples and comparisons. The comma was there, but in #688, it was accidentally deleted during the change of the versioning style from `"1.0"` to `"1.0.0"`<!-- Brief description of your PR / Short summary of the discussion or issue -->

**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->