### PR TITLE
Add a new `catalogs` property to workflow resources

### DIFF
--- a/.ci/validation/src/index.ts
+++ b/.ci/validation/src/index.ts
@@ -25,7 +25,7 @@ export module SWSchemaValidator {
   addFormats(ajv);
 
   const workflowSchemaId =
-    "https://serverlessworkflow.io/schemas/1.0.0-alpha3/workflow.yaml";
+    "https://serverlessworkflow.io/schemas/1.0.0-alpha5/workflow.yaml";
   const schemaPath = "../../../schema";
   export const defaultEncoding = "utf-8";
 

--- a/.ci/validation/test/fixtures/invalid/extra-property-in-call.yaml
+++ b/.ci/validation/test/fixtures/invalid/extra-property-in-call.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: two-tasks-in-one-item
   version: '0.1.0'

--- a/.ci/validation/test/fixtures/invalid/two-tasks-in-one-item.yaml
+++ b/.ci/validation/test/fixtures/invalid/two-tasks-in-one-item.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: two-tasks-in-one-item
   version: '0.1.0'

--- a/ctk/features/branch.feature
+++ b/ctk/features/branch.feature
@@ -8,7 +8,7 @@ Feature: Composite Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: fork
       version: '1.0.0'

--- a/ctk/features/call.feature
+++ b/ctk/features/call.feature
@@ -11,7 +11,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: http-call-with-content-output
       version: '1.0.0'
@@ -40,7 +40,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: http-call-with-response-output
       version: '1.0.0'
@@ -68,7 +68,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: http-call-with-basic-auth
       version: '1.0.0'
@@ -98,7 +98,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: openapi-call-with-content-output
       version: '1.0.0'
@@ -127,7 +127,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: openapi-call-with-response-output
       version: '1.0.0'

--- a/ctk/features/data-flow.feature
+++ b/ctk/features/data-flow.feature
@@ -8,7 +8,7 @@ Feature: Data Flow
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: output-filtering
       version: '1.0.0'
@@ -36,7 +36,7 @@ Feature: Data Flow
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: output-filtering
       version: '1.0.0'
@@ -65,7 +65,7 @@ Feature: Data Flow
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: non-object-output
       version: '1.0.0'

--- a/ctk/features/do.feature
+++ b/ctk/features/do.feature
@@ -8,7 +8,7 @@ Feature: Composite Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: do
       version: '1.0.0'

--- a/ctk/features/emit.feature
+++ b/ctk/features/emit.feature
@@ -8,7 +8,7 @@ Feature: Emit Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: emit
       version: '1.0.0'

--- a/ctk/features/flow.feature
+++ b/ctk/features/flow.feature
@@ -7,7 +7,7 @@ Feature: Flow Directive
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: implicit-sequence
       version: '1.0.0'
@@ -35,7 +35,7 @@ Feature: Flow Directive
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: explicit-sequence
       version: '1.0.0'

--- a/ctk/features/for.feature
+++ b/ctk/features/for.feature
@@ -10,7 +10,7 @@ Feature: For Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: for
       version: '1.0.0'

--- a/ctk/features/raise.feature
+++ b/ctk/features/raise.feature
@@ -7,7 +7,7 @@ Feature: Raise Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: raise-custom-error
       version: '1.0.0'

--- a/ctk/features/set.feature
+++ b/ctk/features/set.feature
@@ -8,7 +8,7 @@ Feature: Set Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: set
       version: '1.0.0'

--- a/ctk/features/switch.feature
+++ b/ctk/features/switch.feature
@@ -7,7 +7,7 @@ Feature: Switch Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: switch-match
       version: '1.0.0'
@@ -52,7 +52,7 @@ Feature: Switch Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: switch-default-implicit
       version: '1.0.0'
@@ -95,7 +95,7 @@ Feature: Switch Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: switch-default-implicit
       version: '1.0.0'

--- a/ctk/features/try.feature
+++ b/ctk/features/try.feature
@@ -11,7 +11,7 @@ Feature: Try Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: try-catch-404
       version: '1.0.0'
@@ -55,7 +55,7 @@ Feature: Try Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0-alpha3'
+      dsl: '1.0.0-alpha5'
       namespace: default
       name: try-catch-503
       version: '1.0.0'

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -38,6 +38,7 @@
     - [Digest](#digest-authentication)
     - [OAUTH2](#oauth2-authentication)
     - [OpenIdConnect](#openidconnect-authentication)
+  + [Catalog](#catalog)
   + [Extension](#extension)
   + [Error](#error)
     - [Standard Error Types](#standard-error-types)
@@ -100,6 +101,7 @@ Defines the workflow's reusable components.
 | Name | Type | Required | Description|
 |:--|:---:|:---:|:---|
 | authentications | [`map[string, authentication]`](#authentication) | `no` | A name/value mapping of the workflow's reusable authentication policies. |
+| catalogs | [`map[string, catalog]`(#catalog)] | `no` | A name/value mapping of the workflow's reusable resource catalogs. |
 | errors | [`map[string, error]`](#error) | `no` | A name/value mapping of the workflow's reusable errors. | 
 | extensions | [`map[string, extension][]`](#extension) | `no` | A list of the workflow's reusable extensions. |
 | functions | [`map[string, task]`](#task) | `no` | A name/value mapping of the workflow's reusable tasks. |
@@ -131,7 +133,7 @@ Configures a workflow's runtime expression evaluation.
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: order-pet
   version: '0.1.0'
@@ -272,7 +274,7 @@ Enables the execution of a specified function within a workflow, allowing seamle
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: call-example
   version: '0.1.0'
@@ -311,7 +313,7 @@ The [AsyncAPI Call](#asyncapi-call) enables workflows to interact with external 
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: asyncapi-example
   version: '0.1.0'
@@ -349,7 +351,7 @@ The [gRPC Call](#grpc-call) enables communication with external systems via the 
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: grpc-example
   version: '0.1.0'
@@ -387,7 +389,7 @@ The [HTTP Call](#http-call) enables workflows to interact with external services
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: http-example
   version: '0.1.0'
@@ -417,7 +419,7 @@ The [OpenAPI Call](#openapi-call) enables workflows to interact with external se
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: openapi-example
   version: '0.1.0'
@@ -446,7 +448,7 @@ Serves as a fundamental building block within workflows, enabling the sequential
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: do-example
   version: '0.1.0'
@@ -511,7 +513,7 @@ Allows workflows to publish events to event brokers or messaging systems, facili
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: emit-example
   version: '0.1.0'
@@ -549,7 +551,7 @@ Allows workflows to iterate over a collection of items, executing a defined set 
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: for-example
   version: '0.1.0'
@@ -586,7 +588,7 @@ Allows workflows to execute multiple subtasks concurrently, enabling parallel pr
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: fork-example
   version: '0.1.0'
@@ -627,7 +629,7 @@ Provides a mechanism for workflows to await and react to external events, enabli
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: listen-example
   version: '0.1.0'
@@ -660,7 +662,7 @@ Intentionally triggers and propagates errors. By employing the "Raise" task, wor
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: raise-example
   version: '0.1.0'
@@ -726,7 +728,7 @@ Provides the capability to execute external [containers](#container-process), [s
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: run-example
   version: '0.1.0'
@@ -775,7 +777,7 @@ Enables the execution of external processes encapsulated within a containerized 
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: run-container-example
   version: '0.1.0'
@@ -804,7 +806,7 @@ Enables the execution of custom scripts or code within a workflow, empowering wo
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: run-script-example
   version: '0.1.0'
@@ -835,7 +837,7 @@ Enables the execution of shell commands within a workflow, enabling workflows to
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: run-shell-example
   version: '0.1.0'
@@ -862,7 +864,7 @@ Enables the invocation and execution of nested workflows within a parent workflo
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: run-workflow-example
   version: '0.1.0'
@@ -891,7 +893,7 @@ A task used to set data.
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: set-example
   version: '0.1.0'
@@ -917,7 +919,7 @@ Enables conditional branching within workflows, allowing them to dynamically sel
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: switch-example
   version: '0.1.0'
@@ -1001,7 +1003,7 @@ Serves as a mechanism within workflows to handle errors gracefully, potentially 
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: try-example
   version: '0.1.0'
@@ -1058,7 +1060,7 @@ Allows workflows to pause or delay their execution for a specified period of tim
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: wait-example
   version: '0.1.0'
@@ -1122,7 +1124,7 @@ Defines the mechanism used to authenticate users and workflows attempting to acc
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: authentication-example
   version: '0.1.0'
@@ -1159,7 +1161,7 @@ Defines the fundamentals of a 'basic' authentication.
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: basic-authentication-example
   version: '0.1.0'
@@ -1194,7 +1196,7 @@ Defines the fundamentals of a 'bearer' authentication
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: bearer-authentication-example
   version: '0.1.0'
@@ -1228,7 +1230,7 @@ Defines the fundamentals of a 'digest' authentication.
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: digest-authentication-example
   version: '0.1.0'
@@ -1279,7 +1281,7 @@ Defines the fundamentals of an 'oauth2' authentication.
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: oauth2-authentication-example
   version: '0.1.0'
@@ -1341,7 +1343,7 @@ Defines the fundamentals of an 'oidc' authentication.
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: oidc-authentication-example
   version: '0.1.0'
@@ -1361,6 +1363,44 @@ do:
                 secret: "**********"
               scopes: [ api ]
               audiences: [ runtime ]
+```
+
+### Catalog
+
+A **resource catalog** is an external collection of reusable components, such as functions, that can be referenced and imported into workflows. Catalogs allow workflows to integrate with externally defined resources, making it easier to manage reuse and versioning across different workflows.
+
+Each catalog is defined by an `endpoint` property, specifying the root URL where the resources are hosted, enabling workflows to access external functions and services. For portability, catalogs must adhere to a specific file structure, as defined [here](https://github.com/serverlessworkflow/catalog?tab=readme-ov-file#structure).
+
+For more information about catalogs, refer to the [Serverless Workflow DSL document](https://github.com/serverlessworkflow/specification/blob/main/dsl.md#catalogs).
+
+#### Properties
+
+| Property | Type | Required | Description |
+|----------|:----:|:--------:|-------------|
+| endpoint | [`endpoint`](#endpoint) | `yes` | The endpoint that defines the root URL at which the catalog is located. |
+
+#### Examples
+
+```yaml
+document:
+  dsl: '1.0.0-alpha5'
+  namespace: test
+  name: catalog-example
+  version: '0.1.0'
+use:
+  catalogs:
+    global:
+      endpoint:
+        uri: https://github.com/serverlessworkflow/catalog
+        authentication:
+          basic:
+            username: user
+            password: '012345'
+do:
+  - log:
+      call: log:0.5.2@global
+      with:
+        message: The cataloged custom function has been successfully called
 ```
 
 ### Extension
@@ -1383,7 +1423,7 @@ Extensions enable the execution of tasks prior to those they extend, offering th
 *Perform logging before and after any non-extension task is run:*
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: logging-extension-example
   version: '0.1.0'
@@ -1418,7 +1458,7 @@ do:
 *Intercept HTTP calls to 'https://mocked.service.com' and mock its response:*
 ```yaml
 document:  
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: intercept-extension-example
   version: '0.1.0'
@@ -1733,7 +1773,7 @@ Defines a workflow or task timeout.
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: timeout-example
   version: '0.1.0'

--- a/examples/accumulate-room-readings.yaml
+++ b/examples/accumulate-room-readings.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: accumulate-room-readings
   version: '0.1.0'

--- a/examples/authentication-bearer-uri-format.yaml
+++ b/examples/authentication-bearer-uri-format.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/authentication-bearer.yaml
+++ b/examples/authentication-bearer.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: bearer-auth-uri-format
   version: '0.1.0'

--- a/examples/authentication-oauth2.yaml
+++ b/examples/authentication-oauth2.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: oauth2-authentication
   version: '0.1.0'

--- a/examples/authentication-oidc.yaml
+++ b/examples/authentication-oidc.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: oidc-authentication
   version: '0.1.0'

--- a/examples/authentication-reusable.yaml
+++ b/examples/authentication-reusable.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/call-asyncapi.yaml
+++ b/examples/call-asyncapi.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/call-custom-function-cataloged.yaml
+++ b/examples/call-custom-function-cataloged.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: samples
   name: call-custom-function-cataloged
   version: '0.1.0'

--- a/examples/call-custom-function-inline.yaml
+++ b/examples/call-custom-function-inline.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: samples
   name: call-custom-function-inline
   version: '0.1.0'

--- a/examples/call-grpc.yaml
+++ b/examples/call-grpc.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: grpc-example
   version: '0.1.0'

--- a/examples/call-http-endpoint-interpolation-shorthand.yaml
+++ b/examples/call-http-endpoint-interpolation-shorthand.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: call-http-shorthand-endpoint
   version: '0.1.0'

--- a/examples/call-http-endpoint-interpolation.yaml
+++ b/examples/call-http-endpoint-interpolation.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: call-http-shorthand-endpoint
   version: '0.1.0'

--- a/examples/call-openapi.yaml
+++ b/examples/call-openapi.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: openapi-example
   version: '0.1.0'

--- a/examples/conditional-task.yaml
+++ b/examples/conditional-task.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: conditional-task
   version: '0.1.0'

--- a/examples/do-multiple.yaml
+++ b/examples/do-multiple.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: call-http-shorthand-endpoint
   version: '0.1.0'

--- a/examples/do-single.yaml
+++ b/examples/do-single.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: call-http-shorthand-endpoint
   version: '0.1.0'

--- a/examples/emit.yaml
+++ b/examples/emit.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: emit
   version: '0.1.0'

--- a/examples/for.yaml
+++ b/examples/for.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: for-example
   version: '0.1.0'

--- a/examples/fork.yaml
+++ b/examples/fork.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: fork-example
   version: '0.1.0'

--- a/examples/listen-to-all.yaml
+++ b/examples/listen-to-all.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: listen-to-all
   version: '0.1.0'

--- a/examples/listen-to-any.yaml
+++ b/examples/listen-to-any.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: listen-to-any
   version: '0.1.0'

--- a/examples/listen-to-one.yaml
+++ b/examples/listen-to-one.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: listen-to-one
   version: '0.1.0'

--- a/examples/mock-service-extension.yaml
+++ b/examples/mock-service-extension.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: sample-workflow
   version: 0.1.0

--- a/examples/raise-inline copy.yaml
+++ b/examples/raise-inline copy.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: raise-not-implemented
   version: '0.1.0'

--- a/examples/raise-reusable.yaml
+++ b/examples/raise-reusable.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: raise-not-implemented
   version: '0.1.0'

--- a/examples/run-container.yaml
+++ b/examples/run-container.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: run-container
   version: '0.1.0'

--- a/examples/run-script-with-arguments.yaml
+++ b/examples/run-script-with-arguments.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: samples
   name: run-script-with-arguments
   version: 0.1.0

--- a/examples/run-subflow.yaml
+++ b/examples/run-subflow.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: run-subflow
   version: '0.1.0'

--- a/examples/schedule-cron.yaml
+++ b/examples/schedule-cron.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: cron-schedule
   version: '0.1.0'

--- a/examples/schedule-event-driven.yaml
+++ b/examples/schedule-event-driven.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: examples
   name: event-driven-schedule
   version: '0.1.0'

--- a/examples/set.yaml
+++ b/examples/set.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: set
   version: '0.1.0'

--- a/examples/switch-then-string.yaml
+++ b/examples/switch-then-string.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: sample-workflow
   version: 0.1.0

--- a/examples/try-catch-retry-inline.yaml
+++ b/examples/try-catch-retry-inline.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: try-catch-retry
   version: '0.1.0'

--- a/examples/try-catch-retry-reusable.yaml
+++ b/examples/try-catch-retry-reusable.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: try-catch-retry
   version: '0.1.0'

--- a/examples/try-catch-then.yaml
+++ b/examples/try-catch-then.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: try-catch
   version: '0.1.0'

--- a/examples/try-catch.yaml
+++ b/examples/try-catch.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: try-catch
   version: '0.1.0'

--- a/examples/wait-duration-inline.yaml
+++ b/examples/wait-duration-inline.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: wait-duration-inline
   version: '0.1.0'

--- a/examples/wait-duration-iso8601.yaml
+++ b/examples/wait-duration-iso8601.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: test
   name: wait-duration-8601
   version: '0.1.0'

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0-alpha3/workflow.yaml
+$id: https://serverlessworkflow.io/schemas/1.0.0-alpha5/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object
@@ -107,6 +107,12 @@ properties:
         description: The workflow's reusable timeouts.
         additionalProperties:
           $ref: '#/$defs/timeout'
+      catalogs:
+        type: object
+        title: UseCatalogs
+        description: The workflow's reusable catalogs.
+        additionalProperties:
+          $ref: '#/$defs/catalog'
   do:
     $ref: '#/$defs/taskList'
     title: Do
@@ -1485,6 +1491,17 @@ $defs:
         title: TimeoutAfter
         description: The duration after which to timeout.
     required: [ after ]
+  catalog:
+    type: object
+    title: Catalog
+    description: The definition of a resource catalog
+    unevaluatedProperties: false
+    properties:
+      endpoint:
+        $ref: '#/$defs/endpoint'
+        title: CatalogEndpoint
+        description: The root URL where the catalog is hosted
+    required: [ endpoint ]
   runtimeExpression:
     type: string
     title: RuntimeExpression

--- a/use-cases/automated-data-backup/README.md
+++ b/use-cases/automated-data-backup/README.md
@@ -54,7 +54,7 @@ The following diagram represents the high-level flow of the workflow:
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: sql-export-to-minio
   version: 0.1.2

--- a/use-cases/managing-ev-charging-stations/README.md
+++ b/use-cases/managing-ev-charging-stations/README.md
@@ -70,7 +70,7 @@ The following diagram represents the high-level flow of the workflow:
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: manage-ev-charging-stations
   version: '0.1.0'

--- a/use-cases/managing-github-issues/README.md
+++ b/use-cases/managing-github-issues/README.md
@@ -63,7 +63,7 @@ The following diagram represents the high-level flow of the workflow:
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: manage-github-issues
   version: '0.1.0'

--- a/use-cases/multi-agent-ai-content-generation/README.md
+++ b/use-cases/multi-agent-ai-content-generation/README.md
@@ -66,7 +66,7 @@ The following diagram represents the high-level flow of the workflow:
 
 ```yaml
 document:
-  dsl: '1.0.0-alpha3'
+  dsl: '1.0.0-alpha5'
   namespace: default
   name: multi-agent-collaboration-for-ai-content
   version: '0.1.0'


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
#1021

**What this PR does**:

* Updates the schema to include add `catalogs` property to the top level `use` statement.
* Updates the `dsl.md` file to document catalogs, their structure, and how to use cataloged resources
* Updates the `dsl-reference.md` file to document the properties of a catalog
* Updates DSL version to `alpha5` in all examples and definitions.