### PR TITLE
Consolidate `endpoint` and `externalResource` definitions

### DIFF
--- a/ctk/features/call.feature
+++ b/ctk/features/call.feature
@@ -103,7 +103,7 @@ Feature: Call Task
           call: openapi
           with:
             document:
-              uri: "https://petstore.swagger.io/v2/swagger.json"
+              endpoint: "https://petstore.swagger.io/v2/swagger.json"
             operation: findPetsByStatus
             parameters:
               status: ${ .status }
@@ -131,7 +131,7 @@ Feature: Call Task
           call: openapi
           with:
             document:
-              uri: "https://petstore.swagger.io/v2/swagger.json"
+              endpoint: "https://petstore.swagger.io/v2/swagger.json"
             operation: getPetById
             parameters:
               petId: ${ .petId }

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -178,7 +178,7 @@ use:
       call: openapi
       with:
         document:
-          uri: https://petstore.swagger.io/v2/swagger.json
+          endpoint: https://petstore.swagger.io/v2/swagger.json
         operationId: findByStatus
         parameters:
           status: available

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -49,6 +49,7 @@
   + [Export](#export)
   + [Timeout](#timeout)
   + [Duration](#duration)
+  + [Endpoint](#endpoint)
   + [HTTP Response](#http-response)
   + [HTTP Request](#http-request)
   + [URI Template](#uri-template)
@@ -314,7 +315,8 @@ do:
   - findPet:
       call: asyncapi
       with:
-        document: https://fake.com/docs/asyncapi.json
+        document:
+          endpoint: https://fake.com/docs/asyncapi.json
         operationRef: findPetsByStatus
         server: staging
         message: getPetByStatusQuery
@@ -351,7 +353,8 @@ do:
   - greet:
       call: grpc
       with:
-        proto: file://app/greet.proto
+        proto: 
+          endpoint: file://app/greet.proto
         service:
           name: GreeterApi.Greeter
           host: localhost
@@ -418,7 +421,8 @@ do:
   - findPet:
       call: openapi
       with:
-        document: https://petstore.swagger.io/v2/swagger.json
+        document: 
+          endpoint: https://petstore.swagger.io/v2/swagger.json
         operationId: findPetsByStatus
         parameters:
           status: available
@@ -1079,18 +1083,18 @@ Defines an external resource.
 | Property | Type | Required | Description |
 |----------|:----:|:--------:|-------------|
 | name | `string` | `no` | The name, if any, of the defined resource. |
-| uri | [`uri-template`](#uri-template) | `yes` | The URI at which to get the defined resource. |
-| authentication | [`authentication`](#authentication) | `no` | The authentication policy, or the name of the authentication policy, to use when fecthing the resource. |
+| endpoint | [`endpoint`](#endpoint) | `yes` | The endpoint at which to get the defined resource. |
 
 ##### Examples
 
 ```yaml
 name: sample-resource
-uri: https://fake.com/resource/0123
-authentication:
-  basic:
-    username: admin
-    password: 1234
+endpoint:
+  uri: https://fake.com/resource/0123
+  authentication:
+    basic:
+      username: admin
+      password: 1234
 ```
 
 ### Authentication
@@ -1611,7 +1615,7 @@ document:
 ```yaml
 format: json
 resource:
-  uri: https://test.com/fake/schema/json/document.json
+  endpoint: https://test.com/fake/schema/json/document.json
 ```
 
 ### Timeout

--- a/examples/accumulate-room-readings.yaml
+++ b/examples/accumulate-room-readings.yaml
@@ -31,13 +31,13 @@ do:
             call: openapi
             with:
               document:
-                uri: http://myorg.io/ordersservices.json
+                endpoint: http://myorg.io/ordersservices.json
               operationId: logreading
   - generateReport:
       call: openapi
       with:
         document:
-          uri: http://myorg.io/ordersservices.json
+          endpoint: http://myorg.io/ordersservices.json
         operationId: produceReport
 timeout:
   after:

--- a/examples/asyncapi.yaml
+++ b/examples/asyncapi.yaml
@@ -8,7 +8,7 @@ do:
       call: asyncapi
       with:
         document:
-          uri: https://fake.com/docs/asyncapi.json
+          endpoint: https://fake.com/docs/asyncapi.json
         operationRef: findPetsByStatus
         server: staging
         message: getPetByStatusQuery

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -314,12 +314,7 @@ $defs:
               endpoint:
                 title: WithHTTPEndpoint
                 description: The HTTP endpoint to send the request to.
-                oneOf:
-                  - $ref: '#/$defs/endpoint'
-                  - $ref: '#/$defs/runtimeExpression'
-                  - title: LiteralEndpoint
-                    type: string
-                    format: uri-template
+                $ref: '#/$defs/endpoint'
               headers:
                 type: object
                 title: WithHTTPHeaders
@@ -1011,24 +1006,31 @@ $defs:
     type: object
     title: Endpoint
     description: Represents an endpoint.
-    unevaluatedProperties: false
-    properties:
-      uri:
-        title: EndpointUri
-        description: The endpoint's URI.
-        oneOf:
-          - title: LiteralEndpointURI
-            description: The literal endpoint's URI.
-            type: string
-            format: uri-template
-          - $ref: '#/$defs/runtimeExpression'
-            title: ExpressionEndpointURI
-            description: An expression based endpoint's URI.
-      authentication:
-        $ref: '#/$defs/referenceableAuthenticationPolicy'
-        title: EndpointAuthentication
-        description: The authentication policy to use.
-    required: [ uri ]
+    oneOf:
+      - $ref: '#/$defs/runtimeExpression'
+      - title: LiteralEndpoint
+        type: string
+        format: uri-template
+      - title: EndpointConfiguration
+        type: object
+        unevaluatedProperties: false
+        properties:
+          uri:
+            title: EndpointUri
+            description: The endpoint's URI.
+            oneOf:
+              - title: LiteralEndpointURI
+                description: The literal endpoint's URI.
+                type: string
+                format: uri-template
+              - $ref: '#/$defs/runtimeExpression'
+                title: ExpressionEndpointURI
+                description: An expression based endpoint's URI.
+          authentication:
+            $ref: '#/$defs/referenceableAuthenticationPolicy'
+            title: EndpointAuthentication
+            description: The authentication policy to use.
+        required: [ uri ]
   eventProperties:
     type: object
     title: EventProperties
@@ -1162,28 +1164,20 @@ $defs:
         description: The task(s) to execute after the extended task, if any.
     required: [ extend ]
   externalResource:
+    type: object
     title: ExternalResource
     description: Represents an external resource.
-    oneOf:
-      - type: string
-        format: uri-template
-      - title: ExternalResourceURI
-        type: object
-        unevaluatedProperties: false
-        properties:
-          uri:
-            type: string
-            format: uri-template
-            title: ExternalResourceURIEndpoint
-            description: The endpoint's URI.
-          authentication:
-            $ref: '#/$defs/referenceableAuthenticationPolicy'
-            title: ExternalResourceURIAuthentication
-            description: The authentication policy to use.
-          name:
-            type: string
-            description: The external resource's name, if any.
-        required: [ uri ]
+    unevaluatedProperties: false
+    properties:
+      name:
+        type: string
+        title: ExternalResourceName
+        description: The name of the external resource, if any.
+      endpoint:
+        $ref: '#/$defs/endpoint'
+        title: ExternalResourceEndpoint
+        description: The endpoint of the external resource.
+    required: [ endpoint ]
   input:
     type: object
     title: Input

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1003,7 +1003,6 @@ $defs:
         description: A human-readable explanation specific to this occurrence of the error.
     required: [ type, status, instance ]
   endpoint:
-    type: object
     title: Endpoint
     description: Represents an endpoint.
     oneOf:


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [x] CTK
- [ ] Other

**Discussion or Issue link**:
#930 


**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
This PR consolidates the definitions of `endpoint` and `externalResource`.

*Endpoint*
- Updated endpoint to support two options (moved from CallHTTP.with.endpoint): a string URI template or an object with properties uri and authentication.
- Ensured that uri is always required when using an object.

*External resource*
- Added a new level `endpoint` which refers to the endpoint definition.

