### PR TITLE
Expel member for breaching Code of Conduct

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,6 @@
 
 # Serverless Workflow Org Emeritus Maintainers
 * [Antonio Mendoza Pérez](https://github.com/antmendoza)
-* [Tihomir Surdilovic](https://github.com/tsurdilo)
 
 # Maintainers Mailing list
 [cncf-serverlessws-maintainers](mailto:cncf-serverlessws-maintainers@lists.cncf.io)

--- a/community/contributors.md
+++ b/community/contributors.md
@@ -79,7 +79,6 @@ us know in chat or team meeting.
 
 * **Temporal Technologies**
   * Antonio Mendoza Pérez
-  * Tihomir Surdilovic
 
 * **WSO2**
   * Chathura Ekanayake

--- a/community/contributors.md
+++ b/community/contributors.md
@@ -79,6 +79,7 @@ us know in chat or team meeting.
 
 * **Temporal Technologies**
   * Antonio Mendoza Pérez
+  * Tihomir Tsurdilovic
 
 * **WSO2**
   * Chathura Ekanayake

--- a/community/contributors.md
+++ b/community/contributors.md
@@ -79,7 +79,7 @@ us know in chat or team meeting.
 
 * **Temporal Technologies**
   * Antonio Mendoza Pérez
-  * Tihomir Tsurdilovic
+  * Tihomir Surdilovic
 
 * **WSO2**
   * Chathura Ekanayake


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [ ] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [x] Community
- [ ] CTK
- [ ] Other

**What this PR does**:
Removes/bans @tsurdilo from emeritus maintainers for critical breach of code of conduct:

- Sent an incendiary email publicly insulting another member.
- Deleted CNCF software content from both YouTube and X.
- Withheld/disabled CNCF owned accounts on GMAIL, YouTube and X.
