### PR TITLE
Add warnings about using the `$secrets` runtime expression

### DIFF
--- a/dsl.md
+++ b/dsl.md
@@ -348,6 +348,7 @@ When the evaluation of an expression fails, runtimes **must** raise an error wit
 | workflow | [`workflowDescriptor`](#workflow-descriptor) | Describes the current workflow. |
 | runtime | [`runtimeDescriptor`](#runtime-descriptor) | Describes the runtime. |
 
+⚠️ **Warning**: Use `$secrets` with caution: incorporating them in expressions or passing them as call inputs may inadvertently expose sensitive information.
 
 ##### Runtime Descriptor
 
@@ -405,6 +406,8 @@ The following table shows which arguments are available for each runtime express
 | Task `output.as` | Raw task output | Transformed task output | ✔ | ✔ | | ✔ | ✔ | ✔ | ✔ | ✔ |
 | Task `export.as` | Transformed task output | `$context` | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
 | Workflow `output.as` | Last task's transformed output | Transformed workflow output | ✔ | | | ✔ | | ✔ | ✔ | |
+
+⚠️ **Warning**: Use `$secrets` with caution: incorporating them in expressions or passing them as call inputs may inadvertently expose sensitive information.
 
 ### Fault Tolerance
 


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
#979 

**What this PR does**:
- Adds warnings about using the `$secrets` runtime expression

**Additional information:**
This PR comes as a consensual, impactless fix to #979, which proposed (breaking) changes which [were deemed unnecessary and potentially harmful](https://github.com/serverlessworkflow/specification/issues/979#issuecomment-2298350064).