### PR TITLE
Refactor OAuth2 and add OIDC authentication policy

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1249,7 +1249,7 @@ Defines the fundamentals of an 'oauth2' authentication.
 
 | Name | Type | Required | Description |
 |:-----|:----:|:--------:|:------------|
-| authority | `uri-template` | `yes` | The URI that references the authority to use when making OAUTH2 calls. |
+| authority | `uri-template` | `yes` | The URI that references the authority to use when making OAuth2 calls. |
 | endpoints.token | `uri-template` | `no` | The relative path to the endpoint for OAUTH2 token requests.<br>Defaults to `/oauth2/token`. |
 | endpoints.revocation | `uri-template` | `no` | The relative path to the endpoint used to invalidate tokens.<br>Defaults to `/oauth2/revoke`. |
 | endpoints.introspection | `uri-template` | `no` | The relative path to the endpoint used to validate and obtain information about a token, typically to check its validity and associated metadata.<br>Defaults to `/oauth2/introspect`. | 

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -148,7 +148,7 @@ use:
     petStoreOAuth2:
       oauth2: 
         authority: https://petstore.swagger.io/.well-known/openid-configuration
-        grant: client-credentials
+        grant: client_credentials
         client:
           id: workflow-runtime
           secret: "**********"
@@ -1287,7 +1287,7 @@ do:
               authority: http://keycloak/realms/fake-authority
               endpoints:
                 token: /oauth2/token
