### PR TITLE
Fix #818 - Merge REST and OPENAPI operations, introduce HTTP functions

### DIFF
--- a/.ci/validation/package-lock.json
+++ b/.ci/validation/package-lock.json
@@ -13,7 +13,7 @@
         "ajv-formats": "^2.1.1"
       },
       "devDependencies": {
-        "@types/jest": "^29.5.10",
+        "@types/jest": "^29.5.12",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.3.2"
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.10",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.10.tgz",
-      "integrity": "sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==",
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",

--- a/.ci/validation/package-lock.json
+++ b/.ci/validation/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "validation",
-  "version": "1.0.0",
+  "version": "0.9.0-snapshot",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "validation",
-      "version": "1.0.0",
+      "version": "0.9.0-snapshot",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1"
       },
       "devDependencies": {
-        "@babel/preset-typescript": "^7.23.3",
         "@types/jest": "^29.5.10",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
@@ -186,18 +185,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
@@ -215,34 +202,12 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.5.tgz",
-      "integrity": "sha512-QELlRWxSpgdwdJzSJn4WAhKC+hvw/AtHbbrIoncKHkhKKR/luAlKkgBDcri1EzWAo8f8VvYVryEHN4tax/V67A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-member-expression-to-functions": "^7.23.0",
-        "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/helper-replace-supers": "^7.22.20",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
       "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -252,6 +217,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
       "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
         "@babel/types": "^7.23.0"
@@ -273,23 +239,12 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
-      "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
       "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.15"
       },
@@ -302,6 +257,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
       "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-module-imports": "^7.22.15",
@@ -316,42 +272,14 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
-      "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
-      "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-member-expression-to-functions": "^7.22.15",
-        "@babel/helper-optimise-call-expression": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
@@ -359,18 +287,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
-      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -383,6 +300,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -395,6 +313,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
       "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -413,6 +332,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
       "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -522,6 +442,7 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
       "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -599,6 +520,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
       "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
       },
@@ -708,62 +630,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
       "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
-      "integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-simple-access": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.5.tgz",
-      "integrity": "sha512-2fMkXEJkrmwgu2Bsv1Saxgj30IXZdJ+84lQcKKI7sm719oXs0BBw2ZENKdJdR1PjWndgLCEBNXJOri0fk7RYQA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.23.5",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-syntax-typescript": "^7.23.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-typescript": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.3.tgz",
-      "integrity": "sha512-17oIGVlqz6CchO9RFYn5U6ZpWRZIngayYCtrPRSgANSwC2V1Jb+iP74nVxzzXJte8b8BYxrL1yY96xfhTBrNNQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-validator-option": "^7.22.15",
-        "@babel/plugin-syntax-jsx": "^7.23.3",
-        "@babel/plugin-transform-modules-commonjs": "^7.23.3",
-        "@babel/plugin-transform-typescript": "^7.23.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -777,6 +646,7 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
       "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/parser": "^7.22.15",
@@ -813,6 +683,7 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
       "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -3760,6 +3631,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3977,6 +3849,7 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }

--- a/.ci/validation/package.json
+++ b/.ci/validation/package.json
@@ -11,7 +11,7 @@
   "author": "CNCF Serverless Workflow Specification",
   "license": "ISC",
   "devDependencies": {
-    "@types/jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.2"

--- a/.ci/validation/package.json
+++ b/.ci/validation/package.json
@@ -11,7 +11,7 @@
   "author": "CNCF Serverless Workflow Specification",
   "license": "ISC",
   "devDependencies": {
-    "@types/jest": "^29.5.10",
+    "@types/jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.2"

--- a/.github/workflows/schema-check.yaml
+++ b/.github/workflows/schema-check.yaml
@@ -44,9 +44,9 @@ jobs:
         node-version: [21.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/examples/curl.json
+++ b/examples/curl.json
@@ -1,8 +1,7 @@
 {
-    "id": "curl",
+    "name": "curlgoogle",
     "version": "1.0.0",
     "specVersion": "0.8",
-    "name": "curlgoogle",
     "description": "Curl Google",
     "start": "curl",
     "functions": [

--- a/examples/curl.json
+++ b/examples/curl.json
@@ -1,0 +1,36 @@
+{
+    "id": "curl",
+    "version": "1.0.0",
+    "specVersion": "0.9",
+    "name": "curl-workflow",
+    "description": "Curl Google",
+    "start": "curl",
+    "functions": [
+        {
+            "name": "curl-google",
+            "type": "http",
+            "operation": {
+                "method": "GET",
+                "uri": "https://www.google.com/search?q={query}"
+            }
+        }
+    ],
+    "states": [
+        {
+            "name": "curl",
+            "type": "operation",
+            "actions": [
+                {
+                    "name": "do-curl",
+                    "functionRef": {
+                        "refName": "curl-google",
+                        "arguments": {
+                            "query": "${ .query }"
+                        }
+                    }
+                }
+            ],
+            "end": true
+        }
+    ]
+}

--- a/examples/curl.json
+++ b/examples/curl.json
@@ -1,8 +1,8 @@
 {
     "id": "curl",
     "version": "1.0.0",
-    "specVersion": "0.9",
-    "name": "curl-workflow",
+    "specVersion": "0.8",
+    "name": "curlgoogle",
     "description": "Curl Google",
     "start": "curl",
     "functions": [

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -101,7 +101,8 @@
             "^/": {
               "type": "object"
             }
-          }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -133,7 +134,8 @@
               "additionalProperties": { "type": "string" }
             }
           },
-          "required": ["method", "uri"]
+          "required": ["method", "uri"],
+          "additionalProperties": false
         }
       ]
     }

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -108,6 +108,7 @@
           "description": "HTTP Function operation definition",
           "properties": {
             "method": {
+              "type": "string",
               "enum": [
                 "GET",
                 "HEAD",

--- a/schema/functions.json
+++ b/schema/functions.json
@@ -22,9 +22,7 @@
       }
     ]
   },
-  "required": [
-    "functions"
-  ],
+  "required": ["functions"],
   "definitions": {
     "function": {
       "type": "object",
@@ -40,9 +38,9 @@
         },
         "type": {
           "type": "string",
-          "description": "Defines the function type. Is either `rest`, `openapi`,`asyncapi, `rpc`, `graphql`, `odata`, `expression`, or `custom`. Default is `openapi`.",
+          "description": "Defines the function type. Is either `http`, `openapi`,`asyncapi, `rpc`, `graphql`, `odata`, `expression`, or `custom`. Default is `openapi`.",
           "enum": [
-            "rest",
+            "http",
             "openapi",
             "asyncapi",
             "rpc",
@@ -77,9 +75,7 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "resource"
-              ]
+              "required": ["resource"]
             }
           ]
         },
