### PR TITLE
Fixed inconsistencies between `listen` and `emit`

### DIFF
--- a/ctk/features/set.feature
+++ b/ctk/features/set.feature
@@ -3,7 +3,7 @@ Feature: Set Task
   I want to ensure that set tasks can be executed within the workflow
   So that my implementation conforms to the expected behavior
 
-  # Tests emit tasks
+  # Tests set tasks
   Scenario: Set Task
     Given a workflow with definition:
     """yaml

--- a/dsl.md
+++ b/dsl.md
@@ -81,7 +81,7 @@ Workflows in the Serverless Workflow DSL can exist in several phases, each indic
 
 Additionally, the flow of execution within a workflow can be controlled using [directives*](dsl-reference.md#flow-directive), which provide instructions to the workflow engine on how to manage and handle specific aspects of workflow execution.
 
-**To learn more about flow directives and how they can be utilized to control the execution and behavior of workflows, please refer to [Flow Directives](dsl-reference.md#flow-directive).*
+\**To learn more about flow directives and how they can be utilized to control the execution and behavior of workflows, please refer to [Flow Directives](dsl-reference.md#flow-directive).*
 
 #### Components
 
@@ -102,14 +102,14 @@ The Serverless Workflow DSL defines several default [task](dsl-reference.md#task
 
 - [Call](dsl-reference.md#call), used to call services and/or functions.
 - [Do](dsl-reference.md#do), used to define one or more subtasks to perform in sequence.
-- [Fork](dsl-reference.md#fork), used to define one or more two subtasks to perform in parallel.
 - [Emit](dsl-reference.md#emit), used to emit [events](dsl-reference.md#event).
 - [For](dsl-reference.md#for), used to iterate over a collection of items, and conditionally perform a task for each of them.
+- [Fork](dsl-reference.md#fork), used to define one or more two subtasks to perform in parallel.
 - [Listen](dsl-reference.md#listen), used to listen for an [event](dsl-reference.md#event) or more.
 - [Raise](dsl-reference.md#raise), used to raise an [error](dsl-reference.md#error) and potentially fault the [workflow](dsl-reference.md#workflow).
 - [Run](dsl-reference.md#run), used to run a [container](dsl-reference.md#container-process), a [script](dsl-reference.md#script-process), a [shell](dsl-reference.md#shell-process) command or even another [workflow](dsl-reference.md#workflow-process). 
-- [Switch](dsl-reference.md#switch), used to dynamically select and execute one of multiple alternative paths based on specified conditions
 - [Set](dsl-reference.md#set), used to dynamically set or update the [workflow](dsl-reference.md#workflow)'s data during the its execution. 
+- [Switch](dsl-reference.md#switch), used to dynamically select and execute one of multiple alternative paths based on specified conditions
 - [Try](dsl-reference.md#try), used to attempt executing a specified [task](dsl-reference.md#task), and to handle any resulting [errors](dsl-reference.md#error) gracefully, allowing the [workflow](dsl-reference.md#workflow) to continue without interruption.
 - [Wait](dsl-reference.md#wait), used to pause or wait for a specified duration before proceeding to the next task.
 
@@ -138,7 +138,7 @@ A workflow begins with the first task defined.
 
 Once the task has been executed, different things can happen:
 
-- `continue`: the task ran to completion, and the next task, if any, should be executed. The task to run next is implictly the next in declaration order, or explicitly defined by the `then` property of the executed task. If the executed task is the last task, then the workflow's execution gracefully ends.
+- `continue`: the task ran to completion, and the next task, if any, should be executed. The task to run next is implicitly the next in declaration order, or explicitly defined by the `then` property of the executed task. If the executed task is the last task, then the workflow's execution gracefully ends.
 - `fault`: the task raised an uncaught error, which abruptly halts the workflow's execution and makes it transition to `faulted` [status phase](#status-phases).
 - `end`: the task explicitly and gracefully ends the workflow's execution. 
 

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1,3 +1,4 @@
+
 $id: https://serverlessworkflow.io/schemas/1.0.0-alpha1/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema
@@ -369,37 +370,9 @@ $defs:
           event:
             type: object
             properties:
-              id:
-                type: string
-                description: The event's unique identifier
-              source:
-                description: Identifies the context in which an event happened
-                oneOf:
-                  - title: LiteralSource
-                    type: string
-                    format: uri-template
-                  - $ref: '#/$defs/runtimeExpression'
-              type:
-                type: string
-                description: This attribute contains a value describing the type of event related to the originating occurrence.
-              time:
-                oneOf:
-                  - title: LiteralTime
-                    type: string
-                    format: date-time
-                  - $ref: '#/$defs/runtimeExpression'
-              subject:
-                type: string
-              datacontenttype:
-                type: string
-                description: Content type of data value. This attribute enables data to carry any type of content, whereby format and encoding might differ from that of the chosen event format.
-              dataschema:
-                oneOf:
-                  - title: LiteralDataSchema
-                    type: string
-                    format: uri-template
-                  - $ref: '#/$defs/runtimeExpression'
-            required: [ source, type ]
+              with:
+                $ref: '#/$defs/eventProperties'
+                required: [ source, type ]
             additionalProperties: true
         required: [ event ]
   forTask:
@@ -852,6 +825,40 @@ $defs:
         $ref: '#/$defs/referenceableAuthenticationPolicy'
         description: The authentication policy to use.
     required: [ uri ]
+  eventProperties:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The event's unique identifier
+      source:
+        description: Identifies the context in which an event happened
+        oneOf:
+          - title: LiteralSource
+            type: string
+            format: uri-template
+          - $ref: '#/$defs/runtimeExpression'
+      type:
+        type: string
+        description: This attribute contains a value describing the type of event related to the originating occurrence.
+      time:
+        oneOf:
+          - title: LiteralTime
+            type: string
+            format: date-time
+          - $ref: '#/$defs/runtimeExpression'
+      subject:
+        type: string
+      datacontenttype:
+        type: string
+        description: Content type of data value. This attribute enables data to carry any type of content, whereby format and encoding might differ from that of the chosen event format.
+      dataschema:
+        oneOf:
+          - title: LiteralDataSchema
+            type: string
+            format: uri-template
+          - $ref: '#/$defs/runtimeExpression'
+    additionalProperties: true
   eventConsumptionStrategy:
     type: object
     unevaluatedProperties: false
@@ -884,28 +891,8 @@ $defs:
     properties:
       with:
         title: WithEvent
-        type: object
+        $ref: '#/$defs/eventProperties'
         minProperties: 1
-        properties:
-          id:
-            type: string
-            description: The event's unique identifier
-          source:
-            type: string
-            description: Identifies the context in which an event happened
-          type:
-            type: string
-            description: This attribute contains a value describing the type of event related to the originating occurrence.
-          time:
-            type: string
-          subject:
-            type: string
-          datacontenttype:
-            type: string
-            description: Content type of data value. This attribute enables data to carry any type of content, whereby format and encoding might differ from that of the chosen event format.
-          dataschema:
-            type: string
-        additionalProperties: true
         description: An event filter is a mechanism used to selectively process or handle events based on predefined criteria, such as event type, source, or specific attributes.
       correlate:
         type: object


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

Redo of #926 and #943 because I messed up the history again -_-

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [x] CTK
- [ ] Other

**Discussion or Issue link**:
Closes #917 (and other little minor typo)

**What this PR does**:
- Fixes inconsistencies between `listen` and `emit`
  - Added new `event` section in the specification documentation
  - Fixed the sample of `emit` in the specification documentation
  - Added new `event` definition in the JSON schema and referenced it in `emit.event.with` and `eventFilter.with`
- Fixes a typo in the set feature
- Fixed type of an http call `endpoint` by adding `string`
- Added new (missing) `endpoint` section in the specification documentation
- Escaped * character
- Fixed double `https://https://`
- Fixed links to runtime expressions
- Fixed typo in `implictly`

**Additional information:**
\-