### PR TITLE
Fix and add links to Workflow Timeout Definition

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -5470,11 +5470,11 @@ If `object` type, it is used to define the timeout definitions in-line and has t
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| workflowExecTimeout | Workflow execution timeout (ISO 8601 duration format) | string or object | no |
-| stateExecTimeout | Workflow state execution timeout (ISO 8601 duration format) | string or object | no |
+| [workflowExecTimeout](#workflowexectimeout-definition) | Workflow execution timeout (ISO 8601 duration format) | string or object | no |
+| [stateExecTimeout](#states-timeout-definition) | Workflow state execution timeout (ISO 8601 duration format) | string | no |
 | actionExecTimeout | Actions execution timeout (ISO 8601 duration format) | string | no |
-| branchExecTimeout | Branch execution timeout (ISO 8601 duration format) | string | no |
-| eventTimeout | Default timeout for consuming defined events (ISO 8601 duration format) | string | no |
+| [branchExecTimeout](#branch-timeout-definition) | Branch execution timeout (ISO 8601 duration format) | string | no |
+| [eventTimeout](#event-timeout-definition) | Default timeout for consuming defined events (ISO 8601 duration format) | string | no |
 
 The `eventTimeout` property defines the maximum amount of time to wait to consume defined events. If not specified it should default to
 "unlimited".


### PR DESCRIPTION
Signed-off-by: Tomas David <tdavid@redhat.com>

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
- [stateExecTimeout](https://github.com/serverlessworkflow/specification/blob/main/schema/timeouts.json#L76) can be only string, not object
- add links to the definitions of timeout sections

**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->