### PR TITLE
[WIP] feat: [#1096] While, Do-while loop implementation for fetching paginated data from an API 

### DIFF
--- a/examples/while.yaml
+++ b/examples/while.yaml
@@ -1,0 +1,47 @@
+document:
+  dsl: '1.0.0'
+  namespace: test
+  name: while-examples
+  version: '0.1.0'
+
+do:
+  # Example of a while loop (condition evaluated before execution)
+  - fetchPaginatedData:
+      while: .hasNextPage == true
+      maxIterations: 100
+      do:
+        - fetchPage:
+            call: getPageData
+            input:
+              pageToken: .nextPageToken
+            output: .fetchedData
+        - accumulateData:
+            run: mergeResults
+            input:
+              newData: .fetchedData
+              existingData: .accumulatedResults
+            output: .accumulatedResults
+
+  # Example of a do-while loop (condition evaluated after execution)
+  - retryOperation:
+      while: .retryCount < 3 && .success == false
+      postConditionCheck: true
+      do:
+        - attempt:
+            call: someOperation
+            output:
+              as: .success
+        - updateRetry:
+            set:
+              retryCount: '${ .retryCount + 1 }'
+
+  # Example using iteration counter
+  - countToMax:
+      while: .counter < .maxValue
+      at: iteration
+      maxIterations: 10
+      do:
+        - increment:
+            set:
+              counter: '${ .counter + 1 }'
+              iterations: '${ .iterations + [.iteration] }' 

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -213,6 +213,7 @@ $defs:
       - $ref: '#/$defs/forkTask'
       - $ref: '#/$defs/emitTask'
       - $ref: '#/$defs/forTask'
+      - $ref: '#/$defs/whileTask'
       - $ref: '#/$defs/listenTask'
       - $ref: '#/$defs/raiseTask'
       - $ref: '#/$defs/runTask'
@@ -544,6 +545,37 @@ $defs:
       do:
         $ref: '#/$defs/taskList'
         title: ForTaskDo
+  whileTask:
+    type: object
+    $ref: '#/$defs/taskBase'
+    title: WhileTask
+    description: A task that enables conditional looping with support for both while and do-while behavior.
+    required: [ while, do ]
+    unevaluatedProperties: false
+    properties:
+      while:
+        type: string
+        title: WhileCondition
+        description: A runtime expression that represents the condition that must be met for the iteration to continue.
+      postConditionCheck:
+        type: boolean
+        title: PostConditionCheck
+        description: Controls whether the condition is evaluated after (do-while) or before (while) executing the tasks. When true, enables do-while behavior.
+        default: false
+      maxIterations:
+        type: integer
+        title: MaxIterations
+        description: The maximum number of iterations to perform, if any.
+        minimum: 1
+      at:
+        type: string
+        title: WhileAt
+        description: The name of the variable used to store the index of the current iteration.
+        default: index
+      do:
+        $ref: '#/$defs/taskList'
+        title: WhileTaskDo
+        description: The tasks to execute in each iteration.
   listenTask:
     type: object
     $ref: '#/$defs/taskBase'


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [x] Examples
- [ ] Extensions
- [x] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other
Discussion or Issue link:
https://github.com/serverlessworkflow/specification/issues/1096

What this PR does:
This PR introduces enhancements to support iterative logic within the do block using a while loop construct. Specifically, it adds support for:

A while condition to allow loop execution as long as the condition evaluates to true.

postConditionCheck: false to enable do-while loop semantics.

maxIterations to define an upper limit on loop executions, providing safety against infinite loops.

The changes are accompanied by an example paginated-fetch-example that demonstrates fetching paginated API data until .hasNextPage == true, accumulating results across iterations.

Additional information:
This capability enables richer control flow for iterative data-fetching use cases in serverless workflows, reducing the need for complex custom code and improving the expressiveness of the DSL.

**Sample document:**

```
document:
  dsl: '1.0.0'
  namespace: test
  name: paginated-fetch-example
  version: '0.1.0'

do:
  - fetchPaginatedData:
      condition: .hasNextPage == true
      isDoWhile: true # Enables do-while behavior
      limit: 100
      do:
        - fetchPage:
            call: getPageData
            input:
              pageToken: .nextPageToken
            output: .fetchedData
        - accumulateData:
            run: mergeResults
            input:
              newData: .fetchedData
              existingData: .accumulatedResults
            output: .accumulatedResults
```