### PR TITLE
Fix the `catalog` link in the `use` section table

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -129,7 +129,7 @@ Defines the workflow's reusable components.
 | Name | Type | Required | Description|
 |:--|:---:|:---:|:---|
 | authentications | [`map[string, authentication]`](#authentication) | `no` | A name/value mapping of the workflow's reusable authentication policies. |
-| catalogs | [`map[string, catalog]`(#catalog)] | `no` | A name/value mapping of the workflow's reusable resource catalogs. |
+| catalogs | [`map[string, catalog]`](#catalog) | `no` | A name/value mapping of the workflow's reusable resource catalogs. |
 | errors | [`map[string, error]`](#error) | `no` | A name/value mapping of the workflow's reusable errors. | 
 | extensions | [`map[string, extension]`](#extension) | `no` | A list of the workflow's reusable extensions. |
 | functions | [`map[string, task]`](#task) | `no` | A name/value mapping of the workflow's reusable tasks. |


### PR DESCRIPTION
**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**What this PR does**:
- Fixes the `catalog` link in the `use` section table