@@ -88,10 +84,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [
-        "name",
-        "operation"
-      ]
+      "required": ["name", "operation"]
     },
     "operation": {
       "oneOf": [
@@ -109,6 +102,37 @@
               "type": "object"
             }
           }
+        },
+        {
+          "type": "object",
+          "description": "HTTP Function operation definition",
+          "properties": {
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD",
+                "POST",
+                "PUT",
+                "DELETE",
+                "CONNECT",
+                "OPTIONS",
+                "TRACE"
+              ],
+              "default": "GET"
+            },
+            "uri": {
+              "type": "string"
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "cookies": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          },
+          "required": ["method", "uri"]
         }
       ]
     }

--- a/specification.md
+++ b/specification.md
@@ -24,7 +24,7 @@
     + [Data Merging](#data-merging)
   * [Workflow Functions](#workflow-functions)
     + [Using Functions for OpenAPI Service Invocations](#using-functions-for-openapi-service-invocations)
-    + [Using Functions for RESTful Service Invocations](#using-functions-for-restful-service-invocations)
+    + [Using Functions for HTTP Service Invocations](#using-functions-for-http-service-invocations)
     + [Using Functions for Async API Service Invocations](#using-functions-for-async-api-service-invocations)
     + [Using Functions for RPC Service Invocations](#using-functions-for-rpc-service-invocations)
     + [Using Functions for GraphQL Service Invocations](#using-functions-for-graphql-service-invocations)
@@ -995,7 +995,7 @@ They can be referenced by their domain-specific names inside workflow [states](#
 Reference the following sections to learn more about workflow functions:
 
 * [Using functions for OpenAPI Service invocations](#using-functions-for-openapi-service-invocations)
-+ [Using functions for RESTful Service Invocations](#using-functions-for-rest-service-invocations)
++ [Using functions for HTTP Service Invocations](#using-functions-for-http-service-invocations)
 * [Using functions for Async API Service Invocations](#Using-Functions-for-Async-API-Service-Invocations)
 * [Using functions for gRPC service invocation](#Using-Functions-For-RPC-Service-Invocations)
 * [Using functions for GraphQL service invocation](#Using-Functions-For-GraphQL-Service-Invocations)
@@ -1061,11 +1061,7 @@ For example:
 
 Note that the referenced function definition type in this case must be `openapi` (default type).
 
-For more information about functions, reference the [Functions definitions](#Function-Definition) section.
-
-#### Using functions for RESTful Service Invocations
-
-The specification also supports describing REST invocations in the [functions definition](#Function-Definition) using [OpenAPI Paths Object](https://spec.openapis.org/oas/v3.1.0#paths-object).
+The specification also supports describing OpenAPI for REST invocations inline in the [functions definition](#Function-Definition) using [OpenAPI Paths Object](https://spec.openapis.org/oas/v3.1.0#paths-object).
 
 Here is an example function definition for REST requests with method `GET` and request target corresponding with [URI Template](https://www.rfc-editor.org/rfc/rfc6570.html) `/users/{id}`:
 
@@ -1085,7 +1081,7 @@ Here is an example function definition for REST requests with method `GET` and r
           }
         }
       },
-      "type":"rest"
+      "type":"openapi"
     }
   ]
 }
@@ -1122,7 +1118,7 @@ Example of the `POST` request sending the state data as part of the body:
   "functions":[
     {
       "name": "createUser",
-      "type": "rest",
+      "type": "openapi",
       "operation": {
         "/users": {
           "post": {
@@ -1219,7 +1215,119 @@ In this case, only the contents of the `user` attribute will be passed to the fu
 }
 ```
 
-The specification does not support the [Security Requirement Object](https://spec.openapis.org/oas/v3.1.0#security-requirement-object) since its redundat to function [Auth Definition](#Auth-Definition). If provided, this field is ignored.
+When inlining the OpenAPI operation, the specification does not support the [Security Requirement Object](https://spec.openapis.org/oas/v3.1.0#security-requirement-object) since its redundat to function [Auth Definition](#Auth-Definition). If provided, this field is ignored.
+
+For more information about functions, reference the [Functions definitions](#Function-Definition) section.
+
+#### Using functions for HTTP Service Invocations
+
+The HTTP function can make HTTP requests to a given endpoint. It can be used in cases a service doesn't have an OpenAPI definition or users require a simple HTTP, curl-style invocation.
+
+The table below lists the `operation` properties for the `http` function type.
+
+| Property | Description | Type | Required |
+| --- | --- |  --- | --- |
+
+| uri     | The URI where to send the request | String | yes |
+| method  | The HTTP method according to the [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#page-36) | String | yes |
+| headers | Headers to send in the HTTP call. The `Content-Type` header mandates the body convertion. | Map | no |
+| cookies | Cookies to send in the HTTP call. | Map | no |
+
+Note that in the function definition, these values are static. When invoking the function in the `actions` definition, `jq` can be used to set the attribute values.
+
+Here is a function definition example for a HTTP service operation.
+
+```json
+{
+"functions": [
+  {
+    "name": "getPetById",
+    "type": "http",
+    "operation": {
+      "method": "GET",
+      "uri": "https://petstore.swagger.io/v2/pet/{petId}"
+    }
+  }
+]
+}
+```
+
+This function can be used later in the workflow definition:
+
+```json
+{
+  "states":[
+    {
+      "name": "getpet",
+      "type": "operation",
+      "actions":[
+        {
+          "functionRef": "getPetById",
+          "arguments":{
+            "petId": "${ .pet.id }"
+          }
+        }
+      ],
+      "end":true
+    }
+  ]
+}
+```
+
+Not that the `arguments` attribute must map the template in the `uri` definition so the underlying engine can map the arguments correctly.
+
+The `arguments` attribute accepts the following reserved properties when calling a HTTP function type:
+
+| Property | Description | Type | Required |
+| --- | --- |  --- | --- |
+
+| body | The HTTP body. If an object, it will be sent as a JSON payload by default if the `Content-Type` header is missing. Otherwise, it will try to convert it based on the `Content-Type` header definition | Object or String | no |
+| headers | Headers to send in the HTTP call. The `Content-Type` header mandates the body convertion. | Map | no |
+| cookies | Cookies to send in the HTTP call. | Map | no |
+
+These attributes are merged with the ones in the function definition.
+
+The listing below exemplifies how to define and call a HTTP POST endpoint.
+
+```json
+{
+"functions": [
+  {
+    "name": "createPet",
+    "type": "http",
+    "operation": {
+      "method": "POST",
+      "uri": "https://petstore.swagger.io/v2/pet/",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]
+},
+{
+  "states":[
+    {
+      "name":"create-pet",
+      "type":"operation",
+      "actions":[
+        {
+          "functionRef":"createPet",
+          "arguments":{
+            "body": {
+              "name": "Lulu"
+            },
+            "headers": {
+              "my-header": "my-value"
+            }
+          }
+        }
+      ],
+      "end":true
+    }
+  ]
+}
+```
 
 #### Using Functions for Async API Service Invocations
 
@@ -3294,7 +3402,7 @@ Note that `transition` and `end` properties are mutually exclusive, meaning that
 | --- | --- | --- | --- |
 | name | Unique function name. Must follow the [Serverless Workflow Naming Convention](#naming-convention) | string | yes |
 | operation | See the table "Function Operation description by type" below. | string or object | yes |
-| type | Defines the function type. Can be either `rest`, `openapi`, `asyncapi`, `rpc`, `graphql`, `odata`, `expression`, or [`custom`](#defining-custom-function-types). Default is `openapi` | enum | no |
+| type | Defines the function type. Can be either `http`, `openapi`, `asyncapi`, `rpc`, `graphql`, `odata`, `expression`, or [`custom`](#defining-custom-function-types). Default is `openapi` | enum | no |
 | authRef | References an [auth definition](#Auth-Definition) name to be used to access to resource defined in the operation parameter | string | no |
 | [metadata](#Workflow-Metadata) | Metadata information. Can be used to define custom function information | object | no |
 


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
Closes #818 

**What this PR does / why we need it**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
In this PR, we merged the old `rest` and `openapi` functions into one. Now we can inline the `openapi` definition in the `operation` attribute. To facilitate making HTTP simple calls, one can now use the new `http` to mimic a curl-like operation.

Updated schemas and add a new example.

**Special notes for reviewers**:

**Additional information:**
<!-- Optional -->