### PR TITLE
Support to specify auth parameters as secrets

### DIFF
--- a/examples/secret-basic-auth.yaml
+++ b/examples/secret-basic-auth.yaml
@@ -1,0 +1,22 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: secret-basic-auth
+  version: 1.0.0-alpha1
+use:
+  secrets:
+    - secretUser
+    - secretPassword
+do:
+  - getPet:
+      call: http
+      with:
+        method: get
+        endpoint:
+          uri: https://petstore.swagger.io/v2/pet/{petId}
+          authentication:
+            basic:
+              username:
+                use: secretUser
+              password:
+                use: secretPassword

--- a/examples/secret-bearer-auth.yaml
+++ b/examples/secret-bearer-auth.yaml
@@ -1,0 +1,19 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: secret-bearer-auth
+  version: 1.0.0-alpha1
+use:
+  secrets:
+    - secretToken
+do:
+  - getPet:
+      call: http
+      with:
+        method: get
+        endpoint:
+          uri: https://petstore.swagger.io/v2/pet/{petId}
+          authentication:
+            bearer:
+              token:
+                use: secretToken

--- a/examples/secret-oauth2-auth.yaml
+++ b/examples/secret-oauth2-auth.yaml
@@ -1,0 +1,23 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: secret-oauth2-auth
+  version: 1.0.0-alpha1
+use:
+  secrets:
+    - clientSecret
+do:
+  - getPet:
+      call: http
+      with:
+        method: get
+        endpoint:
+          uri: https://petstore.swagger.io/v2/pet/{petId}
+          authentication:
+            oauth2:
+              authority: https://petstore.swagger.io/.well-known/openid-configuration
+              grant: client_credentials
+              client:
+                id: petstore
+                secret: 
+                  use: clientSecret

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -649,6 +649,14 @@ $defs:
         enum: [ continue, exit, end ]
         default: continue
       - type: string
+  secretReference:
+    type: object
+    properties:
+      use:
+        type: string
+        minLength: 1
+        description: The name of secret to use
+    required: [use]
   referenceableAuthenticationPolicy:
     type: object
     oneOf:
@@ -660,14 +668,6 @@ $defs:
             description: The name of the authentication policy to use
         required: [use]
       - $ref: '#/$defs/authenticationPolicy'
-  secretBasedAuthenticationPolicy:
-    type: object
-    properties:
-      use:
-        type: string
-        minLength: 1
-        description: The name of the authentication policy to use
-    required: [use]
   authenticationPolicy:
     type: object
     oneOf:
@@ -679,13 +679,19 @@ $defs:
             - title: BasicAuthenticationData
               properties:
                 username:
-                  type: string
-                  description: The username to use.
+                  oneOf:
+                    - title: LiteralUsername
+                      type: string
+                      description: The username to use.
+                    - $ref: '#/$defs/secretReference'
                 password:
-                  type: string
-                  description: The password to use.
+                  oneOf:
+                    - title: LiteralPassword
+                      type: string
+                      description: The password to use.
+                    - $ref: '#/$defs/secretReference'
               required: [ username, password ]
-            - $ref: '#/$defs/secretBasedAuthenticationPolicy'
+            - $ref: '#/$defs/secretReference'
       required: [ basic ]
       description: Use basic authentication.
     - title: BearerAuthenticationPolicy
@@ -696,10 +702,13 @@ $defs:
             - title: BearerAuthenticationData
               properties:
                 token:
-                  type: string
-                  description: The bearer token to use.
+                  oneOf:
+                    - title: LiteralBearerToken
+                      type: string
+                      description: The bearer token to use.
+                    - $ref: '#/$defs/secretReference'
               required: [ token ]
-            - $ref: '#/$defs/secretBasedAuthenticationPolicy'
+            - $ref: '#/$defs/secretReference'
       required: [ bearer ]
       description: Use bearer authentication.
     - title: OAuth2AuthenticationPolicy
@@ -717,15 +726,24 @@ $defs:
                   type: string
                   description: The grant type to use.
                 client:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                      description: The client id to use.
-                    secret:
-                      type: string
-                      description: The client secret to use, if any.
-                  required: [ id ]
+                  oneOf:
+                    - title: OAuth2ClientData
+                      type: object
+                      properties:
+                        id:
+                          oneOf:
+                            - title: LiteralClientId
+                              type: string
+                              description: The client id to use.
+                            - $ref: '#/$defs/secretReference'
+                        secret:
+                          oneOf:
+                            - title: LiteralClientSecret
+                              type: string
+                              description: The client secret to use, if any.
+                            - $ref: '#/$defs/secretReference'
+                      required: [ id ]
+                    - $ref: '#/$defs/secretReference'
                 scopes:
                   type: array
                   items:
@@ -737,11 +755,17 @@ $defs:
                     type: string
                   description: The audiences, if any, to request the token for.
                 username:
-                  type: string
-                  description: The username to use. Used only if the grant type is Password.
+                  oneOf:
+                    - title: LiteralUsername
+                      type: string
+                      description: The username to use. Used only if the grant type is Password.
+                    - $ref: '#/$defs/secretReference'
                 password:
-                  type: string
-                  description: The password to use. Used only if the grant type is Password.
+                  oneOf:
+                    - title: LiteralPassword
+                      type: string
+                      description: The password to use. Used only if the grant type is Password.
+                    - $ref: '#/$defs/secretReference'
                 subject:
                   $ref: '#/$defs/oauth2Token'
                   description: The security token that represents the identity of the party on behalf of whom the request is being made.
@@ -749,7 +773,7 @@ $defs:
                   $ref: '#/$defs/oauth2Token'
                   description: The security token that represents the identity of the acting party.
               required: [ authority, grant, client ]
-            - $ref: '#/$defs/secretBasedAuthenticationPolicy'
+            - $ref: '#/$defs/secretReference'
       required: [ oauth2 ]
       description: Use OAUTH2 authentication.
     description: Defines an authentication policy.
@@ -757,8 +781,11 @@ $defs:
     type: object
     properties:
       token:
-        type: string
-        description: The security token to use to use.
+        oneOf:
+          - title: LiteralToken
+            type: string
+            description: The security token to use to use.
+          - $ref: '#/$defs/secretReference'
       type:
         type: string
         description: The type of the security token to use to use.


### PR DESCRIPTION
Signed-off-by: Matthias Pichler <m.pichler@warrify.com>

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [ ] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

I updated the schema so that auth parameters such as client_id, password, token etc can be specified via secrets with `use:`

**Additional information:**
<!-- Optional -->

The way I understand it is that in principle any literal value can be specified as a secret. Even random things like `grant` or even things like the duration in `wait` ... what should we do about this? 

Should any value that currently uses a literal type (such as `string`, `boolean`, `number`) be substitued for a custom type (e.g. `StringValue`) that is a union of `<literal> | #/$defs/secretReference | #/$defs/runtimeExpression`?

What about complex types such as `oauth2.client`, `basic` or even arbitrary like `timeout`?