### PR TITLE
Fix output examples from dsl reference and ctk feature

### DIFF
--- a/ctk/features/call.feature
+++ b/ctk/features/call.feature
@@ -22,7 +22,7 @@ Feature: Call Task
             endpoint:
               uri: https://petstore.swagger.io/v2/pet/findByStatus?status={status}
           output:
-            from: .[0]
+            as: .[0]
     """
     And given the workflow input is:
     """yaml
@@ -108,7 +108,7 @@ Feature: Call Task
             parameters:
               status: ${ .status }
           output:
-            from: . | length
+            as: . | length
     """
     And given the workflow input is:
     """yaml

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1515,9 +1515,7 @@ schema:
       petId:
         type: string
     required: [ petId ]
-from:
-  petId: '${ .pet.id }'
-to: '.petList += [ . ]'
+as: '.petList += [ . ]'
 ```
 
 ### Export

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1507,15 +1507,20 @@ When set, runtimes must validate output data against the defined schema, unless 
 #### Examples
 
 ```yaml
-schema:
-  format: json
-  document:
-    type: object
-    properties:
-      petId:
-        type: string
-    required: [ petId ]
-as: '.petList += [ . ]'
+output:
+  schema:
+    format: json
+    document:
+      type: object
+      properties:
+        petId:
+          type: string
+      required: [ petId ]
+  as:                        
+    petId: '${ .pet.id }'   
+export:
+  as: 
+   '.petList += [ . ]'  
 ```
 
 ### Export


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [ ] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [x] CTK
- [x] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
#934 

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
Some fixes to specification version : 1.0.0-alpha

- Fixes output property "as" from two of the examples in the call feature in ctk
- Fixes output property "as" and remove "from" against the example of Output in DSL reference. 

**Additional information:**
<!-- Optional -->
Please review in case I misinterpreted any examples of Output in either CTK or DSL reference.