### PR TITLE
Add a new `return` property to the `run` task

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -55,6 +55,7 @@
   + [HTTP Response](#http-response)
   + [HTTP Request](#http-request)
   + [URI Template](#uri-template)
+  + [Process Result](#process-result)
 
 ## Abstract
 
@@ -723,6 +724,7 @@ Provides the capability to execute external [containers](#container-process), [s
 | run.shell | [`shell`](#shell-process) | `no` | The definition of the shell command to run.<br>*Required if `container`, `script` and `workflow` have not been set.* |
 | run.workflow | [`workflow`](#workflow-process) | `no` | The definition of the workflow to run.<br>*Required if `container`, `script` and `shell` have not been set.* |
 | await | `boolean` | `no` | Determines whether or not the process to run should be awaited for.<br>*Defaults to `true`.* |
+| return | `string` | `no` | Configures the output of the process.<br>*Supported values are:*<br>*- `stdout`: Outputs the content of the process **STDOUT**.*<br>*- `stderr`: Outputs the content of the process **STDERR**.*<br>*- `code`:  Outputs the process's **exit code**.*<br>*- `all`: Outputs the **exit code**, the **STDOUT** content and the **STDERR** content, wrapped into a new [processResult](#process-result) object.*<br>*- `none`: Does not output anything.*<br>*Defaults to `stdout`.* |
 
 ##### Examples
 
@@ -1887,4 +1889,55 @@ This has the following limitations compared to runtime expressions:
 
 ```yaml
 uri: https://petstore.swagger.io/v2/pet/{petId}
+```
+
+### Process Result
+
+Describes the result of a process.
+
+#### Properties
+
+| Name | Type | Required | Description|
+|:--|:---:|:---:|:---|
+| code | `integer` | `yes` | The process's exit code. |
+| stdout | `string` | `yes` | The process's **STDOUT** output. |
+| stderr | `string` | `yes` | The process's **STDERR** output. |
+
+#### Examples
+
+```yaml
+document:
+  dsl: '1.0.0-alpha5'
+  namespace: test
+  name: run-example
+  version: '0.1.0'
+do:
+  - runContainer:
+      run:
+        container:
+          image: fake-image
+      return: stderr
+
+  - runScript:
+      run:
+        script:
+          language: js
+          code: >
+            Some cool multiline script
+      return: code
+
+  - runShell:
+      run:
+        shell:
+          command: 'echo "Hello, ${ .user.name }"'
+      return: all
+
+  - runWorkflow:
+      run:
+        workflow:
+          namespace: another-one
+          name: do-stuff
+          version: '0.1.0'
+          input: {}
+      return: none
 ```

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1916,7 +1916,7 @@ do:
       run:
         container:
           image: fake-image
-      return: stderr
+        return: stderr
 
   - runScript:
       run:
@@ -1924,13 +1924,13 @@ do:
           language: js
           code: >
             Some cool multiline script
-      return: code
+        return: code
 
   - runShell:
       run:
         shell:
           command: 'echo "Hello, ${ .user.name }"'
-      return: all
+        return: all
 
   - runWorkflow:
       run:
@@ -1939,5 +1939,5 @@ do:
           name: do-stuff
           version: '0.1.0'
           input: {}
-      return: none
+        return: none
 ```

--- a/examples/run-return-all.yaml
+++ b/examples/run-return-all.yaml
@@ -8,4 +8,4 @@ do:
       run:
         container:
           image: hello-world
-      return: all
+        return: all

--- a/examples/run-return-all.yaml
+++ b/examples/run-return-all.yaml
@@ -1,0 +1,11 @@
+document:
+  dsl: '1.0.0-alpha5'
+  namespace: test
+  name: run-container
+  version: '0.1.0'
+do:
+  - runContainer:
+      run:
+        container:
+          image: hello-world
+      return: all

--- a/examples/run-return-code.yaml
+++ b/examples/run-return-code.yaml
@@ -8,4 +8,4 @@ do:
       run:
         container:
           image: hello-world
-      return: code
+        return: code

--- a/examples/run-return-code.yaml
+++ b/examples/run-return-code.yaml
@@ -1,0 +1,11 @@
+document:
+  dsl: '1.0.0-alpha5'
+  namespace: test
+  name: run-container
+  version: '0.1.0'
+do:
+  - runContainer:
+      run:
+        container:
+          image: hello-world
+      return: code

--- a/examples/run-return-none.yaml
+++ b/examples/run-return-none.yaml
@@ -1,0 +1,11 @@
+document:
+  dsl: '1.0.0-alpha5'
+  namespace: test
+  name: run-container
+  version: '0.1.0'
+do:
+  - runContainer:
+      run:
+        container:
+          image: hello-world
+      return: none

--- a/examples/run-return-none.yaml
+++ b/examples/run-return-none.yaml
@@ -8,4 +8,4 @@ do:
       run:
         container:
           image: hello-world
-      return: none
+        return: none

--- a/examples/run-return-stderr.yaml
+++ b/examples/run-return-stderr.yaml
@@ -8,4 +8,4 @@ do:
       run:
         container:
           image: hello-world
-      return: stderr
+        return: stderr

--- a/examples/run-return-stderr.yaml
+++ b/examples/run-return-stderr.yaml
@@ -1,0 +1,11 @@
+document:
+  dsl: '1.0.0-alpha5'
+  namespace: test
+  name: run-container
+  version: '0.1.0'
+do:
+  - runContainer:
+      run:
+        container:
+          image: hello-world
+      return: stderr

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -581,6 +581,12 @@ $defs:
             default: true
             title: AwaitProcessCompletion
             description: Whether to await the process completion before continuing.
+          return:
+            type: string
+            title: ProcessReturnType
+            description: Configures the output of the process.
+            enum: [ stdout, stderr, code, all, none ]
+            default: stdout
         oneOf:
           - title: RunContainer
             description: Enables the execution of external processes encapsulated within a containerized environment.
@@ -1535,3 +1541,21 @@ $defs:
     title: RuntimeExpression
     description: A runtime expression.
     pattern: "^\\s*\\$\\{.+\\}\\s*$"
+  processResult:
+    type: object
+    title: ProcessResult
+    description: The object returned by a run task when its return type has been set 'all'
+    properties:
+      code:
+        type: integer
+        title: ProcessExitCode
+        description: The process's exit code.
+      stdout:
+        type: string
+        title: ProcessStandardOutput
+        description: The content of the process's STDOUT
+      stderr:
+        type: string
+        title: ProcessStandardError
+        description: The content of the process's STDERR
+    required: [ code, stdout, stderr ]


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
#1051

**What this PR does**:
- Adds a new `return` property to the `run` task, used to configure the output of the process to execute