### PR TITLE
[Fix #712] Describe merge behaviour for non object

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -439,7 +439,7 @@ The second way would be to directly filter only the "veggie like" vegetables wit
 | fromStateData | Workflow expression that filters state data that can be used by the action | string | no |
 | useResults | If set to `false`, action data results are not added/merged to state data. In this case 'results' and 'toStateData' should be ignored. Default is `true`.  | boolean | no |
 | results | Workflow expression that filters the actions data results | string | no |
-| toStateData | Workflow expression that selects a state data element to which the action results should be added/merged into. If not specified denotes the top-level state data element. In case it is not specified and the result of the action is not an object, that result should be merged as value of an automatically generated key. That key name will be the result of concatenating the action name with `_output` suffix. | string | no |
+| toStateData | Workflow expression that selects a state data element to which the action results should be added/merged. If not specified denotes the top-level state data element. In case it is not specified and the result of the action is not an object, that result should be merged as the value of an automatically generated key. That key name will be the result of concatenating the action name with `-output` suffix. | string | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -565,25 +565,24 @@ into. With this, after our action executes the state data would be:
 }
 ```
 
-To  illustrate merge of not json both object,  let`s assume that, in previous example, the action definition is at follows
+To illustrate the merge of non-JSON for both objects,  let's assume that, in the previous example, the action definition is the follows
 
 ```json
 "actions":[
     {
-       "name": "fetch_only_pasta",
+       "name": "fetch-only-pasta",
        "functionRef": "breadAndPastaTypesFunction",
        "actionDataFilter": {
           "results": "${ .pasta[1] ]",
        }
     }
  ]
-}
 ```
-Since there is not `toStateData` and the result is not a json object but an string, the model would be
+Since there is no `toStateData` attribute and the result is not a JSON object but a string, the model would be:
 
 ```json
 {
-  "fetch_only_pasta_output": "spaghetti"
+  "fetch-only-pasta-output": "spaghetti"
 }
 ```
 In the case action results should not be added/merged to state data, we can set the `useResults` property to `false`.

--- a/specification.md
+++ b/specification.md
@@ -565,6 +565,27 @@ into. With this, after our action executes the state data would be:
 }
 ```
 
+To  illustrate merge of not json both object,  let`s assume that, in previous example, the action definition is at follows
+
+```json
+"actions":[
+    {
+       "name": "fetch_only_pasta",
+       "functionRef": "breadAndPastaTypesFunction",
+       "actionDataFilter": {
+          "results": "${ .pasta[1] ]",
+       }
+    }
+ ]
+}
+```
+Since there is not `toStateData` and the result is not a json object but an string, the state would be
+
+```json
+{
+  "response": "spaghetti"
+}
+```
 In the case action results should not be added/merged to state data, we can set the `useResults` property to `false`.
 In this case, the `results` and `toStateData` properties should be ignored, and nothing is added/merged to state data.
 If `useResults` is not specified (or it's value set to `true`), action results, if available, should be added/merged to state data.

--- a/specification.md
+++ b/specification.md
@@ -439,7 +439,7 @@ The second way would be to directly filter only the "veggie like" vegetables wit
 | fromStateData | Workflow expression that filters state data that can be used by the action | string | no |
 | useResults | If set to `false`, action data results are not added/merged to state data. In this case 'results' and 'toStateData' should be ignored. Default is `true`.  | boolean | no |
 | results | Workflow expression that filters the actions data results | string | no |
-| toStateData | Workflow expression that selects a state data element to which the action results should be added/merged into. If not specified denotes the top-level state data element. In case it is not specified and the result of the action is not an object, that result should be merged as value of `response` key. If that `response` key already exist in the model, its value will be overwritten. | string | no |
+| toStateData | Workflow expression that selects a state data element to which the action results should be added/merged into. If not specified denotes the top-level state data element. In case it is not specified and the result of the action is not an object, that result should be merged as value of an automatically generated key. That key name will be the result of concatenating the action name with `_output` suffix. | string | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>
@@ -579,11 +579,11 @@ To  illustrate merge of not json both object,  let`s assume that, in previous ex
  ]
 }
 ```
-Since there is not `toStateData` and the result is not a json object but an string, the state would be
+Since there is not `toStateData` and the result is not a json object but an string, the model would be
 
 ```json
 {
-  "response": "spaghetti"
+  "fetch_only_pasta_output": "spaghetti"
 }
 ```
 In the case action results should not be added/merged to state data, we can set the `useResults` property to `false`.

--- a/specification.md
+++ b/specification.md
@@ -439,7 +439,7 @@ The second way would be to directly filter only the "veggie like" vegetables wit
 | fromStateData | Workflow expression that filters state data that can be used by the action | string | no |
 | useResults | If set to `false`, action data results are not added/merged to state data. In this case 'results' and 'toStateData' should be ignored. Default is `true`.  | boolean | no |
 | results | Workflow expression that filters the actions data results | string | no |
-| toStateData | Workflow expression that selects a state data element to which the action results should be added/merged into. If not specified denotes the top-level state data element | string | no |
+| toStateData | Workflow expression that selects a state data element to which the action results should be added/merged into. If not specified denotes the top-level state data element. In case it is not specified and the result of the action is not an object, that result should be merged as value of `response` key. If that `response` key already exist in the model, its value will be overwritten. | string | no |
 
 <details><summary><strong>Click to view example definition</strong></summary>
 <p>


### PR DESCRIPTION

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
Fixes https://github.com/serverlessworkflow/specification/issues/712

**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
Update specification to make runtimes predicateble when an action produced a non json object and there is not toStateData filter
**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->