### PR TITLE
Use allOf to extend taskBase

### DIFF
--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -151,7 +151,8 @@ $defs:
   callTask:
     oneOf:
       - title: CallAsyncAPI
-        $ref: '#/$defs/taskBase'
+        allOf:
+          - $ref: '#/$defs/taskBase'
         type: object
         required: [ call, with ]
         unevaluatedProperties: false
@@ -188,7 +189,8 @@ $defs:
             additionalProperties: false
             description: Defines the AsyncAPI call to perform.
       - title: CallGRPC
-        $ref: '#/$defs/taskBase'
+        allOf:
+          - $ref: '#/$defs/taskBase'
         type: object
         unevaluatedProperties: false
         required: [ call, with ]
@@ -233,7 +235,8 @@ $defs:
             additionalProperties: false
             description: Defines the GRPC call to perform.
       - title: CallHTTP
-        $ref: '#/$defs/taskBase'
+        allOf:
+          - $ref: '#/$defs/taskBase'
         type: object
         unevaluatedProperties: false
         required: [ call, with ]
@@ -267,7 +270,8 @@ $defs:
             additionalProperties: false
             description: Defines the HTTP call to perform.
       - title: CallOpenAPI
-        $ref: '#/$defs/taskBase'
+        allOf:
+          - $ref: '#/$defs/taskBase'
         type: object
         unevaluatedProperties: false
         required: [ call, with ]
@@ -300,7 +304,8 @@ $defs:
             additionalProperties: false
             description: Defines the OpenAPI call to perform.
       - title: CallFunction
-        $ref: '#/$defs/taskBase'
+        allOf:
+          - $ref: '#/$defs/taskBase'
         type: object
         unevaluatedProperties: false
         required: [ call ]
@@ -317,7 +322,8 @@ $defs:
   forkTask:
     title: ForkTask
     description: Allows workflows to execute multiple tasks concurrently and optionally race them against each other, with a single possible winner, which sets the task's output.
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     unevaluatedProperties: false
     required: [ fork ]
@@ -335,7 +341,8 @@ $defs:
   doTask:
     title: DoTask
     description: Allows to execute a list of tasks in sequence
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     unevaluatedProperties: false
     required: [ do ]
@@ -345,7 +352,8 @@ $defs:
   emitTask:
     title: EmitTask
     description: Allows workflows to publish events to event brokers or messaging systems, facilitating communication and coordination between different components and services.
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ emit ]
     unevaluatedProperties: false
@@ -383,7 +391,8 @@ $defs:
   forTask:
     title: ForTask
     description: Allows workflows to iterate over a collection of items, executing a defined set of subtasks for each item in the collection. This task type is instrumental in handling scenarios such as batch processing, data transformation, and repetitive operations across datasets.
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ for, do ]
     unevaluatedProperties: false
@@ -411,7 +420,8 @@ $defs:
   listenTask:
     title: ListenTask
     description: Provides a mechanism for workflows to await and react to external events, enabling event-driven behavior within workflow systems.
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ listen ]
     unevaluatedProperties: false
@@ -426,7 +436,8 @@ $defs:
   raiseTask:
     title: RaiseTask
     description: Intentionally triggers and propagates errors.
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ raise ]
     unevaluatedProperties: false
@@ -441,7 +452,8 @@ $defs:
   runTask:
     title: RunTask
     description: Provides the capability to execute external containers, shell commands, scripts, or workflows.
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ run ]
     unevaluatedProperties: false
@@ -550,7 +562,8 @@ $defs:
   setTask:
     title: SetTask
     description: A task used to set data
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ set ]
     unevaluatedProperties: false
@@ -563,7 +576,8 @@ $defs:
   switchTask:
     title: SwitchTask
     description: Enables conditional branching within workflows, allowing them to dynamically select different paths based on specified conditions or criteria
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ switch ]
     unevaluatedProperties: false
@@ -591,7 +605,8 @@ $defs:
   tryTask:
     title: TryTask
     description: Serves as a mechanism within workflows to handle errors gracefully, potentially retrying failed tasks before proceeding with alternate ones.
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ try, catch ]
     unevaluatedProperties: false
@@ -623,7 +638,8 @@ $defs:
   waitTask:
     title: WaitTask
     description: Allows workflows to pause or delay their execution for a specified period of time.
-    $ref: '#/$defs/taskBase'
+    allOf:
+      - $ref: '#/$defs/taskBase'
     type: object
     required: [ wait ]
     unevaluatedProperties: false


### PR DESCRIPTION
Signed-off-by: Matthias Pichler <m.pichler@warrify.com>

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [ ] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

From the JSON schema spec (since draft 2019) the following declarations are equivalent:

```yaml
type: object
allOf:
  - $ref: #/$defs/taskBase
properties:
  call: {}
```

and


```yaml
type: object
$ref: #/$defs/taskBase
properties:
  call: {}
```

one can even argue that the second declaration is nicer. Using `allOf` however is more widely supported since it was the only way to do it from draft 4-7.
I however noticed that some tools struggle with the second declaration (specifically https://orval.dev/ and https://redocly.com/).

To make type/client and doc generation easier for implementors I propose to use this more widely supported syntax.

**Additional information:**
<!-- Optional -->