### PR TITLE
Document the output of `fork` tasks in competing and non-competing scenarii

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -609,7 +609,7 @@ Allows workflows to execute multiple subtasks concurrently, enabling parallel pr
 | Name | Type | Required | Description|
 |:--|:---:|:---:|:---|
 | fork.branches | [`map[string, task][]`](#task) | `no` | The tasks to perform concurrently. | 
-| fork.compete | `boolean` | `no` | Indicates whether or not the concurrent [`tasks`](#task) are racing against each other, with a single possible winner, which sets the composite task's output. Defaults to `false`. |
+| fork.compete | `boolean` | `no` | Indicates whether or not the concurrent [`tasks`](#task) are racing against each other, with a single possible winner, which sets the composite task's output.<br>*If set to `false`, the task returns an array that includes the outputs from each branch, preserving the order in which the branches are declared.*<br>*If to `true`, the task returns only the output of the winning branch.*<br>*Defaults to `false`.* |
 
 ##### Examples
 


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
#1011 

**What this PR does**:
- Documents the output of `fork` tasks in competing and non-competing scenarii