### PR TITLE
fix contextAttributes examples as they should be of object/map type

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -5084,9 +5084,9 @@ before the workflow execution is stopped, and continued as a new workflow instan
 {
     "eventRef": "provisioning-complete-event",
     "data": "${ .provisionedOrders }",
-    "contextAttributes": [{
+    "contextAttributes": {
          "buyerId": "${ .buyerId }"
-     }]
+     }
  }
 ```
 
@@ -5097,7 +5097,7 @@ before the workflow execution is stopped, and continued as a new workflow instan
 eventRef: provisioning-complete-event
 data: "${ .provisionedOrders }"
 contextAttributes:
-- buyerId: "${ .buyerId }"
+  buyerId: "${ .buyerId }"
 ```
 
 </td>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
#811 

**What this PR does / why we need it**:

Fixed ProducedEvent.contextAttributes examples as they should be of object/map type.

**Special notes for reviewers**:

**Additional information:**
