### PR TITLE
Add a new `to` property to the `emit` task

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -508,6 +508,7 @@ Allows workflows to publish events to event brokers or messaging systems, facili
 | Name | Type | Required | Description |
 |:--|:---:|:---:|:---|
 | emit.event | [`eventProperties`](#event-properties) | `yes` | Defines the event to emit. |
+| emit.to | [`endpoint`](#endpoint) | `no` | Specifies an additional endpoint for emitting the event. While the runtime's default cloud event endpoint remains the primary destination, setting this property ensures that the event is also published to the specified endpoint. Ideally, this property is left unset so that event delivery relies solely on the runtime's configured endpoint, but when provided, the event will be sent to both endpoints concurrently. |
 
 ##### Examples
 

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -532,7 +532,7 @@ Allows workflows to publish events to event brokers or messaging systems, facili
 | Name | Type | Required | Description |
 |:--|:---:|:---:|:---|
 | emit.event | [`eventProperties`](#event-properties) | `yes` | Defines the event to emit. |
-| emit.to | [`endpoint`](#endpoint) | `no` | Specifies an additional endpoint for emitting the event. While the runtime's default cloud event endpoint remains the primary destination, setting this property ensures that the event is also published to the specified endpoint. Ideally, this property is left unset so that event delivery relies solely on the runtime's configured endpoint, but when provided, the event will be sent to both endpoints concurrently. |
+| emit.cc | [`endpoint`](#endpoint) | `no` | Specifies an additional endpoint for emitting a carbon copy of the event. While the runtime's default cloud event endpoint remains the primary destination, setting this property ensures that the event is also published to the specified endpoint. Ideally, this property is left unset so that event delivery relies solely on the runtime's configured endpoint, but when provided, the event will be sent to both endpoints concurrently. |
 
 ##### Examples
 

--- a/examples/emit-additional-sink.yaml
+++ b/examples/emit-additional-sink.yaml
@@ -1,0 +1,20 @@
+document:
+  dsl: '1.0.0-alpha5'
+  namespace: test
+  name: emit
+  version: '0.1.0'
+do:
+  - emitEvent:
+      emit:
+        event:
+          with:
+            source: https://petstore.com
+            type: com.petstore.order.placed.v1
+            data:
+              client:
+                firstName: Cruella
+                lastName: de Vil
+              items:
+                - breed: dalmatian
+                  quantity: 101
+        to: https://additional-cloud-event-sink.com/pub

--- a/examples/emit-cc.yaml
+++ b/examples/emit-cc.yaml
@@ -17,4 +17,4 @@ do:
               items:
                 - breed: dalmatian
                   quantity: 101
-        to: https://additional-cloud-event-sink.com/pub
+        cc: https://additional-cloud-event-sink.com/pub

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -491,10 +491,10 @@ $defs:
                 description: Defines the properties of event to emit.
                 required: [ source, type ]
             additionalProperties: true
-          to:
+          cc:
             $ref: '#/$defs/endpoint'
-            title: EmitEndpointDefinition
-            description: Defines the additional endpoint, if any, to emit the event to.
+            title: EmitCarbonCopyDefinition
+            description: Defines an additional endpoint, if any, to publish an event's carbon copy to.
         required: [ event ]
   forTask:
     type: object

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0-alpha6/workflow.yaml
+$id: https://serverlessworkflow.io/schemas/1.0.0-alpha5/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0-alpha5/workflow.yaml
+$id: https://serverlessworkflow.io/schemas/1.0.0-alpha6/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object
@@ -482,6 +482,10 @@ $defs:
                 description: Defines the properties of event to emit.
                 required: [ source, type ]
             additionalProperties: true
+          to:
+            $ref: '#/$defs/endpoint'
+            title: EmitEndpointDefinition
+            description: Defines the additional endpoint, if any, to emit the event to.
         required: [ event ]
   forTask:
     type: object


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
#1026

**What this PR does**:
- Adds a new `to` property to the `emit` task, used to configure an additional endpoint to publish the configured event to