### PR TITLE
Extract datetime descriptor

### DIFF
--- a/dsl.md
+++ b/dsl.md
@@ -321,8 +321,8 @@ This argument contains information about the runtime executing the workflow.
 | Name | Type | Description | Example |
 |:-----|:----:|:------------|:--------|
 | iso8601 | `string` | The date time as a ISO 8601 date time string. It uses `T` as the date-time delimiter, either UTC (`Z`) or a time zone offset (`+01:00`). The precision can be either seconds, milliseconds or nanoseconds | `2022-01-01T12:00:00Z`, `2022-01-01T12:00:00.123456Z`, `2022-01-01T12:00:00.123+01:00` |
-| epoch.sec | `integer` | The date time as a integer value of seconds since midnight of 1970-01-01 UTC (i.e. [the Unix Epoch](https://en.wikipedia.org/wiki/Unix_time)) | `1641024000` (="2022-01-01T08:00:00Z") |
-| epoch.ms | `integer` | The date time as a integer value of milliseconds since midnight of 1970-01-01 UTC. This contains the *whole* timestamp, not just the millisecond portion | `1641024000123` (="2022-01-01T08:00:00.123Z") |
+| epoch.seconds | `integer` | The date time as a integer value of seconds since midnight of 1970-01-01 UTC (i.e. [the Unix Epoch](https://en.wikipedia.org/wiki/Unix_time)) | `1641024000` (="2022-01-01T08:00:00Z") |
+| epoch.milliseconds | `integer` | The date time as a integer value of milliseconds since midnight of 1970-01-01 UTC. This contains the *whole* timestamp, not just the millisecond portion | `1641024000123` (="2022-01-01T08:00:00.123Z") |
 
 The following table shows which arguments are available for each runtime expression:
 

--- a/dsl.md
+++ b/dsl.md
@@ -302,10 +302,27 @@ This argument contains information about the runtime executing the workflow.
 |:-----|:----:|:------------|:--------|
 | id | `string` | A unique id of the workflow execution. Now specific format is imposed | UUIDv4: `4a5c8422-5868-4e12-8dd9-220810d2b9ee`, ULID: `0000004JFGDSW1H037G7J7SFB9` |
 | definition | `map` | The workflow's definition as a parsed object | `{ "document": { ... }, "do": [...] }` |
-| input | `any` | The workflow's *raw* input (i.e *BEFORE* the `input.from` expression). For the result of `input.from` expression use the `$input` argument | - |
-| startedAt.iso8601 | `string` | The start time of the execution as a ISO 8601 date time string. It uses `T` as the date-time delimiter, either UTC (`Z`) or a time zone offset (`+01:00`). The precision can be either seconds, milliseconds or nanoseconds | `2022-01-01T12:00:00Z`, `2022-01-01T12:00:00.123456Z`, `2022-01-01T12:00:00.123+01:00` |
-| startedAt.epochMillis | `integer` | The start time of the execution as a integer value of milliseconds since midnight of 1970-01-01 UTC | `1641024000123` (="2022-01-01T08:00:00.123Z") |
-| startedAt.epochNanos | `integer` | The start time of the execution as a integer value of nanoseconds since midnight of 1970-01-01 UTC | `1641024000123456` (="2022-01-01T08:00:00.123456Z") |
+| input | `any` | The workflow's *raw* input (i.e *BEFORE* the `input.from` expression). For the result of `input.from` expression use the `$input` argument | |
+| startedAt | [`dateTimeDescriptor`](#datetime-descriptor) | The start time of the execution | |
+
+##### Task Descriptor
+
+| Name | Type | Description | Example |
+|:-----|:----:|:------------|:--------|
+| name | `string` | The task's name. | `getPet` |
+| reference | `string` | The task's reference. | `/do/2/myTask` |
+| definition | `map` | The tasks definition (specified under the name) as a parsed object | `{ "call": "http", "with": { ... } }` |
+| input | `any` | The task's *raw* input (i.e. *BEFORE* the `input.from` expression). For the result of `input.from` expression use the context of the runtime expression (for jq `.`) | |
+| output | `any` | The task's *raw* output (i.e. *BEFORE* the `output.as` expression). | |
+| startedAt | [`dateTimeDescriptor`](#datetime-descriptor) | The start time of the task | |
+
+##### DateTime Descriptor
+
+| Name | Type | Description | Example |
+|:-----|:----:|:------------|:--------|
+| iso8601 | `string` | The date time as a ISO 8601 date time string. It uses `T` as the date-time delimiter, either UTC (`Z`) or a time zone offset (`+01:00`). The precision can be either seconds, milliseconds or nanoseconds | `2022-01-01T12:00:00Z`, `2022-01-01T12:00:00.123456Z`, `2022-01-01T12:00:00.123+01:00` |
+| epoch.sec | `integer` | The date time as a integer value of seconds since midnight of 1970-01-01 UTC (i.e. [the Unix Epoch](https://en.wikipedia.org/wiki/Unix_time)) | `1641024000` (="2022-01-01T08:00:00Z") |
+| epoch.ms | `integer` | The date time as a integer value of milliseconds since midnight of 1970-01-01 UTC. This contains the *whole* timestamp, not just the millisecond portion | `1641024000123` (="2022-01-01T08:00:00.123Z") |
 
 The following table shows which arguments are available for each runtime expression:
 
@@ -318,19 +335,6 @@ The following table shows which arguments are available for each runtime express
 | Task `output.as` | Raw task output | Transformed task output | ✔ | ✔ | | ✔ | ✔ | ✔ |
 | Task `export.as` | Transformed task output | `$context` | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
 | Workflow `output.as` | Last task's transformed output | Transformed workflow output | ✔ | | | ✔ | | ✔ |
-
-##### Task Descriptor
-
-| Name | Type | Description | Example |
-|:-----|:----:|:------------|:--------|
-| name | `string` | The task's name. | `getPet` |
-| reference | `string` | The task's reference. | `/do/2/myTask` |
-| definition | `map` | The tasks definition (specified under the name) as a parsed object | `{ "call": "http", "with": { ... } }` |
-| input | `any` | The task's *raw* input (i.e. *BEFORE* the `input.from` expression). For the result of `input.from` expression use the context of the runtime expression (for jq `.`) | - |
-| output | `any` | The task's *raw* output (i.e. *BEFORE* the `output.as` expression). | - |
-| startedAt.iso8601 | `string` | The start time of the task as a ISO 8601 date time string. It uses `T` as the date-time delimiter, either UTC (`Z`) or a time zone offset (`+01:00`). The precision can be either seconds, milliseconds or nanoseconds | `2022-01-01T12:00:00Z`, `2022-01-01T12:00:00.123456Z`, `2022-01-01T12:00:00.123+01:00` |
-| startedAt.epochMillis | `integer` | The start time of the task as a integer value of milliseconds since midnight of 1970-01-01 UTC | `1641024000123` (="2022-01-01T08:00:00.123Z") |
-| startedAt.epochNanos | `integer` | The start time of the task as a integer value of nanoseconds since midnight of 1970-01-01 UTC | `1641024000123456` (="2022-01-01T08:00:00.123456Z") |
 
 ### Fault Tolerance
 


### PR DESCRIPTION
Signed-off-by: Matthias Pichler <m.pichler@warrify.com>

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

Closes #966

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->

It extracts the definition for the datetime descriptor and replaces nanosecods with seconds

**Additional information:**
<!-- Optional -->