### PR TITLE
Changes  the way authentication policies can be referenced

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -192,7 +192,8 @@ do:
         method: post
         endpoint:
           uri: https://fake.smtp.service.com/email/send
-          authentication: petStoreOAuth2
+          authentication: 
+            use: petStoreOAuth2
         body:
           from: noreply@fake.petstore.com
           to: ${ .order.client.email }
@@ -438,6 +439,15 @@ document:
   namespace: test
   name: do-example
   version: '0.1.0'
+use:
+  authentications:
+    fake-booking-agency-oauth2:
+      oauth2:
+        authority: https://fake-booking-agency.com
+        grant: client_credentials
+        client:
+          id: serverless-workflow-runtime
+          secret: 0123456789
 do:
   - bookHotel:
       call: http
@@ -445,7 +455,8 @@ do:
         method: post
         endpoint: 
           uri: https://fake-booking-agency.com/hotels/book
-          authentication: fake-booking-agency-oauth2
+          authentication: 
+            use: fake-booking-agency-oauth2
         body:
           name: Four Seasons
           city: Antwerp
@@ -456,7 +467,8 @@ do:
         method: post
         endpoint: 
           uri: https://fake-booking-agency.com/flights/book
-          authentication: fake-booking-agency-oauth2
+          authentication: 
+            use: fake-booking-agency-oauth2
         body:
           departure:
             date: '01/01/26'
@@ -1136,7 +1148,7 @@ document:
   name: basic-authentication-example
   version: '0.1.0'
 use:
-  authentication:
+  authentications:
     sampleBasic:
       basic:
         username: admin
@@ -1148,7 +1160,8 @@ do:
         method: get
         endpoint: 
           uri: https://secured.fake.com/sample
-          authentication: sampleBasic
+          authentication: 
+            use: sampleBasic
 ```
 
 #### Bearer Authentication

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -447,7 +447,7 @@ use:
         grant: client_credentials
         client:
           id: serverless-workflow-runtime
-          secret: 0123456789
+          secret: secret0123456789
 do:
   - bookHotel:
       call: http
@@ -1152,7 +1152,7 @@ use:
     sampleBasic:
       basic:
         username: admin
-        password: 123
+        password: password123
 do:
   - sampleTask:
       call: http

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1083,6 +1083,7 @@ Defines the mechanism used to authenticate users and workflows attempting to acc
 
 | Property | Type | Required | Description |
 |----------|:----:|:--------:|-------------|
+| use | `string` | `no` | The name of the top-level authentication definition to use. Cannot be used by authentication definitions defined at top level. |
 | basic | [`basicAuthentication`](#basic-authentication) | `no` | The `basic` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | bearer | [`bearerAuthentication`](#bearer-authentication) | `no` | The `bearer` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | certificate | [`certificateAuthentication`](#certificate-authentication) | `no` | The `certificate` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
@@ -1102,7 +1103,8 @@ use:
     - usernamePasswordSecret
   authentication:
     sampleBasicFromSecret:
-      basic: usernamePasswordSecret
+      basic:
+        use: usernamePasswordSecret
 do:
   - sampleTask:
       call: http
@@ -1110,7 +1112,8 @@ do:
         method: get
         endpoint: 
           uri: https://secured.fake.com/sample
-          authentication: sampleBasicFromSecret
+          authentication:
+            use: sampleBasicFromSecret
 ```
 
 #### Basic Authentication

--- a/dsl.md
+++ b/dsl.md
@@ -204,6 +204,7 @@ When the evaluation of an expression fails, runtimes **must** raise an error wit
 |:-----|:----:|:------------|
 | context | `map` | The task's context data. |
 | input | `any` | The task's filtered input. |
