### PR TITLE
Fixed `DigestAuthenticationProperties` title in schema

### DIFF
--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -869,7 +869,7 @@ $defs:
           description: The configuration of the digest authentication policy.
           unevaluatedProperties: false
           oneOf:
-            - title: BasicAuthenticationProperties
+            - title: DigestAuthenticationProperties
               description: Inline configuration of the digest authentication policy.
               properties:
                 username:


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [ ] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**What this PR does**:

Fixed a little error introduced in #973: the title of the `DigestAuthenticationPolicy` "properties" was `BasicAuthenticationProperties` instead of `DigestAuthenticationProperties`.