### PR TITLE
Add a new `metadata` property to the workflow document and to tasks

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -91,6 +91,7 @@ Documents the workflow definition.
 | title | `string` | `no` | The workflow's title. |
 | summary | `string` | `no` | The workflow's Markdown summary. |
 | tags | `map[string, string]` | `no` | A key/value mapping of the workflow's tags, if any. |
+| metadata | `map` | `no` | Additional information about the workflow. |
 
 #### Use
 
@@ -253,6 +254,7 @@ The Serverless Workflow DSL defines a list of [tasks](#task) that **must be** su
 | export | [`export`](#export) | `no` | An object used to customize the content of the workflow context. | 
 | timeout | [`timeout`](#timeout) | `no` | The configuration of the task's timeout, if any. |
 | then | [`flowDirective`](#flow-directive) | `no` | The flow directive to execute next.<br>*If not set, defaults to `continue`.* |
+| metadata | `map` | `no` | Additional information about the task. |
 
 #### Call
 

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -43,6 +43,11 @@ properties:
         title: WorkflowTags
         description: A key/value mapping of the workflow's tags, if any.
         additionalProperties: true
+      metadata:
+        type: object
+        title: WorkflowMetadata
+        description: Holds additional information about the workflow.
+        additionalProperties: true
     required: [ dsl, namespace, name, version ]
   input:
     $ref: '#/$defs/input'
@@ -171,6 +176,11 @@ $defs:
         $ref: '#/$defs/flowDirective'
         title: TaskBaseThen
         description: The flow directive to be performed upon completion of the task.
+      metadata:
+        type: object
+        title: TaskMetadata
+        description: Holds additional information about the task.
+        additionalProperties: true
   task:
     title: Task
     description: A discrete unit of work that contributes to achieving the overall objectives defined by the workflow.


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:

Closes #945 

**What this PR does**:

Add a new `metadata` property to the workflow document and to tasks