+| secrets | `map` | A key/value map of the workflow secrets.<br>To avoid unintentional bleeding, secrets can only be used in the `input.from` runtime expression. |
 | task | [`taskDescriptor`](#task-descriptor) | Describes the current task. |
 | workflow | [`workflowDescritor`](#workflow-descriptor) | Describes the current workflow. |
 

--- a/examples/use-authentication.yaml
+++ b/examples/use-authentication.yaml
@@ -15,4 +15,5 @@ do:
         method: get
         endpoint:
           uri: https://petstore.swagger.io/v2/pet/{petId}
-          authentication: petStoreAuth
+          authentication: 
+            use: petStoreAuth

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -181,10 +181,8 @@ $defs:
                 type: object
                 description: The payload to call the AsyncAPI operation with, if any.
               authentication:
+                $ref: '#/$defs/referenceableAuthenticationPolicy'
                 description: The authentication policy, if any, to use when calling the AsyncAPI operation.
-                oneOf:
-                  - $ref: '#/$defs/authenticationPolicy'
-                  - type: string
             required: [ document, operationRef ]
             additionalProperties: false
             description: Defines the AsyncAPI call to perform.
@@ -220,10 +218,8 @@ $defs:
                     max: 65535
                     description: The port number of the GRPC service to call.
                   authentication:
+                    $ref: '#/$defs/referenceableAuthenticationPolicy'
                     description: The endpoint's authentication policy, if any.
-                    oneOf:
-                      - $ref: '#/$defs/authenticationPolicy'
-                      - type: string
                 required: [ name, host ]
               method:
                 type: string
@@ -293,10 +289,8 @@ $defs:
                 additionalProperties: true
                 description: A name/value mapping of the parameters of the OpenAPI operation to call.
               authentication:
+                $ref: '#/$defs/referenceableAuthenticationPolicy'
                 description: The authentication policy, if any, to use when calling the OpenAPI operation.
-                oneOf:
-                  - $ref: '#/$defs/authenticationPolicy'
-                  - type: string
               output:
                 type: string
                 enum: [ raw, content, response ]
@@ -631,6 +625,25 @@ $defs:
         enum: [ continue, exit, end ]
         default: continue
       - type: string
+  referenceableAuthenticationPolicy:
+    type: object
+    oneOf:
+      - title: AuthenticationPolicyReference
+        properties:
+          use:
+            type: string
+            minLength: 1
+            description: The name of the authentication policy to use
+        required: [use]
+      - $ref: '#/$defs/authenticationPolicy'
+  secretBasedAuthenticationPolicy:
+    type: object
+    properties:
+      use:
+        type: string
+        minLength: 1
+        description: The name of the authentication policy to use
+    required: [use]
   authenticationPolicy:
     type: object
     oneOf:
@@ -638,72 +651,78 @@ $defs:
       properties:
         basic:
           type: object
-          properties:
-            username:
-              type: string
-              description: The username to use.
-            password:
-              type: string
-              description: The password to use.
-          required: [ username, password ]
+          oneOf:
+            - properties:
+                username:
+                  type: string
+                  description: The username to use.
+                password:
+                  type: string
+                  description: The password to use.
+              required: [ username, password ]
+            - $ref: '#/$defs/secretBasedAuthenticationPolicy'
       required: [ basic ]
       description: Use basic authentication.
     - title: BearerAuthenticationPolicy
       properties:
         bearer:
           type: object
-          properties:
-            token:
-              type: string
-              description: The bearer token to use.
-          required: [ token ]
+          oneOf:
+            - properties:
+                token:
+                  type: string
+                  description: The bearer token to use.
+              required: [ token ]
+            - $ref: '#/$defs/secretBasedAuthenticationPolicy'
       required: [ bearer ]
       description: Use bearer authentication.
     - title: OAuth2AuthenticationPolicy
       properties:
         oauth2:
           type: object
-          properties:
-            authority:
-              type: string
-              format: uri
-              description: The URI that references the OAuth2 authority to use.
-            grant:
-              type: string
-              description: The grant type to use.
-            client:
-              type: object
-              properties:
-                id:
+          oneOf:
+            - properties:
+                authority:
                   type: string
-                  description: The client id to use.
-                secret:
+                  format: uri
+                  description: The URI that references the OAuth2 authority to use.
+                grant:
                   type: string
-                  description: The client secret to use, if any.
-              required: [ id ]
-            scopes:
-              type: array
-              items:
-                type: string
-              description: The scopes, if any, to request the token for.
-            audiences:
-              type: array
-              items:
-                type: string
-              description: The audiences, if any, to request the token for.
-            username:
-              type: string
-              description: The username to use. Used only if the grant type is Password.
-            password:
-              type: string
-              description: The password to use. Used only if the grant type is Password.
-            subject:
-              $ref: '#/$defs/oauth2Token'
-              description: The security token that represents the identity of the party on behalf of whom the request is being made.
-            actor:
-              $ref: '#/$defs/oauth2Token'
-              description: The security token that represents the identity of the acting party.
-          required: [ authority, grant, client ]
+                  description: The grant type to use.
+                client:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The client id to use.
+                    secret:
+                      type: string
+                      description: The client secret to use, if any.
+                  required: [ id ]
+                scopes:
+                  type: array
+                  items:
+                    type: string
+                  description: The scopes, if any, to request the token for.
+                audiences:
+                  type: array
+                  items:
+                    type: string
+                  description: The audiences, if any, to request the token for.
+                username:
+                  type: string
+                  description: The username to use. Used only if the grant type is Password.
+                password:
+                  type: string
+                  description: The password to use. Used only if the grant type is Password.
+                subject:
+                  $ref: '#/$defs/oauth2Token'
+                  description: The security token that represents the identity of the party on behalf of whom the request is being made.
+                actor:
+                  $ref: '#/$defs/oauth2Token'
+                  description: The security token that represents the identity of the acting party.
+              required: [ authority, grant, client ]
+            - $ref: '#/$defs/secretBasedAuthenticationPolicy'
       required: [ oauth2 ]
       description: Use OAUTH2 authentication.
     description: Defines an authentication policy.
@@ -766,10 +785,8 @@ $defs:
         format: uri-template
         description: The endpoint's URI.
       authentication:
+        $ref: '#/$defs/referenceableAuthenticationPolicy'
         description: The authentication policy to use.
-        oneOf:
-          - $ref: '#/$defs/authenticationPolicy'
-          - type: string
     required: [ uri ]
   eventConsumptionStrategy:
     type: object
@@ -869,10 +886,8 @@ $defs:
             format: uri
             description: The endpoint's URI.
           authentication:
+            $ref: '#/$defs/referenceableAuthenticationPolicy'
             description: The authentication policy to use.
-            oneOf:
-              - $ref: '#/$defs/authenticationPolicy'
-              - type: string
           name:
             type: string
             description: The external resource's name, if any.


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:

- Fixes #904 
- Partially addresses #866

**What this PR does**:

- Changes  the way authentication policies can be referenced
- Changes the way authentication policies can use secret
- Adds a new `secrets` runtime expression argument