-              grant: client-credentials
+              grant: client_credentials
               client:
                 id: workflow-runtime
                 secret: "**********"

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -37,6 +37,7 @@
     - [Certificate](#certificate-authentication)
     - [Digest](#digest-authentication)
     - [OAUTH2](#oauth2-authentication)
+    - [OpenIdConnect](#openidconnect-authentication)
   + [Extension](#extension)
   + [Error](#error)
     - [Standard Error Types](#standard-error-types)
@@ -1107,6 +1108,7 @@ Defines the mechanism used to authenticate users and workflows attempting to acc
 | certificate | [`certificateAuthentication`](#certificate-authentication) | `no` | The `certificate` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | digest | [`digestAuthentication`](#digest-authentication) | `no` | The `digest` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | oauth2 | [`oauth2`](#oauth2-authentication) | `no` | The `oauth2` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
+| oidc | [`oidc`](#openidconnect-authentication) | `no` | The `oidc` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 
 ##### Examples
 
@@ -1205,19 +1207,59 @@ do:
 
 #### Digest Authentication
 
-
-#### OAUTH2 Authentication
-
-Defines the fundamentals of an 'oauth2' authentication
+Defines the fundamentals of a 'digest' authentication.
 
 ##### Properties
 
 | Property | Type | Required | Description |
 |----------|:----:|:--------:|-------------|
-| authority | [`uri-template`](#uri-template) | `yes` | The URI that references the OAuth2 authority to use. |
-| grant | `string` | `yes` | The grant type to use. |
-| client.id | `string` | `yes` | The client id to use. |
+| username | `string` | `yes` | The username to use. |
+| password | `string` | `yes` | The password to use. |
+
+##### Examples
+
+```yaml
+document:
+  dsl: '1.0.0-alpha1'
+  namespace: test
+  name: digest-authentication-example
+  version: '0.1.0'
+use:
+  authentications:
+    sampleDigest:
+      digest:
+        username: admin
+        password: password123
+do:
+  - sampleTask:
+      call: http
+      with:
+        method: get
+        endpoint: 
+          uri: https://secured.fake.com/sample
+          authentication: 
+            use: sampleDigest
+```
+
+#### OAUTH2 Authentication
+
+Defines the fundamentals of an 'oauth2' authentication.
+
+##### Properties
+
+| Name | Type | Required | Description |
+|:-----|:----:|:--------:|:------------|
+| authority | `uri-template` | `yes` | The URI that references the authority to use when making OAUTH2 calls. |
+| endpoints.token | `uri-template` | `no` | The relative path to the endpoint for OAUTH2 token requests.<br>Defaults to `/oauth2/token`. |
+| endpoints.revocation | `uri-template` | `no` | The relative path to the endpoint used to invalidate tokens.<br>Defaults to `/oauth2/revoke`. |
+| endpoints.introspection | `uri-template` | `no` | The relative path to the endpoint used to validate and obtain information about a token, typically to check its validity and associated metadata.<br>Defaults to `/oauth2/introspect`. | 
+| grant | `string` | `yes` | The grant type to use.<br>Supported values are `authorization_code`, `client_credentials`, `password`, `refresh_token` and `urn:ietf:params:oauth:grant-type:token-exchange`. |
+| client.id | `string` | `no` | The client id to use.<br>Required if the `client.authentication` method has **not** been set to `none`. |
 | client.secret | `string` | `no` | The client secret to use, if any. |
+| client.assertion | `string` | `no` | A JWT containing a signed assertion with your application credentials.<br>Required when `client.authentication` has been set to `private_key_jwt`. |
+| client.authentication | `string` | `no` | The client authentication method to use.<br>Supported values are `client_secret_basic`, `client_secret_post`, `client_secret_jwt`, `private_key_jwt` or `none`.<br>Defaults to `client_secret_post`. |
+| request.encoding | `string` | `no` | The encoding of the token request.<br>Supported values are `application/x-www-form-urlencoded` and `application/json`.<br>Defaults to application/x-www-form-urlencoded. |
+| issuers | `uri-template[]` | `no` | A list that contains that contains valid issuers that will be used to check against the issuer of generated tokens. |
 | scopes | `string[]` | `no` | The scopes, if any, to request the token for. |
 | audiences | `string[]` | `no` | The audiences, if any, to request the token for. |
 | username | `string` | `no` | The username to use. Used only if the grant type is `Password`. |
@@ -1242,7 +1284,9 @@ do:
           uri: https://secured.fake.com/sample
           authentication:
             oauth2:
-              authority: http://keycloak/realms/fake-authority/.well-known/openid-configuration
+              authority: http://keycloak/realms/fake-authority
+              endpoints:
+                token: /oauth2/token
               grant: client-credentials
               client:
                 id: workflow-runtime
@@ -1261,6 +1305,55 @@ Represents the definition of an OAUTH2 token
 |----------|:----:|:--------:|-------------|
 | token | `string` | `yes` | The security token to use to use. |
 | type | `string` | `yes` | The type of security token to use. |
+
+#### OpenIdConnect Authentication
+
+Defines the fundamentals of an 'oidc' authentication.
+
+##### Properties
+
+| Name | Type | Required | Description |
+|:-----|:----:|:--------:|:------------|
+| authority | `uri-template` | `yes` | The URI that references the authority to use when making OpenIdConnect calls. |
+| grant | `string` | `yes` | The grant type to use.<br>Supported values are `authorization_code`, `client_credentials`, `password`, `refresh_token` and `urn:ietf:params:oauth:grant-type:token-exchange`. |
+| client.id | `string` | `no` | The client id to use.<br>Required if the `client.authentication` method has **not** been set to `none`. |
+| client.secret | `string` | `no` | The client secret to use, if any. |
+| client.assertion | `string` | `no` | A JWT containing a signed assertion with your application credentials.<br>Required when `client.authentication` has been set to `private_key_jwt`. |
+| client.authentication | `string` | `no` | The client authentication method to use.<br>Supported values are `client_secret_basic`, `client_secret_post`, `client_secret_jwt`, `private_key_jwt` or `none`.<br>Defaults to `client_secret_post`. |
+| request.encoding | `string` | `no` | The encoding of the token request.<br>Supported values are `application/x-www-form-urlencoded` and `application/json`.<br>Defaults to application/x-www-form-urlencoded. |
+| issuers | `uri-template[]` | `no` | A list that contains that contains valid issuers that will be used to check against the issuer of generated tokens. |
+| scopes | `string[]` | `no` | The scopes, if any, to request the token for. |
+| audiences | `string[]` | `no` | The audiences, if any, to request the token for. |
+| username | `string` | `no` | The username to use. Used only if the grant type is `Password`. |
+| password | `string` | `no` | The password to use. Used only if the grant type is `Password`. |
+| subject | [`oauth2Token`](#oauth2-token) | `no` | The security token that represents the identity of the party on behalf of whom the request is being made. |
+| actor | [`oauth2Token`](#oauth2-token) | `no` | The security token that represents the identity of the acting party. |
+
+##### Examples
+
+```yaml
+document:
+  dsl: '1.0.0-alpha1'
+  namespace: test
+  name: oidc-authentication-example
+  version: '0.1.0'
+do:
+  - sampleTask:
+      call: http
+      with:
+        method: get
+        endpoint: 
+          uri: https://secured.fake.com/sample
+          authentication:
+            oidc:
+              authority: http://keycloak/realms/fake-authority/.well-known/openid-configuration
+              grant: client_credentials
+              client:
+                id: workflow-runtime
+                secret: "**********"
+              scopes: [ api ]
+              audiences: [ runtime ]
+```
 
 ### Extension
 

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1250,7 +1250,7 @@ Defines the fundamentals of an 'oauth2' authentication.
 | Name | Type | Required | Description |
 |:-----|:----:|:--------:|:------------|
 | authority | `uri-template` | `yes` | The URI that references the authority to use when making OAuth2 calls. |
-| endpoints.token | `uri-template` | `no` | The relative path to the endpoint for OAUTH2 token requests.<br>Defaults to `/oauth2/token`. |
+| endpoints.token | `uri-template` | `no` | The relative path to the endpoint for OAuth2 token requests.<br>Defaults to `/oauth2/token`. |
 | endpoints.revocation | `uri-template` | `no` | The relative path to the endpoint used to invalidate tokens.<br>Defaults to `/oauth2/revoke`. |
 | endpoints.introspection | `uri-template` | `no` | The relative path to the endpoint used to validate and obtain information about a token, typically to check its validity and associated metadata.<br>Defaults to `/oauth2/introspect`. | 
 | grant | `string` | `yes` | The grant type to use.<br>Supported values are `authorization_code`, `client_credentials`, `password`, `refresh_token` and `urn:ietf:params:oauth:grant-type:token-exchange`. |

--- a/examples/oauth2.yaml
+++ b/examples/oauth2.yaml
@@ -1,0 +1,22 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: oauth2-authentication
+  version: 1.0.0-alpha1
+do:
+  - getPet:
+      call: http
+      with:
+        method: get
+        endpoint:
+          uri: https://petstore.swagger.io/v2/pet/{petId}
+          authentication:
+            oauth2:
+              authority: http://keycloak/realms/fake-authority
+              endpoints: #optional
+                token: /auth/token #defaults to /oauth2/token
+                introspection: /auth/introspect #defaults to /oauth2/introspect
+              grant: client_credentials
+              client:
+                id: workflow-runtime-id
+                secret: workflow-runtime-secret

--- a/examples/oidc.yaml
+++ b/examples/oidc.yaml
@@ -1,0 +1,19 @@
+document:
+  dsl: 1.0.0-alpha1
+  namespace: examples
+  name: oidc-authentication
+  version: 1.0.0-alpha1
+do:
+  - getPet:
+      call: http
+      with:
+        method: get
+        endpoint:
+          uri: https://petstore.swagger.io/v2/pet/{petId}
+          authentication:
+            oidc:
+              authority: http://keycloak/realms/fake-authority #endpoints are resolved using the OIDC configuration located at '/.well-known/openid-configuration'
+              grant: client_credentials
+              client:
+                id: workflow-runtime-id
+                secret: workflow-runtime-secret

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -822,7 +822,7 @@ $defs:
           description: The configuration of the basic authentication policy.
           unevaluatedProperties: false
           oneOf:
-            - title: BasicAuthenticationData
+            - title: BasicAuthenticationProperties
               description: Inline configuration of the basic authentication policy.
               properties:
                 username:
@@ -845,7 +845,7 @@ $defs:
           description: The configuration of the bearer authentication policy.
           unevaluatedProperties: false
           oneOf:
-            - title: BearerAuthenticationData
+            - title: BearerAuthenticationProperties
               description: Inline configuration of the bearer authentication policy.
               properties:
                 token:
@@ -856,6 +856,29 @@ $defs:
               title: BearerAuthenticationPolicySecret
               description: Secret based configuration of the bearer authentication policy.
       required: [ bearer ]
+    - title: DigestAuthenticationPolicy
+      description: Use digest authentication.
+      properties:
+        digest:
+          type: object
+          title: DigestAuthenticationPolicyConfiguration
+          description: The configuration of the digest authentication policy.
+          unevaluatedProperties: false
+          oneOf:
+            - title: BasicAuthenticationProperties
+              description: Inline configuration of the digest authentication policy.
+              properties:
+                username:
+                  type: string
+                  description: The username to use.
+                password:
+                  type: string
+                  description: The password to use.
+              required: [ username, password ]
+            - $ref: '#/$defs/secretBasedAuthenticationPolicy'
+              title: DigestAuthenticationPolicySecret
+              description: Secret based configuration of the digest authentication policy.
+      required: [ digest ]
     - title: OAuth2AuthenticationPolicy
       description: Use OAuth2 authentication.
       properties:
@@ -865,65 +888,139 @@ $defs:
           description: The configuration of the OAuth2 authentication policy.
           unevaluatedProperties: false
           oneOf:
-            - title: OAuth2AutenthicationData
-              description: Inline configuration of the OAuth2 authentication policy.
-              properties:
-                authority:
-                  type: string
-                  format: uri-template
-                  title: OAuth2AutenthicationDataAuthority
-                  description: The URI that references the OAuth2 authority to use.
-                grant:
-                  type: string
-                  title: OAuth2AutenthicationDataGrant
-                  description: The grant type to use.
-                client:
-                  type: object
-                  title: OAuth2AutenthicationDataClient
-                  description: The definition of an OAuth2 client.
-                  unevaluatedProperties: false
+            - type: object
+              title: OAuth2ConnectAuthenticationProperties
+              description: The inline configuration of the OAuth2 authentication policy.
+              allOf:
+                - $ref: '#/$defs/oauth2AuthenticationProperties'
+                - type: object
                   properties:
-                    id:
-                      type: string
-                      title: ClientId
-                      description: The client id to use.
-                    secret:
-                      type: string
-                      title: ClientSecret
-                      description: The client secret to use, if any.
-                  required: [ id ]
-                scopes:
-                  type: array
-                  title: OAuth2AutenthicationDataScopes
-                  description: The scopes, if any, to request the token for.
-                  items:
-                    type: string
-                audiences:
-                  type: array
-                  title: OAuth2AutenthicationDataAudiences
-                  description: The audiences, if any, to request the token for.
-                  items:
-                    type: string
-                username:
-                  type: string
-                  title: OAuth2AutenthicationDataUsername
-                  description: The username to use. Used only if the grant type is Password.
-                password:
-                  type: string
-                  title: OAuth2AutenthicationDataPassword
-                  description: The password to use. Used only if the grant type is Password.
-                subject:
-                  $ref: '#/$defs/oauth2Token'
-                  title: OAuth2AutenthicationDataSubject
-                  description: The security token that represents the identity of the party on behalf of whom the request is being made.
-                actor:
-                  $ref: '#/$defs/oauth2Token'
-                  title: OAuth2AutenthicationDataActor
-                  description: The security token that represents the identity of the acting party.
+                    endpoints:
+                      type: object
+                      title: OAuth2AuthenticationPropertiesEndpoints
+                      description: The endpoint configurations for OAuth2.
+                      properties:
+                        token:
+                          type: string
+                          format: uri-template
+                          default: /oauth2/token
+                          title: OAuth2TokenEndpoint
+                          description: The relative path to the token endpoint. Defaults to `/oauth2/token`.
+                        revocation:
+                          type: string
+                          format: uri-template
+                          default: /oauth2/revoke
+                          title: OAuth2RevocationEndpoint
+                          description: The relative path to the revocation endpoint. Defaults to `/oauth2/revoke`.
+                        introspection:
+                          type: string
+                          format: uri-template
+                          default: /oauth2/introspect
+                          title: OAuth2IntrospectionEndpoint
+                          description: The relative path to the introspection endpoint. Defaults to `/oauth2/introspect`.
             - $ref: '#/$defs/secretBasedAuthenticationPolicy'
               title: OAuth2AuthenticationPolicySecret
               description: Secret based configuration of the OAuth2 authentication policy.
       required: [ oauth2 ]
+    - title: OpenIdConnectAuthenticationPolicy
+      description: Use OpenIdConnect authentication.
+      properties:
+        oidc:
+          type: object
+          title: OpenIdConnectAuthenticationPolicyConfiguration
+          description: The configuration of the OpenIdConnect authentication policy.
+          unevaluatedProperties: false
+          oneOf:
+            - $ref: '#/$defs/oauth2AuthenticationProperties'
+              title: OpenIdConnectAuthenticationProperties
+              description: The inline configuration of the OpenIdConnect authentication policy.
+            - $ref: '#/$defs/secretBasedAuthenticationPolicy'
+              title: OpenIdConnectAuthenticationPolicySecret
+              description: Secret based configuration of the OpenIdConnect authentication policy.
+      required: [ oidc ]
+  oauth2AuthenticationProperties:
+    type: object
+    title: OAuth2AutenthicationData
+    description: Inline configuration of the OAuth2 authentication policy.
+    properties:
+      authority:
+        type: string
+        format: uri-template
+        title: OAuth2AutenthicationDataAuthority
+        description: The URI that references the OAuth2 authority to use.
+      grant:
+        type: string
+        enum: [ authorization_code, client_credentials, password, refresh_token, 'urn:ietf:params:oauth:grant-type:token-exchange']
+        title: OAuth2AutenthicationDataGrant
+        description: The grant type to use.
+      client:
+        type: object
+        title: OAuth2AutenthicationDataClient
+        description: The definition of an OAuth2 client.
+        unevaluatedProperties: false
+        properties:
+          id:
+            type: string
+            title: ClientId
+            description: The client id to use.
+          secret:
+            type: string
+            title: ClientSecret
+            description: The client secret to use, if any.
+          assertion:
+            type: string
+            title: ClientAssertion
+            description: A JWT containing a signed assertion with your application credentials.
+          authentication:
+            type: string
+            enum: [ client_secret_basic, client_secret_post, client_secret_jwt, private_key_jwt, none ]
+            default: client_secret_post
+            title: ClientAuthentication
+            description: The authentication method to use to authenticate the client.
+      request:
+        type: object
+        title: OAuth2TokenRequest
+        description: The configuration of an OAuth2 token request
+        properties:
+          encoding:
+            type: string
+            enum: [ 'application/x-www-form-urlencoded', 'application/json' ]
+            default: 'application/x-www-form-urlencoded'
+            title: Oauth2TokenRequestEncoding
+      issuers:
+        type: array
+        title: OAuth2Issuers
+        description: A list that contains that contains valid issuers that will be used to check against the issuer of generated tokens.
+        items:
+          type: string
+      scopes:
+        type: array
+        title: OAuth2AutenthicationDataScopes
+        description: The scopes, if any, to request the token for.
+        items:
+          type: string
+      audiences:
+        type: array
+        title: OAuth2AutenthicationDataAudiences
+        description: The audiences, if any, to request the token for.
+        items:
+          type: string
+      username:
+        type: string
+        title: OAuth2AutenthicationDataUsername
+        description: The username to use. Used only if the grant type is Password.
+      password:
+        type: string
+        title: OAuth2AutenthicationDataPassword
+        description: The password to use. Used only if the grant type is Password.
+      subject:
+        $ref: '#/$defs/oauth2Token'
+        title: OAuth2AutenthicationDataSubject
+        description: The security token that represents the identity of the party on behalf of whom the request is being made.
+      actor:
+        $ref: '#/$defs/oauth2Token'
+        title: OAuth2AutenthicationDataActor
+        description: The security token that represents the identity of the acting party.
   oauth2Token:
     type: object
     title: OAuth2TokenDefinition


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
Closes #912

**What this PR does**:
- Refactors the `oauth2` authentication by:
  - Adding a new (optional) `endpoints` property, used to configure `token`, `revocation` and `introspection` endpoints
  - Addind a new (optional) `issuers` property, used to configure the trusted issuers of issued tokens, in case it differs from the configured authority 
  - Adding a new (optional) `request.encoding` property, used to configure the encoding of token requests
  - Adding a new (optional) `client.authentication` property, used to configure how the client should authenticate on the authorization server
- Adds a new  `oidc` authentication policy
- Adds both the documentation and schema for the `digest` authentication 
- Fixes schema documentation (ex: replaced `*AuthenticationData` instances by `*AuthenticationProperties`)