### PR TITLE
Add a new `redirect` property to both `http`and `openapi` calls

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -408,6 +408,7 @@ The [HTTP Call](#http-call) enables workflows to interact with external services
 | body | `any` | `no` | The HTTP request body, if any. |
 | query | `map[string, any]` | `no` | A name/value mapping of the query parameters to use, if any. |
 | output | `string` | `no` | The http call's output format.<br>*Supported values are:*<br>*- `raw`, which output's the base-64 encoded [http response](#http-response) content, if any.*<br>*- `content`, which outputs the content of [http response](#http-response), possibly deserialized.*<br>*- `response`, which outputs the [http response](#http-response).*<br>*Defaults to `content`.* |
+| redirect | `boolean` | `no` | Specifies whether redirection status codes (`300–399`) should be treated as errors.<br>*If set to `false`, runtimes must raise an error for response status codes outside the `200–299` range.*<br>*If set to `true`, they must raise an error for status codes outside the `200–399` range.*<br>*Defaults to `false`.* |
 
 ###### Examples
 
@@ -438,6 +439,7 @@ The [OpenAPI Call](#openapi-call) enables workflows to interact with external se
 | parameters | `map` | `no` | A name/value mapping of the parameters, if any, of the OpenAPI operation to call. |
 | authentication | [`authentication`](#authentication) | `no` | The authentication policy, or the name of the authentication policy, to use when calling the OpenAPI operation. |
 | output | `string` | `no` | The OpenAPI call's output format.<br>*Supported values are:*<br>*- `raw`, which output's the base-64 encoded [http response](#http-response) content, if any.*<br>*- `content`, which outputs the content of [http response](#http-response), possibly deserialized.*<br>*- `response`, which outputs the [http response](#http-response).*<br>*Defaults to `content`.* |
+| redirect | `boolean` | `no` | Specifies whether redirection status codes (`300–399`) should be treated as errors.<br>*If set to `false`, runtimes must raise an error for response status codes outside the `200–299` range.*<br>*If set to `true`, they must raise an error for status codes outside the `200–399` range.*<br>*Defaults to `false`.* |
 
 ###### Examples
 

--- a/examples/call-http-redirect.yaml
+++ b/examples/call-http-redirect.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=../schema/workflow.yaml
+document:
+  dsl: 1.0.0-alpha2
+  namespace: examples
+  name: http-query-params
+  version: 1.0.0-alpha2
+input:
+  schema:
+    format: json
+    document:
+      type: object
+      required:
+        - searchQuery
+      properties:
+        searchQuery:
+          type: string
+do:
+  - searchStarWarsCharacters:
+      call: http
+      with:
+        method: get
+        endpoint: https://swapi.dev/api/people/
+        query:
+          search: ${.searchQuery}
+        redirect: true
+      

--- a/examples/call-openapi-redirect.yaml
+++ b/examples/call-openapi-redirect.yaml
@@ -1,0 +1,15 @@
+document:
+  dsl: '1.0.0-alpha5'
+  namespace: test
+  name: openapi-example
+  version: '0.1.0'
+do:
+  - findPet:
+      call: openapi
+      with:
+        document: 
+          endpoint: https://petstore.swagger.io/v2/swagger.json
+        operationId: findPetsByStatus
+        parameters:
+          status: available
+        redirect: true

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -350,29 +350,33 @@ $defs:
             properties:
               method:
                 type: string
-                title: WithHTTPMethod
+                title: HTTPMethod
                 description: The HTTP method of the HTTP request to perform.
               endpoint:
-                title: WithHTTPEndpoint
+                title: HTTPEndpoint
                 description: The HTTP endpoint to send the request to.
                 $ref: '#/$defs/endpoint'
               headers:
                 type: object
-                title: WithHTTPHeaders
+                title: HTTPHeaders
                 description: A name/value mapping of the headers, if any, of the HTTP request to perform.
               body:
-                title: WithHTTPBody
+                title: HTTPBody
                 description: The body, if any, of the HTTP request to perform.
               query:
                 type: object
-                title: WithHTTPQuery
+                title: HTTPQuery
                 description: A name/value mapping of the query parameters, if any, of the HTTP request to perform.
                 additionalProperties: true
               output:
                 type: string
-                title: WithHTTPOutput
+                title: HTTPOutput
                 description: The http call output format. Defaults to 'content'.
                 enum: [ raw, content, response ]
+              redirect:
+                type: boolean
+                title: HttpRedirect
+                description: Specifies whether redirection status codes (`300–399`) should be treated as errors.
             required: [ method, endpoint ]
             unevaluatedProperties: false
       - title: CallOpenAPI
@@ -412,6 +416,10 @@ $defs:
                 enum: [ raw, content, response ]
                 title: WithOpenAPIOutput
                 description: The http call output format. Defaults to 'content'.
+              redirect:
+                type: boolean
+                title: HttpRedirect
+                description: Specifies whether redirection status codes (`300–399`) should be treated as errors.
             required: [ document, operationId ]
             unevaluatedProperties: false
       - title: CallFunction


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
#985

**What this PR does**:
- Adds a new `redirect` property to both `http`and `openapi` calls