### PR TITLE
Fix workflow schema: change `const`, adding missing `object`; etc.

### DIFF
--- a/examples/asyncapi.yaml
+++ b/examples/asyncapi.yaml
@@ -1,0 +1,20 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: bearer-auth
+  version: 1.0.0-alpha1
+do:
+  greetUser:
+    call: asyncapi
+    with:
+      document:
+        uri: https://fake.com/docs/asyncapi.json
+      operation: findPetsByStatus
+      server: staging
+      message: getPetByStatusQuery
+      binding: http
+      payload:
+        petId: ${ .pet.id }
+      authentication:
+        bearer:
+          token: ${ .token }

--- a/examples/asyncapi.yaml
+++ b/examples/asyncapi.yaml
@@ -9,7 +9,7 @@ do:
     with:
       document:
         uri: https://fake.com/docs/asyncapi.json
-      operation: findPetsByStatus
+      operationRef: findPetsByStatus
       server: staging
       message: getPetByStatusQuery
       binding: http

--- a/examples/use-authentication.yaml
+++ b/examples/use-authentication.yaml
@@ -1,0 +1,18 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: bearer-auth
+  version: 1.0.0-alpha1
+use:
+  authentications:
+    petStoreAuth:
+      bearer:
+        token: ${ .token }
+do:
+  getPetById:
+    call: http
+    with:
+      method: get
+      endpoint:
+        uri: https://petstore.swagger.io/v2/pet/{petId}
+        authentication: petStoreAuth

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -270,6 +270,7 @@ $defs:
             description: A name/value mapping of the parameters, if any, to call the function with.
         required: [ call ]
   compositeTask:
+    type: object
     properties:
       execute:
         type: object
@@ -297,6 +298,7 @@ $defs:
     required: [ execute ]
     description: Serves as a pivotal orchestrator within workflow systems, enabling the seamless integration and execution of multiple subtasks to accomplish complex operations
   emitTask:
+    type: object
     properties:
       emit:
         type: object
@@ -338,6 +340,7 @@ $defs:
         default: continue
       - type: string
   forTask:
+    type: object
     properties:
       for:
         type: object

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -133,7 +133,7 @@ $defs:
       - properties:
           call:
             type: string
-            constant: asyncapi
+            const: asyncapi
           with:
             type: object
             properties:
@@ -164,7 +164,7 @@ $defs:
       - properties:
           call:
             type: string
-            constant: grpc
+            const: grpc
           with:
             type: object
             properties:
@@ -203,7 +203,7 @@ $defs:
       - properties:
           call:
             type: string
-            constant: http
+            const: http
           with:
             type: object
             properties:
@@ -228,7 +228,7 @@ $defs:
       - properties:
           call:
             type: string
-            constant: openapi
+            const: openapi
           with:
             type: object
             properties:

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -156,8 +156,10 @@ $defs:
                 type: object
                 description: The payload to call the AsyncAPI operation with, if any.
               authentication:
-                $ref: '#/$defs/authenticationPolicy'
                 description: The authentication policy, if any, to use when calling the AsyncAPI operation.
+                oneOf:
+                  - $ref: '#/$defs/authenticationPolicy'
+                  - type: string
             required: [ document, operationRef ]
             description: Defines the AsyncAPI call to perform.
         required: [ call, with ]
@@ -187,8 +189,10 @@ $defs:
                     max: 65535
                     description: The port number of the GRPC service to call.
                   authentication:
-                    $ref: '#/$defs/authenticationPolicy'
                     description: The endpoint's authentication policy, if any.
+                    oneOf:
+                      - $ref: '#/$defs/authenticationPolicy'
+                      - type: string
                 required: [ name, host ]
               method:
                 type: string
@@ -243,8 +247,10 @@ $defs:
                 additionalProperties: true
                 description: A name/value mapping of the parameters of the OpenAPI operation to call.
               authentication:
-                $ref: '#/$defs/authenticationPolicy'
                 description: The authentication policy, if any, to use when calling the OpenAPI operation.
+                oneOf:
+                  - $ref: '#/$defs/authenticationPolicy'
+                  - type: string
               output:
                 type: string
                 enum: [ raw, content, response ]
@@ -668,8 +674,10 @@ $defs:
         format: uri
         description: The endpoint's URI.
       authentication:
-        $ref: '#/$defs/authenticationPolicy'
         description: The authentication policy to use.
+        oneOf:
+          - $ref: '#/$defs/authenticationPolicy'
+          - type: string
     required: [ uri ]
   eventConsumptionStrategy:
     type: object
@@ -761,8 +769,10 @@ $defs:
         format: uri
         description: The endpoint's URI.
       authentication:
-        $ref: '#/$defs/authenticationPolicy'
         description: The authentication policy to use.
+        oneOf:
+          - $ref: '#/$defs/authenticationPolicy'
+          - type: string
       name:
         type: string
         description: The external resource's name, if any.

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -156,7 +156,7 @@ $defs:
                 type: object
                 description: The payload to call the AsyncAPI operation with, if any.
               authentication:
-                ref: '#/$defs/authenticationPolicy'
+                $ref: '#/$defs/authenticationPolicy'
                 description: The authentication policy, if any, to use when calling the AsyncAPI operation.
             required: [ document, operationRef ]
             description: Defines the AsyncAPI call to perform.


### PR DESCRIPTION
Signed-off-by: Matthias Pichler <m.pichler@warrify.com>

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [ ] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

I adressed some issues with the workflow schema:

1. I used `const` instead of `constant` as described here: https://json-schema.org/understanding-json-schema/reference/const
2. I added some missing `type: object` directives that made the schema fail certain strict schema checks (specifically ajv complained about the use of `properties` without `type: object`)
3. I allowed tasks to reference authentication policies defined under `use` by allowing string values for `authentication` fields of tasks
4. I replaced one erroneous use of `ref` with the correct `$ref`

**Additional information:**
<!-- Optional -->

the schema is very inconsistently formatted: would it be okay for me to configure `yamllint` and format the schema (in a separate PR?)