### PR TITLE
Fix #862 - Switch 'then' must accept free strings

### DIFF
--- a/examples/switch-then-string.yaml
+++ b/examples/switch-then-string.yaml
@@ -1,0 +1,48 @@
+document:
+  dsl: '1.0.0-alpha1'
+  namespace: test
+  name: sample-workflow
+  version: '0.1.0'
+do:
+  processOrder:
+    switch:
+      case1:
+        when: .orderType == "electronic"
+        then: processElectronicOrder
+      case2:
+        when: .orderType == "physical"
+        then: processPhysicalOrder
+      default:
+        then: handleUnknownOrderType
+  processElectronicOrder:
+    execute:
+      sequentially:
+        validatePayment:
+          set:
+            validate: true
+        fulfillOrder:
+          set:
+            status: fulfilled
+    then: exit
+  processPhysicalOrder:
+    execute:
+      sequentially:
+        checkInventory:
+          set:
+            inventory: clear
+        packItems:
+          set:
+            items: 1
+        scheduleShipping:
+          set:
+            address: Elmer St
+    then: exit
+  handleUnknownOrderType:
+    execute:
+      sequentially:
+        logWarning:
+          set:
+            log: warn
+        notifyAdmin:
+          set:
+            message: something's wrong

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -325,9 +325,12 @@ $defs:
     required: [ emit ]
     description: Allows workflows to publish events to event brokers or messaging systems, facilitating communication and coordination between different components and services.
   flowDirective:
-    type: string
-    enum: [ continue, exit, end ]
-    default: continue
+    additionalProperties: false
+    anyOf:
+      - type: string
+        enum: [ continue, exit, end ]
+        default: continue
+      - type: string
   forTask:
     properties:
       for:


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [ ] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
Fixes #862 

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
This is somewhat questionable since the text is, in practice, an open string. At least it's validating the attribute and documenting the enum.

**Additional information:**
<!-- Optional -->