### PR TITLE
[Fix_#873] Rename output.from and output.to

### DIFF
--- a/ctk/features/data-flow.feature
+++ b/ctk/features/data-flow.feature
@@ -44,7 +44,7 @@ Feature: Data Flow
         endpoint:
           uri: https://petstore.swagger.io/v2/pet/{petId} #simple interpolation, only possible with top level variables
       output:
-        from: .id #filters the output of the http call, using only the id of the returned object
+        as: .id #filters the output of the http call, using only the id of the returned object
     """
     And given the workflow input is:
     """yaml
@@ -74,7 +74,7 @@ Feature: Data Flow
                 endpoint:
                   uri: https://petstore.swagger.io/v2/pet/{petId} #simple interpolation, only possible with top level variables
               output:
-                from: .id
+                as: .id
           - getPetById2:
               call: http
               with:
@@ -82,7 +82,7 @@ Feature: Data Flow
                 endpoint:
                   uri: https://petstore.swagger.io/v2/pet/2
               output:
-                from: '{ ids: [ $input, .id ] }'
+                as: '{ ids: [ $input, .id ] }'
     """
     When the workflow is executed
     Then the workflow should complete with output:

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -176,7 +176,7 @@ do:
       - getAvailablePets:
           call: getAvailablePets
           output:
-            from: "$input + { availablePets: [.[] | select(.category.name == "dog" and (.tags[] | .breed == $input.order.breed))] }"
+            as: "$input + { availablePets: [.[] | select(.category.name == "dog" and (.tags[] | .breed == $input.order.breed))] }"
       - submitMatchesByMail:
           call: http
           with:
@@ -234,6 +234,7 @@ The Serverless Workflow DSL defines a list of [tasks](#task) that **must be** su
 |:--|:---:|:---:|:---|
 | input | [`input`](#input) | `no` | An object used to customize the task's input and to document its schema, if any. |
 | output | [`output`](#output) | `no` | An object used to customize the task's output and to document its schema, if any. |
+| export | [`export`](#export) | `no` | An object used to customize the content of the workflow context. | 
 | timeout | [`timeout`](#timeout) | `no` | The configuration of the task's timeout, if any. |
 | then | [`flowDirective`](#flow-directive) | `no` | The flow directive to execute next.<br>*If not set, defaults to `continue`.* |
 
@@ -558,7 +559,7 @@ do:
           with:
             type: com.fake.petclinic.pets.checkup.completed.v2
       output:
-        to: '.pets + [{ "id": $pet.id }]'        
+        as: '.pets + [{ "id": $pet.id }]'        
 ```
 
 #### Listen
@@ -1415,6 +1416,36 @@ from:
   petId: '${ .pet.id }'
 to: '.petList += [ . ]'
 ```
+
+### Export
+
+Certain task needs to set the context of the workflow using the task output for later usage. User set the content of the context through a runtime expression. The result of the expression is the new value of the context. If user want to merge the new data into the current context, he might do that using `$context` variable. 
+
+Optionally, the context can have a predefined schema. 
+
+
+#### Properties
+
+| Property | Type | Required | Description |
+|----------|:----:|:--------:|-------------|
+| schema | [`schema`](#schema) | `no` | The [`schema`](#schema) used to describe and validate context.<br>*Included to handle the non frequent case in which the context has a known format.* |
+| as | `string`<br>`object` | `no` | A [runtime expression](#runtime-expressions), if any, used to set the context value. |
+
+#### Examples
+
+Assuming the output of the task is a json object (not primitive, not array)
+Merge into the current context the output of the task. 
+
+```yaml
+as: '$context+=.'
+```
+
+Replace the context with the output of the task. 
+
+```yaml
+as: .
+```
+
 
 ### Schema
 

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -44,6 +44,7 @@
   + [Retry](#retry)
   + [Input](#input)
   + [Output](#output)
+  + [Export] (#export)
   + [Timeout](#timeout)
   + [Duration](#duration)
   + [HTTP Response](#http-response)
@@ -1419,33 +1420,30 @@ to: '.petList += [ . ]'
 
 ### Export
 
-Certain task needs to set the context of the workflow using the task output for later usage. User set the content of the context through a runtime expression. The result of the expression is the new value of the context. If user want to merge the new data into the current context, he might do that using `$context` variable. 
+Certain task needs to set the workflow context to save the task output for later usage. Users set the content of the context through a runtime expression. The result of the expression is the new value of the context. The expression is evaluated against the existing context. 
 
-Optionally, the context can have a predefined schema. 
-
+Optionally, the context might have an associated schema. 
 
 #### Properties
 
 | Property | Type | Required | Description |
 |----------|:----:|:--------:|-------------|
 | schema | [`schema`](#schema) | `no` | The [`schema`](#schema) used to describe and validate context.<br>*Included to handle the non frequent case in which the context has a known format.* |
-| as | `string`<br>`object` | `no` | A [runtime expression](#runtime-expressions), if any, used to set the context value. |
+| as | `string`<br>`object` | `no` | A runtime expression, if any, used to export the output data to the context. |
 
 #### Examples
 
-Assuming the output of the task is a json object (not primitive, not array)
-Merge into the current context the output of the task. 
+Merge the task output into the current context. 
 
 ```yaml
-as: '$context+=.'
+as: '.+$output'
 ```
 
-Replace the context with the output of the task. 
+Replace the context with the task output. 
 
 ```yaml
-as: .
+as: $output
 ```
-
 
 ### Schema
 

--- a/examples/accumulate-room-readings.yaml
+++ b/examples/accumulate-room-readings.yaml
@@ -17,7 +17,7 @@ do:
                     roomId:
                       from: .roomid
                   output:
-                    from: .data.reading
+                    as: .data.reading
                 - with:
                     source: https://my.home.com/sensor
                     type: my.home.sensors.humidity
@@ -25,7 +25,7 @@ do:
                     roomId:
                       from: .roomid
                   output:
-                    from: .data.reading
+                    as: .data.reading
           as: readings
       - logReading:
           for:

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -828,7 +828,7 @@ $defs:
         description: The schema used to describe and validate the workflow context.
       as:
         type: string
-        description: A runtime expression, if any, used to set the context with output data.
+        description: A runtime expression, if any, used to export the output data to the context.
     description: Set the content of the context. 
   retryPolicy:
     type: object

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -816,13 +816,20 @@ $defs:
       schema:
         $ref: '#/$defs/schema'
         description: The schema used to describe and validate the output of the workflow or task.
-      from:
+      as:
         type: string
         description: A runtime expression, if any, used to mutate and/or filter the output of the workflow or task.
-      to:
-        type: string
-        description: A runtime expression, if any, used to output data to the current context.
     description: Configures the output of a workflow or task.
+  export:
+    type: object
+    properties:
+      schema:
+        $ref: '#/$defs/schema'
+        description: The schema used to describe and validate the workflow context.
+      as:
+        type: string
+        description: A runtime expression, if any, used to set the context with output data.
+    description: Set the content of the context. 
   retryPolicy:
     type: object
     properties:


### PR DESCRIPTION
Fix https://github.com/serverlessworkflow/specification/issues/873
output.from is renamed as output.as
output.to is renamed as export.as

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

**Additional information:**
<!-- Optional -->