### PR TITLE
Fixes the schema to allow `input.from`, `output.as` and `export.as` to be either a runtime expression string or object

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1486,8 +1486,7 @@ When set, runtimes must validate output data against the defined schema, unless 
 | Property | Type | Required | Description |
 |----------|:----:|:--------:|-------------|
 | schema | [`schema`](#schema) | `no` | The [`schema`](#schema) used to describe and validate output data.<br>*Even though the schema is not required, it is strongly encouraged to document it, whenever feasible.* |
-| from | `string`<br>`object` | `no` | A [runtime expression](#runtime-expressions), if any, used to filter and/or mutate the workflow/task output. |
-| to | `string`<br>`object` | `no` | A [runtime expression](#runtime-expressions), if any, used to update the context, using both output and context data. |
+| as | `string`<br>`object` | `no` | A [runtime expression](#runtime-expressions), if any, used to filter and/or mutate the workflow/task output. |
 
 #### Examples
 

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -884,7 +884,9 @@ $defs:
         $ref: '#/$defs/schema'
         description: The schema used to describe and validate the input of the workflow or task.
       from:
-        type: string
+        oneOf:
+          - type: string
+          - type: object
         description: A runtime expression, if any, used to mutate and/or filter the input of the workflow or task.
     description: Configures the input of a workflow or task.
   output:
@@ -894,7 +896,9 @@ $defs:
         $ref: '#/$defs/schema'
         description: The schema used to describe and validate the output of the workflow or task.
       as:
-        type: string
+        oneOf:
+          - type: string
+          - type: object
         description: A runtime expression, if any, used to mutate and/or filter the output of the workflow or task.
     description: Configures the output of a workflow or task.
   export:
@@ -904,7 +908,9 @@ $defs:
         $ref: '#/$defs/schema'
         description: The schema used to describe and validate the workflow context.
       as:
-        type: string
+        oneOf:
+          - type: string
+          - type: object
         description: A runtime expression, if any, used to export the output data to the context.
     description: Set the content of the context. 
   retryPolicy:


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
#899 

**What this PR does**:
Fixes the schema to allow `input.from`, `output.as` and `export.as` to be either a runtime expression string or object

**Additional information:**
Fixes the `output` of the `dsl-reference.md`, which still had wording from `alpha1`