### PR TITLE
[Fix #677] Atomic produce and consume actions

### DIFF
--- a/examples/README_TEMPLATE.md
+++ b/examples/README_TEMPLATE.md
@@ -1091,7 +1091,6 @@ events:
   - contextAttributeName: accountId
 - name: ConfirmationCompletedEvent
   type: payment.confirmation
-  kind: produced
 
 ```
 

--- a/examples/event-based-service-invocation.json
+++ b/examples/event-based-service-invocation.json
@@ -9,14 +9,12 @@
         {
             "name": "make-vet-appointment",
             "source": "VetServiceSource",
-            "type": "events.vet.appointments",
-            "kind": "produced"
+            "type": "events.vet.appointments"
         },
         {
             "name": "vet-appointment-info",
             "source": "VetServiceSource",
-            "type": "events.vet.appointments",
-            "kind": "consumed"
+            "type": "events.vet.appointments"
         }
     ],
     "states": [

--- a/examples/event-based-service-invocation.json
+++ b/examples/event-based-service-invocation.json
@@ -24,15 +24,15 @@
             "actions": [
                 {
                     "name": "make-appointment-action",
-                    "produceEventRef": {
-                        "name": "make-vet-appointment",
+                    "publish": {
+                        "event": "make-vet-appointment",
                         "data": "${ .patientInfo }"
                     }
                 },
                 {
                     "name": "wait-appointement-confirmation",
-                    "consumeEventRef": {
-                        "name": "vet-appointment-info"
+                    "subscribe": {
+                        "event": "vet-appointment-info"
                     },
                     "actionDataFilter": {
                         "results": "${ .appointmentInfo }"

--- a/examples/event-based-service-invocation.json
+++ b/examples/event-based-service-invocation.json
@@ -26,10 +26,15 @@
             "actions": [
                 {
                     "name": "make-appointment-action",
-                    "eventRef": {
-                        "produceEventRef": "make-vet-appointment",
-                        "data": "${ .patientInfo }",
-                        "consumeEventRef": "vet-appointment-info"
+                    "produceEventRef": {
+                        "name": "make-vet-appointment",
+                        "data": "${ .patientInfo }"
+                    }
+                },
+                {
+                    "name": "wait-appointement-confirmation",
+                    "consumeEventRef": {
+                        "name": "vet-appointment-info"
                     },
                     "actionDataFilter": {
                         "results": "${ .appointmentInfo }"

--- a/examples/purchase-order-deadline.json
+++ b/examples/purchase-order-deadline.json
@@ -137,13 +137,11 @@
         },
         {
             "name": "order-finished-event",
-            "type": "my.company.orders",
-            "kind": "produced"
+            "type": "my.company.orders"
         },
         {
             "name": "order-cancelled-event",
-            "type": "my.company.orders",
-            "kind": "produced"
+            "type": "my.company.orders"
         }
     ],
     "functions": [

--- a/examples/send-cloudevent-on-workflow-completion.json
+++ b/examples/send-cloudevent-on-workflow-completion.json
@@ -7,8 +7,7 @@
     "events": [
         {
             "name": "provisioning-complete-event",
-            "type": "provisionCompleteType",
-            "kind": "produced"
+            "type": "provisionCompleteType"
         }
     ],
     "functions": [

--- a/schema/events.json
+++ b/schema/events.json
@@ -43,15 +43,6 @@
           "type": "string",
           "description": "CloudEvent type"
         },
-        "kind": {
-          "type": "string",
-          "enum": [
-            "consumed",
-            "produced"
-          ],
-          "description": "Defines the CloudEvent as either 'consumed' or 'produced' by the workflow. Default is 'consumed'",
-          "default": "consumed"
-        },
         "correlation": {
           "type": "array",
           "description": "CloudEvent correlation definitions",

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -413,13 +413,13 @@
           "description": "References a function to be invoked",
           "$ref": "#/definitions/functionref"
         },
-        "produceEventRef": {
-          "description": "References a `produce` reusable event definition",
-          "$ref": "#/definitions/produceeventref"
+        "publish": {
+          "description": "Publish an event",
+          "$ref": "#/definitions/publish"
         },
-        "consumeEventRef": {
-          "description": "References a `consume` reusable event definition",
-          "$ref": "#/definitions/consumeeventref"
+        "subscribe": {
+          "description": "Subscribe to an event channel",
+          "$ref": "#/definitions/subscribe"
         },
         "subFlowRef": {
           "description": "References a sub-workflow to invoke",
@@ -472,13 +472,13 @@
         {
           "required": [
             "name",
-            "produceEventRef"
+            "publish"
           ]
         },
         {
           "required": [
             "name",
-            "consumeEventRef"
+            "subscribe"
           ]
         },
         {
@@ -531,13 +531,13 @@
         }
       ]
     },
-    "produceeventref": {
+    "publish": {
       "type": "object",
       "description": "Publish an event",
       "properties": {
-        "name": {
+        "event": {
           "type": "string",
-          "description": "Reference to the unique name of a 'produced' event definition",
+          "description": "Reference to the unique name of a 'published' event definition",
           "pattern": "^[a-z0-9](-?[a-z0-9])*$"
         },
         "data": {
@@ -545,7 +545,7 @@
             "string",
             "object"
           ],
-          "description": "If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by 'produceEventRef'. If object type, a custom object to become the data (payload) of the event referenced by 'produceEventRef'."
+          "description": "If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by 'publish'. If object type, a custom object to become the data (payload) of the event referenced by 'publish'."
         },
         "contextAttributes": {
           "type": "object",
@@ -557,26 +557,26 @@
       },
       "additionalProperties": false,
       "required": [
-        "name", "data"
+        "event", "data"
       ]
     },
-    "consumeeventref": {
+    "subscribe": {
       "type": "object",
-      "description": "Waits for an event",
+      "description": "Subscribe to an event channel",
       "properties": {
-        "name": {
+        "event": {
           "type": "string",
-          "description": "Reference to the unique name of a 'consumed' event definition",
+          "description": "Reference to the unique name of a 'subscribed' event definition",
           "pattern": "^[a-z0-9](-?[a-z0-9])*$"
         },
-        "consumeEventTimeout": {
+        "timeout": {
           "type": "string",
           "description": "Maximum amount of time (ISO 8601 format) to wait for the result event. If not defined it should default to the actionExecutionTimeout"
         }
        },
       "additionalProperties": false,
       "required": [
-        "name"
+        "event"
       ]
     },
     "subflowref": {

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -413,9 +413,13 @@
           "description": "References a function to be invoked",
           "$ref": "#/definitions/functionref"
         },
-        "eventRef": {
-          "description": "References a `produce` and `consume` reusable event definitions",
-          "$ref": "#/definitions/eventref"
+        "produceEventRef": {
+          "description": "References a `produce` reusable event definition",
+          "$ref": "#/definitions/produceeventref"
+        },
+        "consumeEventRef": {
+          "description": "References a `consume` reusable event definition",
+          "$ref": "#/definitions/consumeeventref"
         },
         "subFlowRef": {
           "description": "References a sub-workflow to invoke",
@@ -468,7 +472,13 @@
         {
           "required": [
             "name",
-            "eventRef"
+            "produceEventRef"
+          ]
+        },
+        {
+          "required": [
+            "name",
+            "consumeEventRef"
           ]
         },
         {
@@ -521,23 +531,14 @@
         }
       ]
     },
-    "eventref": {
+    "produceeventref": {
       "type": "object",
-      "description": "Event References",
+      "description": "Publish an event",
       "properties": {
-        "produceEventRef": {
+        "name": {
           "type": "string",
           "description": "Reference to the unique name of a 'produced' event definition",
           "pattern": "^[a-z0-9](-?[a-z0-9])*$"
-        },
-        "consumeEventRef": {
-          "type": "string",
-          "description": "Reference to the unique name of a 'consumed' event definition",
-          "pattern": "^[a-z0-9](-?[a-z0-9])*$"
-        },
-        "consumeEventTimeout": {
-          "type": "string",
-          "description": "Maximum amount of time (ISO 8601 format) to wait for the result event. If not defined it should default to the actionExecutionTimeout"
         },
         "data": {
           "type": [
@@ -556,7 +557,26 @@
       },
       "additionalProperties": false,
       "required": [
-        "produceEventRef"
+        "name", "data"
+      ]
+    },
+    "consumeeventref": {
+      "type": "object",
+      "description": "Waits for an event",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Reference to the unique name of a 'consumed' event definition",
+          "pattern": "^[a-z0-9](-?[a-z0-9])*$"
+        },
+        "consumeEventTimeout": {
+          "type": "string",
+          "description": "Maximum amount of time (ISO 8601 format) to wait for the result event. If not defined it should default to the actionExecutionTimeout"
+        }
+       },
+      "additionalProperties": false,
+      "required": [
+        "name"
       ]
     },
     "subflowref": {
@@ -1690,7 +1710,7 @@
           "name",
           "type",
           "action",
-          "eventRef"
+          ""
         ]
       },
       "else": {

--- a/specification.md
+++ b/specification.md
@@ -3968,22 +3968,21 @@ functionRef:
 
 </details>
 
-Actions specify invocations of services or other workflows during workflow execution.
-Service invocation can be done in three different ways:
+An action can:
 
 * Reference [functions definitions](#Function-Definition) by its unique name using the `functionRef` property.
-* Reference a [event definitions](#Event-Definition) via the `produceEventRef` property in order to publish that event.
-* Reference a [event definitions](#Event-Definition) via the `consumeEventRef` property in order to consume that event.
+* Publish an event [event definitions](#Event-Definition) via the `publish` property.
+* Subscribe to an event [event definitions](#Event-Definition) via the `subscribe` property.
 * Reference a sub-workflow invocation via the `subFlowRef` property.
 
-Note that `functionRef`, `eventRef`, and `subFlowRef` are mutually exclusive, meaning that only one of them can be
+Note that `functionRef`, `publish`, `subscribe` and `subFlowRef` are mutually exclusive, meaning that only one of them can be
 specified in a single action definition.
 
 The `name` property specifies the action name.
 
 In the event-based scenario a service, or a set of services we want to invoke are not exposed via a specific resource URI for example, but can only be invoked via an event.
-In that case, an event definition might be referenced via its `produceEventRef` property. 
-Also, if there is the need to consume an event within a set of actions (for example, wait for the result of a previous action invocation) an event definition might be referenced via its `consumeEventRef` property.
+In that case, an event definition might be referenced via its `publish` property. 
+Also, if there is the need to consume an event within a set of actions (for example, wait for the result of a previous action invocation) an event definition might be referenced via its `susbcribe` property.
 
 The `sleep` property can be used to define time periods that workflow execution should sleep
 before and/or after function execution. It can have two properties:
@@ -4110,14 +4109,14 @@ In addition, functions that are invoked async do not propagate their errors to t
 workflow state, meaning that any errors that happen during their execution cannot be handled in the workflow states 
 onErrors definition. Note that errors raised during functions that are invoked async should not fail workflow execution.
 
-##### ProduceEventRef Definition
+##### Publish Definition
 
 Publish an event. 
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| [name](#Event-Definition) | Reference to the unique name of an event definition. Must follow the [Serverless Workflow Naming Convention](#naming-convention) | string | yes |
-| data | If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by `produceEventRef`. If object type, a custom object to become the data (payload) of the event referenced by `produceEventRef`. | string or object | yes |
+| [event](#Event-Definition) | Reference to the unique name of an event definition. Must follow the [Serverless Workflow Naming Convention](#naming-convention) | string | yes |
+| data | If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by `publish`. If object type, a custom object to become the data (payload) of the event referenced by `publish`. | string or object | yes |
 | contextAttributes | Add additional event extension context attributes to the trigger/produced event | object | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
@@ -4133,8 +4132,8 @@ Publish an event.
 
 ```json
 {
-   "produceEventRef": {
-      "name": "make-vet-appointment",
+   "publish": {
+      "event": "make-vet-appointment",
       "data": "${ .patientInfo }",
    }
 }
@@ -4144,8 +4143,8 @@ Publish an event.
 <td valign="top">
 
 ```yaml
-produceEventRef:
-  name: make-vet-appointment
+publish:
+  event: make-vet-appointment
   data: "${ .patientInfo }"
 ```
 
@@ -4155,22 +4154,22 @@ produceEventRef:
 
 </details>
 
-Publish an [event definition](#Event-Definition) referenced via the `name` property.
+Publish an [event definition](#Event-Definition) referenced via the `event` property.
 
 The `data` property can have two types: string or object. If it is of string type, it is an expression that can select parts of state data
-to be used as payload of the event referenced by `produceEventRef`. If it is of object type, you can define a custom object to be the event payload.
+to be used as payload of the event referenced by `publish`. If it is of object type, you can define a custom object to be the event payload.
 
 The `contextAttributes` property allows you to add one or more [extension context attributes](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#extension-context-attributes)
 to the trigger/produced event.
 
-##### ConsumeEventRef Definition
+##### Susbscribe Definition
 
 Wait for an event to arrive. 
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| [name](#Event-Definition) | Reference to the unique name of an event definition. Must follow the [Serverless Workflow Naming Convention](#naming-convention) | string | yes |
-| consumeEventTimeout | Maximum amount of time (ISO 8601 format literal or expression) to wait for the consume event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition) | string | no |
+| [event](#Event-Definition) | Reference to the unique name of an event definition. Must follow the [Serverless Workflow Naming Convention](#naming-convention) | string | yes |
+| timeout | Maximum amount of time (ISO 8601 format literal or expression) to wait for the consume event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition) | string | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -4185,7 +4184,7 @@ Wait for an event to arrive.
 
 ```json
 {
-   "consumeEventRef": {
+   "subscribe": {
       "name": "approved-appointment",
    }
 }
@@ -4196,7 +4195,7 @@ Wait for an event to arrive.
 
 ```yaml
 eventRef:
-  consumeEventRef: approved-appointment
+  subscribe: approved-appointment
 
 ```
 
@@ -4206,9 +4205,9 @@ eventRef:
 
 </details>
 
-Consumes an [event definition](#Event-Definition) referenced via the `name` property.
+Consumes an [event definition](#Event-Definition) referenced via the `event` property.
 
-The `consumeEventTimeout` property defines the maximum amount of time (ISO 8601 format literal or expression) to wait for the result event. If not defined it should default to the  [actionExecutionTimeout](#Workflow-Timeout-Definition).
+The `timeout` property defines the maximum amount of time (ISO 8601 format literal or expression) to wait for the result event. If not defined it should default to the  [actionExecutionTimeout](#Workflow-Timeout-Definition).
 If the event defined by the `name` property is not received in that set time, action invocation should raise an error that can be handled in the states `onErrors` definition. 
 
 ##### SubFlowRef Definition


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [X] Specification
- [X] Schema
- [X] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
Fixes https://github.com/serverlessworkflow/specification/issues/677
**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
Separated produceEventRef from consumeEventRef, removing eventRef, and promoting both to first class actions.
Remove kind property from event definition. Therefore the same event definition can be both used for consumption and publishing. if needed. 
**Special notes for reviewers**:
I have couple of doubts about naming notation that I reflected as comments. 
**Additional information:**
<!-- Optional -->