### PR TITLE
Fix usage of endpoint in-call http tasks

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -149,14 +149,14 @@ use:
         call: http
         with:
           method: post
-          uri: https://fake.log.collector.com
+          endpoint: https://fake.log.collector.com
           body:
             message: "${ \"Executing task '\($task.reference)'...\" }"
       after:
         call: http
         with:
           method: post
-          uri: https://fake.log.collector.com
+          endpoint: https://fake.log.collector.com
           body:
             message: "${ \"Executed task '\($task.reference)'...\" }"
   functions:
@@ -259,7 +259,7 @@ do:
     call: http
     with:
       method: get
-      uri: https://petstore.swagger.io/v2/pet/{petId}
+      endpoint: https://petstore.swagger.io/v2/pet/{petId}
 ```
 
 Serverless Workflow defines several default functions that **MUST** be supported by all implementations and runtimes:
@@ -371,7 +371,7 @@ do:
     call: http
     with:
       method: get
-      uri: https://petstore.swagger.io/v2/pet/{petId}
+      endpoint: https://petstore.swagger.io/v2/pet/{petId}
 ```
 
 ##### OpenAPI Call
@@ -481,7 +481,7 @@ do:
           call: http
           with:
             method: put
-            uri: https://fake-hospital.com/api/v3/alert/nurses
+            endpoint: https://fake-hospital.com/api/v3/alert/nurses
             body:
               patientId: ${ .patient.fullName }
               room: ${ .room.number }
@@ -489,7 +489,7 @@ do:
           call: http
           with:
             method: put
-            uri: https://fake-hospital.com/api/v3/alert/doctor
+            endpoint: https://fake-hospital.com/api/v3/alert/doctor
             body:
               patientId: ${ .patient.fullName }
               room: ${ .room.number }
@@ -917,7 +917,7 @@ do:
       call: http
       with:
         method: get
-        uri: https://
+        endpoint: https://
     catch:
       errors:
         with:
@@ -1203,14 +1203,14 @@ use:
         call: http
         with:
           method: post
-          uri: https://fake.log.collector.com
+          endpoint: https://fake.log.collector.com
           body:
             message: "${ \"Executing task '\($task.reference)'...\" }"
       after:
         call: http
         with:
           method: post
-          uri: https://fake.log.collector.com
+          endpoint: https://fake.log.collector.com
           body:
             message: "${ \"Executed task '\($task.reference)'...\" }"
 do:
@@ -1218,7 +1218,7 @@ do:
     call: http
     with:
       method: get
-      uri: https://fake.com/sample
+      endpoint: https://fake.com/sample
 ```
 
 *Intercept HTTP calls to 'https://mocked.service.com' and mock its response:*
@@ -1247,7 +1247,7 @@ do:
     call: http
     with:
       method: get
-      uri: https://fake.com/sample
+      endpoint: https://fake.com/sample
 ```
 
 ### Error

--- a/examples/call-http-shorthand-endpoint.yaml
+++ b/examples/call-http-shorthand-endpoint.yaml
@@ -8,4 +8,4 @@ do:
     call: http
     with:
       method: get
-      endpoint: https://petstore.swagger.io/v2/pet/1
+      endpoint: https://petstore.swagger.io/v2/pet/{petId}

--- a/examples/call-http-shorthand-endpoint.yaml
+++ b/examples/call-http-shorthand-endpoint.yaml
@@ -1,0 +1,11 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: call-http-shorthand-endpoint
+  version: 1.0.0-alpha1
+do:
+  getPetById:
+    call: http
+    with:
+      method: get
+      endpoint: https://petstore.swagger.io/v2/pet/1

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -211,8 +211,11 @@ $defs:
                 type: string
                 description: The HTTP method of the HTTP request to perform.
               endpoint:
-                $ref: '#/$defs/endpoint'
                 description: The HTTP endpoint to send the request to.
+                oneOf:
+                  - $ref: '#/$defs/endpoint'
+                  - type: string
+                    format: uri
               headers:
                 type: object
                 description: A name/value mapping of the headers, if any, of the HTTP request to perform.

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -219,7 +219,7 @@ $defs:
                 oneOf:
                   - $ref: '#/$defs/endpoint'
                   - type: string
-                    format: uri
+                    format: uri-template
               headers:
                 type: object
                 description: A name/value mapping of the headers, if any, of the HTTP request to perform.


### PR DESCRIPTION
Signed-off-by: Matthias Pichler <m.pichler@warrify.com>

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [ ] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

The DSL describes the callHttp endpoint property as:

> An URI or an object that describes the HTTP endpoint to call.

However: 

1. many examples used a `uri` field directly in call http tasks
1. the schema did not allow to specify a string directly

so I fixed both

**Additional information:**
<!-- Optional -->