### PR TITLE
change: documentation fix bearer.token property

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1015,7 +1015,7 @@ Defines the mechanism used to authenticate users and workflows attempting to acc
 | Property | Type | Required | Description |
 |----------|:----:|:--------:|-------------|
 | basic | [`basicAuthentication`](#basic-authentication) | `no` | The `basic` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
-| bearer | [`basicAuthentication`](#bearer-authentication) | `no` | The `bearer` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
+| bearer | [`bearerAuthentication`](#bearer-authentication) | `no` | The `bearer` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | certificate | [`certificateAuthentication`](#certificate-authentication) | `no` | The `certificate` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | digest | [`digestAuthentication`](#digest-authentication) | `no` | The `digest` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | bearer | [`oauth2`](#oauth2-authentication) | `no` | The `oauth2` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1087,7 +1087,7 @@ Defines the fundamentals of a 'bearer' authentication
 
 | Property | Type | Required | Description |
 |----------|:----:|:--------:|-------------|
-| bearer | `string` | `yes` | The bearer token to use. |
+| token | `string` | `yes` | The bearer token to use. |
 
 ##### Examples
 

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1018,7 +1018,7 @@ Defines the mechanism used to authenticate users and workflows attempting to acc
 | bearer | [`bearerAuthentication`](#bearer-authentication) | `no` | The `bearer` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | certificate | [`certificateAuthentication`](#certificate-authentication) | `no` | The `certificate` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | digest | [`digestAuthentication`](#digest-authentication) | `no` | The `digest` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
-| bearer | [`oauth2`](#oauth2-authentication) | `no` | The `oauth2` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
+| oauth2 | [`oauth2`](#oauth2-authentication) | `no` | The `oauth2` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 
 ##### Examples
 

--- a/examples/bearer-auth.yaml
+++ b/examples/bearer-auth.yaml
@@ -1,0 +1,15 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: bearer-auth
+  version: 1.0.0-alpha1
+do:
+  getPetById:
+    call: http
+    with:
+      method: get
+      endpoint:
+        uri: https://petstore.swagger.io/v2/pet/{petId}
+        authentication:
+          bearer:
+            token: ${ .token }


### PR DESCRIPTION
change: documentation

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

fixes the `token` property inside the `bearer` authentication being accidentally referred to as `bearer` as well

**Additional information:**
<!-- Optional -->