### PR TITLE
Improve JSON Schema compatibility

### DIFF
--- a/.ci/validation/src/index.ts
+++ b/.ci/validation/src/index.ts
@@ -24,7 +24,7 @@ export module SWSchemaValidator {
   const ajv = new Ajv({ strict: false, allowUnionTypes: true });
   addFormats(ajv);
 
-  const workflowSchemaId = "https://serverlessworkflow.io/schemas/1.0.0/workflow.yaml";
+  const workflowSchemaId = "https://serverlessworkflow.io/schemas/1.0.1/workflow.yaml";
   const schemaPath = "../../../schema";
   export const defaultEncoding = "utf-8";
 

--- a/.ci/validation/test/fixtures/invalid/extra-property-in-call.yaml
+++ b/.ci/validation/test/fixtures/invalid/extra-property-in-call.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: two-tasks-in-one-item
   version: '0.1.0'

--- a/.ci/validation/test/fixtures/invalid/listen-any-until-any-until.yaml
+++ b/.ci/validation/test/fixtures/invalid/listen-any-until-any-until.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-any
   version: '0.1.0'

--- a/.ci/validation/test/fixtures/invalid/two-tasks-in-one-item.yaml
+++ b/.ci/validation/test/fixtures/invalid/two-tasks-in-one-item.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: two-tasks-in-one-item
   version: '0.1.0'

--- a/ctk/features/branch.feature
+++ b/ctk/features/branch.feature
@@ -8,7 +8,7 @@ Feature: Composite Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: fork
       version: '1.0.0'

--- a/ctk/features/call.feature
+++ b/ctk/features/call.feature
@@ -11,7 +11,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: http-call-with-content-output
       version: '1.0.0'
@@ -40,7 +40,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: http-call-with-response-output
       version: '1.0.0'
@@ -68,7 +68,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: http-call-with-basic-auth
       version: '1.0.0'
@@ -98,7 +98,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: openapi-call-with-content-output
       version: '1.0.0'
@@ -127,7 +127,7 @@ Feature: Call Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: openapi-call-with-response-output
       version: '1.0.0'

--- a/ctk/features/data-flow.feature
+++ b/ctk/features/data-flow.feature
@@ -8,7 +8,7 @@ Feature: Data Flow
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: output-filtering
       version: '1.0.0'
@@ -36,7 +36,7 @@ Feature: Data Flow
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: output-filtering
       version: '1.0.0'
@@ -65,7 +65,7 @@ Feature: Data Flow
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: non-object-output
       version: '1.0.0'

--- a/ctk/features/do.feature
+++ b/ctk/features/do.feature
@@ -8,7 +8,7 @@ Feature: Composite Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: do
       version: '1.0.0'

--- a/ctk/features/emit.feature
+++ b/ctk/features/emit.feature
@@ -8,7 +8,7 @@ Feature: Emit Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: emit
       version: '1.0.0'

--- a/ctk/features/flow.feature
+++ b/ctk/features/flow.feature
@@ -7,7 +7,7 @@ Feature: Flow Directive
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: implicit-sequence
       version: '1.0.0'
@@ -35,7 +35,7 @@ Feature: Flow Directive
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: explicit-sequence
       version: '1.0.0'

--- a/ctk/features/for.feature
+++ b/ctk/features/for.feature
@@ -10,7 +10,7 @@ Feature: For Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: for
       version: '1.0.0'

--- a/ctk/features/raise.feature
+++ b/ctk/features/raise.feature
@@ -7,7 +7,7 @@ Feature: Raise Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: raise-custom-error
       version: '1.0.0'

--- a/ctk/features/set.feature
+++ b/ctk/features/set.feature
@@ -8,7 +8,7 @@ Feature: Set Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: set
       version: '1.0.0'

--- a/ctk/features/switch.feature
+++ b/ctk/features/switch.feature
@@ -7,7 +7,7 @@ Feature: Switch Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: switch-match
       version: '1.0.0'
@@ -52,7 +52,7 @@ Feature: Switch Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: switch-default-implicit
       version: '1.0.0'
@@ -95,7 +95,7 @@ Feature: Switch Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: switch-default-implicit
       version: '1.0.0'

--- a/ctk/features/try.feature
+++ b/ctk/features/try.feature
@@ -11,7 +11,7 @@ Feature: Try Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: try-catch-404
       version: '1.0.0'
@@ -55,7 +55,7 @@ Feature: Try Task
     Given a workflow with definition:
     """yaml
     document:
-      dsl: '1.0.0'
+      dsl: '1.0.1'
       namespace: default
       name: try-catch-503
       version: '1.0.0'

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -161,7 +161,7 @@ Configures a workflow's runtime expression evaluation.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: order-pet
   version: '0.1.0'
@@ -302,7 +302,7 @@ Enables the execution of a specified function within a workflow, allowing seamle
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: call-example
   version: '0.1.0'
@@ -342,7 +342,7 @@ The [AsyncAPI Call](#asyncapi-call) enables workflows to interact with external 
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: asyncapi-example
   version: '0.1.0'
@@ -398,7 +398,7 @@ The [gRPC Call](#grpc-call) enables communication with external systems via the 
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: grpc-example
   version: '0.1.0'
@@ -437,7 +437,7 @@ The [HTTP Call](#http-call) enables workflows to interact with external services
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: http-example
   version: '0.1.0'
@@ -468,7 +468,7 @@ The [OpenAPI Call](#openapi-call) enables workflows to interact with external se
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: openapi-example
   version: '0.1.0'
@@ -497,7 +497,7 @@ Serves as a fundamental building block within workflows, enabling the sequential
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: do-example
   version: '0.1.0'
@@ -562,7 +562,7 @@ Allows workflows to publish events to event brokers or messaging systems, facili
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: emit-example
   version: '0.1.0'
@@ -600,7 +600,7 @@ Allows workflows to iterate over a collection of items, executing a defined set 
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: for-example
   version: '0.1.0'
@@ -637,7 +637,7 @@ Allows workflows to execute multiple subtasks concurrently, enabling parallel pr
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: fork-example
   version: '0.1.0'
@@ -690,7 +690,7 @@ Provides a mechanism for workflows to await and react to external events, enabli
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-example
   version: '0.1.0'
@@ -721,7 +721,7 @@ Intentionally triggers and propagates errors. By employing the "Raise" task, wor
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: raise-example
   version: '0.1.0'
@@ -788,7 +788,7 @@ Provides the capability to execute external [containers](#container-process), [s
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-example
   version: '0.1.0'
@@ -839,7 +839,7 @@ Enables the execution of external processes encapsulated within a containerized 
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container-example
   version: '0.1.0'
@@ -882,7 +882,7 @@ Enables the execution of custom scripts or code within a workflow, empowering wo
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-script-example
   version: '0.1.0'
@@ -913,7 +913,7 @@ Enables the execution of shell commands within a workflow, enabling workflows to
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-shell-example
   version: '0.1.0'
@@ -940,7 +940,7 @@ Enables the invocation and execution of nested workflows within a parent workflo
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-workflow-example
   version: '0.1.0'
@@ -969,7 +969,7 @@ A task used to set data.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: set-example
   version: '0.1.0'
@@ -997,7 +997,7 @@ Enables conditional branching within workflows, allowing them to dynamically sel
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: switch-example
   version: '0.1.0'
@@ -1081,7 +1081,7 @@ Serves as a mechanism within workflows to handle errors gracefully, potentially 
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: try-example
   version: '0.1.0'
@@ -1138,7 +1138,7 @@ Allows workflows to pause or delay their execution for a specified period of tim
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: wait-example
   version: '0.1.0'
@@ -1588,7 +1588,7 @@ Defines the mechanism used to authenticate users and workflows attempting to acc
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: authentication-example
   version: '0.1.0'
@@ -1625,7 +1625,7 @@ Defines the fundamentals of a 'basic' authentication.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: basic-authentication-example
   version: '0.1.0'
@@ -1660,7 +1660,7 @@ Defines the fundamentals of a 'bearer' authentication
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: bearer-authentication-example
   version: '0.1.0'
@@ -1694,7 +1694,7 @@ Defines the fundamentals of a 'digest' authentication.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: digest-authentication-example
   version: '0.1.0'
@@ -1745,7 +1745,7 @@ Defines the fundamentals of an 'oauth2' authentication.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: oauth2-authentication-example
   version: '0.1.0'
@@ -1807,7 +1807,7 @@ Defines the fundamentals of an 'oidc' authentication.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: oidc-authentication-example
   version: '0.1.0'
@@ -1847,7 +1847,7 @@ For more information about catalogs, refer to the [Serverless Workflow DSL docum
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: catalog-example
   version: '0.1.0'
@@ -1887,7 +1887,7 @@ Extensions enable the execution of tasks prior to those they extend, offering th
 *Perform logging before and after any non-extension task is run:*
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: logging-extension-example
   version: '0.1.0'
@@ -1922,7 +1922,7 @@ do:
 *Intercept HTTP calls to 'https://mocked.service.com' and mock its response:*
 ```yaml
 document:  
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: intercept-extension-example
   version: '0.1.0'
@@ -2238,7 +2238,7 @@ Defines a workflow or task timeout.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: timeout-example
   version: '0.1.0'
@@ -2380,7 +2380,7 @@ Describes the result of a process.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container-example
   version: '0.1.0'
@@ -2434,7 +2434,7 @@ Configures the target server of an AsyncAPI operation.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: asyncapi-example
   version: '0.1.0'
@@ -2472,7 +2472,7 @@ Configures an AsyncAPI message to publish.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: asyncapi-example
   version: '0.1.0'
@@ -2537,7 +2537,7 @@ Configures a subscription to an AsyncAPI operation.
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: asyncapi-example
   version: '0.1.0'
@@ -2574,7 +2574,7 @@ Configures the lifetime of an AsyncAPI subscription
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: asyncapi-example
   version: '0.1.0'
@@ -2612,7 +2612,7 @@ Configures the iteration over each item (event or message) consumed by a subscri
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: asyncapi-example
   version: '0.1.0'

--- a/dsl.md
+++ b/dsl.md
@@ -566,7 +566,7 @@ This format ensures that the function, its version, and the catalog it belongs t
 *Calling a custom function defined within a catalog:*
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: catalog-example
   version: '0.1.0'
@@ -667,7 +667,7 @@ The following example demonstrates how to use the `validateEmailAddress` custom 
 ```yaml
 # workflow.yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: customFunctionWorkflow
   version: '0.1.0'
@@ -735,7 +735,7 @@ See the [DSL reference](dsl-reference.md#extension) for more details about exten
 *Sample logging extension:*
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: sample-workflow
   version: '0.1.0'

--- a/examples/accumulate-room-readings.yaml
+++ b/examples/accumulate-room-readings.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: accumulate-room-readings
   version: '0.1.0'

--- a/examples/authentication-bearer-uri-format.yaml
+++ b/examples/authentication-bearer-uri-format.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/authentication-bearer.yaml
+++ b/examples/authentication-bearer.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: bearer-auth-uri-format
   version: '0.1.0'

--- a/examples/authentication-oauth2-secret.yaml
+++ b/examples/authentication-oauth2-secret.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: oauth2-authentication
   version: '1.0.0'

--- a/examples/authentication-oauth2.yaml
+++ b/examples/authentication-oauth2.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: oauth2-authentication
   version: '0.1.0'

--- a/examples/authentication-oidc-secret.yaml
+++ b/examples/authentication-oidc-secret.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: oidc-authentication
   version: '1.0.0'

--- a/examples/authentication-oidc.yaml
+++ b/examples/authentication-oidc.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: oidc-authentication
   version: '0.1.0'

--- a/examples/authentication-reusable.yaml
+++ b/examples/authentication-reusable.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/call-asyncapi-publish.yaml
+++ b/examples/call-asyncapi-publish.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/call-asyncapi-subscribe-consume-amount.yaml
+++ b/examples/call-asyncapi-subscribe-consume-amount.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/call-asyncapi-subscribe-consume-forever-foreach.yaml
+++ b/examples/call-asyncapi-subscribe-consume-forever-foreach.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/call-asyncapi-subscribe-consume-until.yaml
+++ b/examples/call-asyncapi-subscribe-consume-until.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/call-asyncapi-subscribe-consume-while.yaml
+++ b/examples/call-asyncapi-subscribe-consume-while.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: bearer-auth
   version: '0.1.0'

--- a/examples/call-custom-function-cataloged.yaml
+++ b/examples/call-custom-function-cataloged.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: samples
   name: call-custom-function-cataloged
   version: '0.1.0'

--- a/examples/call-custom-function-inline.yaml
+++ b/examples/call-custom-function-inline.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: samples
   name: call-custom-function-inline
   version: '0.1.0'

--- a/examples/call-grpc.yaml
+++ b/examples/call-grpc.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: grpc-example
   version: '0.1.0'

--- a/examples/call-http-endpoint-interpolation-shorthand.yaml
+++ b/examples/call-http-endpoint-interpolation-shorthand.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: call-http-shorthand-endpoint
   version: '0.1.0'

--- a/examples/call-http-endpoint-interpolation.yaml
+++ b/examples/call-http-endpoint-interpolation.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: call-http-shorthand-endpoint
   version: '0.1.0'

--- a/examples/call-http-query-headers-expressions.yaml
+++ b/examples/call-http-query-headers-expressions.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../schema/workflow.yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: http-query-headers-expressions
   version: '1.0.0'

--- a/examples/call-http-query-parameters.yaml
+++ b/examples/call-http-query-parameters.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../schema/workflow.yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: http-query-params
   version: '1.0.0'

--- a/examples/call-http-redirect.yaml
+++ b/examples/call-http-redirect.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../schema/workflow.yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: http-query-params
   version: '1.0.0'

--- a/examples/call-openapi-redirect.yaml
+++ b/examples/call-openapi-redirect.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: openapi-example
   version: '0.1.0'

--- a/examples/call-openapi.yaml
+++ b/examples/call-openapi.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: openapi-example
   version: '0.1.0'

--- a/examples/conditional-task.yaml
+++ b/examples/conditional-task.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: conditional-task
   version: '0.1.0'

--- a/examples/do-multiple.yaml
+++ b/examples/do-multiple.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: call-http-shorthand-endpoint
   version: '0.1.0'

--- a/examples/do-single.yaml
+++ b/examples/do-single.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: call-http-shorthand-endpoint
   version: '0.1.0'

--- a/examples/emit.yaml
+++ b/examples/emit.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: emit
   version: '0.1.0'

--- a/examples/for.yaml
+++ b/examples/for.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: for-example
   version: '0.1.0'

--- a/examples/fork.yaml
+++ b/examples/fork.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: fork-example
   version: '0.1.0'

--- a/examples/listen-to-all read-envelope.yaml
+++ b/examples/listen-to-all read-envelope.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-all-read-envelope
   version: '0.1.0'

--- a/examples/listen-to-all.yaml
+++ b/examples/listen-to-all.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-all
   version: '0.1.0'

--- a/examples/listen-to-any-filter.yaml
+++ b/examples/listen-to-any-filter.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-any-filter
   version: '0.1.0'

--- a/examples/listen-to-any-forever-foreach.yaml
+++ b/examples/listen-to-any-forever-foreach.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-any-while-foreach
   version: '0.1.0'

--- a/examples/listen-to-any-until-condition.yaml
+++ b/examples/listen-to-any-until-condition.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-any
   version: '0.1.0'

--- a/examples/listen-to-any-until-consumed.yaml
+++ b/examples/listen-to-any-until-consumed.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-any
   version: '0.1.0'

--- a/examples/listen-to-any.yaml
+++ b/examples/listen-to-any.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-any
   version: '0.1.0'

--- a/examples/listen-to-one.yaml
+++ b/examples/listen-to-one.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: listen-to-one
   version: '0.1.0'

--- a/examples/mock-service-extension.yaml
+++ b/examples/mock-service-extension.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: sample-workflow
   version: 0.1.0

--- a/examples/raise-inline.yaml
+++ b/examples/raise-inline.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: raise-not-implemented
   version: '0.1.0'

--- a/examples/raise-reusable.yaml
+++ b/examples/raise-reusable.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: raise-not-implemented
   version: '0.1.0'

--- a/examples/run-container-cleanup-always.yaml
+++ b/examples/run-container-cleanup-always.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container
   version: '0.1.0'

--- a/examples/run-container-cleanup-eventually.yaml
+++ b/examples/run-container-cleanup-eventually.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container
   version: '0.1.0'

--- a/examples/run-container-with-name.yaml
+++ b/examples/run-container-with-name.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container-with-name
   version: '0.1.0'

--- a/examples/run-container.yaml
+++ b/examples/run-container.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container
   version: '0.1.0'

--- a/examples/run-return-all.yaml
+++ b/examples/run-return-all.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container
   version: '0.1.0'

--- a/examples/run-return-code.yaml
+++ b/examples/run-return-code.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container
   version: '0.1.0'

--- a/examples/run-return-none.yaml
+++ b/examples/run-return-none.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container
   version: '0.1.0'

--- a/examples/run-return-stderr.yaml
+++ b/examples/run-return-stderr.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-container
   version: '0.1.0'

--- a/examples/run-script-with-arguments.yaml
+++ b/examples/run-script-with-arguments.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: samples
   name: run-script-with-arguments
   version: 0.1.0

--- a/examples/run-subflow.yaml
+++ b/examples/run-subflow.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: run-subflow
   version: '0.1.0'

--- a/examples/schedule-cron.yaml
+++ b/examples/schedule-cron.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: cron-schedule
   version: '0.1.0'

--- a/examples/schedule-event-driven.yaml
+++ b/examples/schedule-event-driven.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: examples
   name: event-driven-schedule
   version: '0.1.0'

--- a/examples/set-expression.yaml
+++ b/examples/set-expression.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: set
   version: '0.1.0'

--- a/examples/set.yaml
+++ b/examples/set.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: set
   version: '0.1.0'

--- a/examples/star-wars-homeworld.yaml
+++ b/examples/star-wars-homeworld.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../schema/workflow.yaml
 document:
-  dsl: 1.0.0
+  dsl: '1.0.1'
   namespace: examples
   name: star-wars-homeplanet
-  version: 1.0.0
+  version: '1.0.0'
 input:
   schema:
     format: json

--- a/examples/switch-then-string.yaml
+++ b/examples/switch-then-string.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: sample-workflow
   version: 0.1.0

--- a/examples/try-catch-retry-inline.yaml
+++ b/examples/try-catch-retry-inline.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: try-catch-retry
   version: '0.1.0'

--- a/examples/try-catch-retry-reusable.yaml
+++ b/examples/try-catch-retry-reusable.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: try-catch-retry
   version: '0.1.0'

--- a/examples/try-catch-then.yaml
+++ b/examples/try-catch-then.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: try-catch
   version: '0.1.0'

--- a/examples/try-catch.yaml
+++ b/examples/try-catch.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: try-catch
   version: '0.1.0'

--- a/examples/wait-duration-inline.yaml
+++ b/examples/wait-duration-inline.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: wait-duration-inline
   version: '0.1.0'

--- a/examples/wait-duration-iso8601.yaml
+++ b/examples/wait-duration-iso8601.yaml
@@ -1,5 +1,5 @@
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: test
   name: wait-duration-8601
   version: '0.1.0'

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1,0 +1,2835 @@
+{
+  "$id": "https://serverlessworkflow.io/schemas/1.0.1/workflow.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Serverless Workflow DSL - Workflow Schema.",
+  "type": "object",
+  "required": [
+      "document",
+      "do"
+  ],
+  "properties": {
+      "document": {
+          "type": "object",
+          "title": "Document",
+          "description": "Documents the workflow.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "dsl": {
+                  "type": "string",
+                  "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+                  "title": "WorkflowDSL",
+                  "description": "The version of the DSL used by the workflow."
+              },
+              "namespace": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
+                  "title": "WorkflowNamespace",
+                  "description": "The workflow's namespace."
+              },
+              "name": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
+                  "title": "WorkflowName",
+                  "description": "The workflow's name."
+              },
+              "version": {
+                  "type": "string",
+                  "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+                  "title": "WorkflowVersion",
+                  "description": "The workflow's semantic version."
+              },
+              "title": {
+                  "type": "string",
+                  "title": "WorkflowTitle",
+                  "description": "The workflow's title."
+              },
+              "summary": {
+                  "type": "string",
+                  "title": "WorkflowSummary",
+                  "description": "The workflow's Markdown summary."
+              },
+              "tags": {
+                  "type": "object",
+                  "title": "WorkflowTags",
+                  "description": "A key/value mapping of the workflow's tags, if any.",
+                  "additionalProperties": true
+              },
+              "metadata": {
+                  "type": "object",
+                  "title": "WorkflowMetadata",
+                  "description": "Holds additional information about the workflow.",
+                  "additionalProperties": true
+              }
+          },
+          "required": [
+              "dsl",
+              "namespace",
+              "name",
+              "version"
+          ]
+      },
+      "input": {
+          "$ref": "#/$defs/input",
+          "title": "Input",
+          "description": "Configures the workflow's input."
+      },
+      "use": {
+          "type": "object",
+          "title": "Use",
+          "description": "Defines the workflow's reusable components.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "authentications": {
+                  "type": "object",
+                  "title": "UseAuthentications",
+                  "description": "The workflow's reusable authentication policies.",
+                  "additionalProperties": {
+                      "$ref": "#/$defs/authenticationPolicy"
+                  }
+              },
+              "errors": {
+                  "type": "object",
+                  "title": "UseErrors",
+                  "description": "The workflow's reusable errors.",
+                  "additionalProperties": {
+                      "$ref": "#/$defs/error"
+                  }
+              },
+              "extensions": {
+                  "type": "array",
+                  "title": "UseExtensions",
+                  "description": "The workflow's extensions.",
+                  "items": {
+                      "type": "object",
+                      "title": "ExtensionItem",
+                      "minProperties": 1,
+                      "maxProperties": 1,
+                      "additionalProperties": {
+                          "$ref": "#/$defs/extension"
+                      }
+                  }
+              },
+              "functions": {
+                  "type": "object",
+                  "title": "UseFunctions",
+                  "description": "The workflow's reusable functions.",
+                  "additionalProperties": {
+                      "$ref": "#/$defs/task"
+                  }
+              },
+              "retries": {
+                  "type": "object",
+                  "title": "UseRetries",
+                  "description": "The workflow's reusable retry policies.",
+                  "additionalProperties": {
+                      "$ref": "#/$defs/retryPolicy"
+                  }
+              },
+              "secrets": {
+                  "type": "array",
+                  "title": "UseSecrets",
+                  "description": "The workflow's reusable secrets.",
+                  "items": {
+                      "type": "string",
+                      "description": "The workflow's secrets."
+                  }
+              },
+              "timeouts": {
+                  "type": "object",
+                  "title": "UseTimeouts",
+                  "description": "The workflow's reusable timeouts.",
+                  "additionalProperties": {
+                      "$ref": "#/$defs/timeout"
+                  }
+              },
+              "catalogs": {
+                  "type": "object",
+                  "title": "UseCatalogs",
+                  "description": "The workflow's reusable catalogs.",
+                  "additionalProperties": {
+                      "$ref": "#/$defs/catalog"
+                  }
+              }
+          }
+      },
+      "do": {
+          "$ref": "#/$defs/taskList",
+          "title": "Do",
+          "description": "Defines the task(s) the workflow must perform."
+      },
+      "timeout": {
+          "title": "DoTimeout",
+          "oneOf": [
+              {
+                  "$ref": "#/$defs/timeout",
+                  "title": "TimeoutDefinition",
+                  "description": "The workflow's timeout configuration, if any."
+              },
+              {
+                  "type": "string",
+                  "title": "TimeoutReference",
+                  "description": "The name of the workflow's timeout, if any."
+              }
+          ]
+      },
+      "output": {
+          "$ref": "#/$defs/output",
+          "title": "Output",
+          "description": "Configures the workflow's output."
+      },
+      "schedule": {
+          "type": "object",
+          "title": "Schedule",
+          "description": "Schedules the workflow.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "every": {
+                  "$ref": "#/$defs/duration",
+                  "title": "ScheduleEvery",
+                  "description": "Specifies the duration of the interval at which the workflow should be executed."
+              },
+              "cron": {
+                  "type": "string",
+                  "title": "ScheduleCron",
+                  "description": "Specifies the schedule using a cron expression, e.g., '0 0 * * *' for daily at midnight."
+              },
+              "after": {
+                  "$ref": "#/$defs/duration",
+                  "title": "ScheduleAfter",
+                  "description": "Specifies a delay duration that the workflow must wait before starting again after it completes."
+              },
+              "on": {
+                  "$ref": "#/$defs/eventConsumptionStrategy",
+                  "title": "ScheduleOn",
+                  "description": "Specifies the events that trigger the workflow execution."
+              }
+          }
+      }
+  },
+  "$defs": {
+      "taskList": {
+          "title": "TaskList",
+          "description": "List of named tasks to perform.",
+          "type": "array",
+          "items": {
+              "type": "object",
+              "title": "TaskItem",
+              "minProperties": 1,
+              "maxProperties": 1,
+              "additionalProperties": {
+                  "$ref": "#/$defs/task"
+              }
+          }
+      },
+      "taskBase": {
+          "type": "object",
+          "title": "TaskBase",
+          "description": "An object inherited by all tasks.",
+          "properties": {
+              "if": {
+                  "type": "string",
+                  "title": "TaskBaseIf",
+                  "description": "A runtime expression, if any, used to determine whether or not the task should be run."
+              },
+              "input": {
+                  "$ref": "#/$defs/input",
+                  "title": "TaskBaseInput",
+                  "description": "Configure the task's input."
+              },
+              "output": {
+                  "$ref": "#/$defs/output",
+                  "title": "TaskBaseOutput",
+                  "description": "Configure the task's output."
+              },
+              "export": {
+                  "$ref": "#/$defs/export",
+                  "title": "TaskBaseExport",
+                  "description": "Export task output to context."
+              },
+              "timeout": {
+                  "title": "TaskTimeout",
+                  "oneOf": [
+                      {
+                          "$ref": "#/$defs/timeout",
+                          "title": "TaskTimeoutDefinition",
+                          "description": "The task's timeout configuration, if any."
+                      },
+                      {
+                          "type": "string",
+                          "title": "TaskTimeoutReference",
+                          "description": "The name of the task's timeout, if any."
+                      }
+                  ]
+              },
+              "then": {
+                  "$ref": "#/$defs/flowDirective",
+                  "title": "TaskBaseThen",
+                  "description": "The flow directive to be performed upon completion of the task."
+              },
+              "metadata": {
+                  "type": "object",
+                  "title": "TaskMetadata",
+                  "description": "Holds additional information about the task.",
+                  "additionalProperties": true
+              }
+          }
+      },
+      "task": {
+          "title": "Task",
+          "description": "A discrete unit of work that contributes to achieving the overall objectives defined by the workflow.",
+          "unevaluatedProperties": false,
+          "oneOf": [
+              {
+                  "$ref": "#/$defs/callTask"
+              },
+              {
+                  "$ref": "#/$defs/doTask"
+              },
+              {
+                  "$ref": "#/$defs/forkTask"
+              },
+              {
+                  "$ref": "#/$defs/emitTask"
+              },
+              {
+                  "$ref": "#/$defs/forTask"
+              },
+              {
+                  "$ref": "#/$defs/listenTask"
+              },
+              {
+                  "$ref": "#/$defs/raiseTask"
+              },
+              {
+                  "$ref": "#/$defs/runTask"
+              },
+              {
+                  "$ref": "#/$defs/setTask"
+              },
+              {
+                  "$ref": "#/$defs/switchTask"
+              },
+              {
+                  "$ref": "#/$defs/tryTask"
+              },
+              {
+                  "$ref": "#/$defs/waitTask"
+              }
+          ]
+      },
+      "callTask": {
+          "title": "CallTask",
+          "description": "Defines the call to perform.",
+          "oneOf": [
+              {
+                  "title": "CallAsyncAPI",
+                  "description": "Defines the AsyncAPI call to perform.",
+                  "type": "object",
+                  "required": [
+                      "call",
+                      "with"
+                  ],
+                  "unevaluatedProperties": false,
+                  "allOf": [
+                      {
+                          "$ref": "#/$defs/taskBase"
+                      },
+                      {
+                          "properties": {
+                              "call": {
+                                  "type": "string",
+                                  "const": "asyncapi"
+                              },
+                              "with": {
+                                  "type": "object",
+                                  "title": "AsyncApiArguments",
+                                  "description": "The Async API call arguments.",
+                                  "properties": {
+                                      "document": {
+                                          "$ref": "#/$defs/externalResource",
+                                          "title": "AsyncAPIDocument",
+                                          "description": "The document that defines the AsyncAPI operation to call."
+                                      },
+                                      "channel": {
+                                          "type": "string",
+                                          "title": "With",
+                                          "description": "The name of the channel on which to perform the operation. Used only in case the referenced document uses AsyncAPI v2.6.0."
+                                      },
+                                      "operation": {
+                                          "type": "string",
+                                          "title": "AsyncAPIOperation",
+                                          "description": "A reference to the AsyncAPI operation to call."
+                                      },
+                                      "server": {
+                                          "$ref": "#/$defs/asyncApiServer",
+                                          "title": "AsyncAPIServer",
+                                          "description": "An object used to configure to the server to call the specified AsyncAPI operation on."
+                                      },
+                                      "protocol": {
+                                          "type": "string",
+                                          "title": "AsyncApiProtocol",
+                                          "description": "The protocol to use to select the target server.",
+                                          "enum": [
+                                              "amqp",
+                                              "amqp1",
+                                              "anypointmq",
+                                              "googlepubsub",
+                                              "http",
+                                              "ibmmq",
+                                              "jms",
+                                              "kafka",
+                                              "mercure",
+                                              "mqtt",
+                                              "mqtt5",
+                                              "nats",
+                                              "pulsar",
+                                              "redis",
+                                              "sns",
+                                              "solace",
+                                              "sqs",
+                                              "stomp",
+                                              "ws"
+                                          ]
+                                      },
+                                      "message": {
+                                          "$ref": "#/$defs/asyncApiOutboundMessage",
+                                          "title": "AsyncApiMessage",
+                                          "description": "An object used to configure the message to publish using the target operation."
+                                      },
+                                      "subscription": {
+                                          "$ref": "#/$defs/asyncApiSubscription",
+                                          "title": "AsyncApiSubscription",
+                                          "description": "An object used to configure the subscription to messages consumed using the target operation."
+                                      },
+                                      "authentication": {
+                                          "$ref": "#/$defs/referenceableAuthenticationPolicy",
+                                          "title": "AsyncAPIAuthentication",
+                                          "description": "The authentication policy, if any, to use when calling the AsyncAPI operation."
+                                      }
+                                  },
+                                  "oneOf": [
+                                      {
+                                          "required": [
+                                              "document",
+                                              "operation",
+                                              "message"
+                                          ]
+                                      },
+                                      {
+                                          "required": [
+                                              "document",
+                                              "operation",
+                                              "subscription"
+                                          ]
+                                      },
+                                      {
+                                          "required": [
+                                              "document",
+                                              "channel",
+                                              "message"
+                                          ]
+                                      },
+                                      {
+                                          "required": [
+                                              "document",
+                                              "channel",
+                                              "subscription"
+                                          ]
+                                      }
+                                  ],
+                                  "unevaluatedProperties": false
+                              }
+                          }
+                      }
+                  ]
+              },
+              {
+                  "title": "CallGRPC",
+                  "description": "Defines the GRPC call to perform.",
+                  "type": "object",
+                  "unevaluatedProperties": false,
+                  "required": [
+                      "call",
+                      "with"
+                  ],
+                  "allOf": [
+                      {
+                          "$ref": "#/$defs/taskBase"
+                      },
+                      {
+                          "properties": {
+                              "call": {
+                                  "type": "string",
+                                  "const": "grpc"
+                              },
+                              "with": {
+                                  "type": "object",
+                                  "title": "GRPCArguments",
+                                  "description": "The GRPC call arguments.",
+                                  "properties": {
+                                      "proto": {
+                                          "$ref": "#/$defs/externalResource",
+                                          "title": "WithGRPCProto",
+                                          "description": "The proto resource that describes the GRPC service to call."
+                                      },
+                                      "service": {
+                                          "type": "object",
+                                          "title": "WithGRPCService",
+                                          "unevaluatedProperties": false,
+                                          "properties": {
+                                              "name": {
+                                                  "type": "string",
+                                                  "title": "WithGRPCServiceName",
+                                                  "description": "The name of the GRPC service to call."
+                                              },
+                                              "host": {
+                                                  "type": "string",
+                                                  "title": "WithGRPCServiceHost",
+                                                  "description": "The hostname of the GRPC service to call.",
+                                                  "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$"
+                                              },
+                                              "port": {
+                                                  "type": "integer",
+                                                  "title": "WithGRPCServicePost",
+                                                  "description": "The port number of the GRPC service to call.",
+                                                  "minimum": 0,
+                                                  "maximum": 65535
+                                              },
+                                              "authentication": {
+                                                  "$ref": "#/$defs/referenceableAuthenticationPolicy",
+                                                  "title": "WithGRPCServiceAuthentication",
+                                                  "description": "The endpoint's authentication policy, if any."
+                                              }
+                                          },
+                                          "required": [
+                                              "name",
+                                              "host"
+                                          ]
+                                      },
+                                      "method": {
+                                          "type": "string",
+                                          "title": "WithGRPCMethod",
+                                          "description": "The name of the method to call on the defined GRPC service."
+                                      },
+                                      "arguments": {
+                                          "type": "object",
+                                          "title": "WithGRPCArguments",
+                                          "description": "The arguments, if any, to call the method with.",
+                                          "additionalProperties": true
+                                      }
+                                  },
+                                  "required": [
+                                      "proto",
+                                      "service",
+                                      "method"
+                                  ],
+                                  "unevaluatedProperties": false
+                              }
+                          }
+                      }
+                  ]
+              },
+              {
+                  "title": "CallHTTP",
+                  "description": "Defines the HTTP call to perform.",
+                  "type": "object",
+                  "unevaluatedProperties": false,
+                  "required": [
+                      "call",
+                      "with"
+                  ],
+                  "allOf": [
+                      {
+                          "$ref": "#/$defs/taskBase"
+                      },
+                      {
+                          "properties": {
+                              "call": {
+                                  "type": "string",
+                                  "const": "http"
+                              },
+                              "with": {
+                                  "type": "object",
+                                  "title": "HTTPArguments",
+                                  "description": "The HTTP call arguments.",
+                                  "properties": {
+                                      "method": {
+                                          "type": "string",
+                                          "title": "HTTPMethod",
+                                          "description": "The HTTP method of the HTTP request to perform."
+                                      },
+                                      "endpoint": {
+                                          "title": "HTTPEndpoint",
+                                          "description": "The HTTP endpoint to send the request to.",
+                                          "$ref": "#/$defs/endpoint"
+                                      },
+                                      "headers": {
+                                          "oneOf": [
+                                              {
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                      "type": "string"
+                                                  }
+                                              },
+                                              {
+                                                  "$ref": "#/$defs/runtimeExpression"
+                                              }
+                                          ],
+                                          "title": "HTTPHeaders",
+                                          "description": "A name/value mapping of the headers, if any, of the HTTP request to perform."
+                                      },
+                                      "body": {
+                                          "title": "HTTPBody",
+                                          "description": "The body, if any, of the HTTP request to perform."
+                                      },
+                                      "query": {
+                                          "oneOf": [
+                                              {
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                      "type": "string"
+                                                  }
+                                              },
+                                              {
+                                                  "$ref": "#/$defs/runtimeExpression"
+                                              }
+                                          ],
+                                          "title": "HTTPQuery",
+                                          "description": "A name/value mapping of the query parameters, if any, of the HTTP request to perform.",
+                                          "additionalProperties": true
+                                      },
+                                      "output": {
+                                          "type": "string",
+                                          "title": "HTTPOutput",
+                                          "description": "The http call output format. Defaults to 'content'.",
+                                          "enum": [
+                                              "raw",
+                                              "content",
+                                              "response"
+                                          ]
+                                      },
+                                      "redirect": {
+                                          "type": "boolean",
+                                          "title": "HttpRedirect",
+                                          "description": "Specifies whether redirection status codes (`300–399`) should be treated as errors."
+                                      }
+                                  },
+                                  "required": [
+                                      "method",
+                                      "endpoint"
+                                  ],
+                                  "unevaluatedProperties": false
+                              }
+                          }
+                      }
+                  ]
+              },
+              {
+                  "title": "CallOpenAPI",
+                  "description": "Defines the OpenAPI call to perform.",
+                  "type": "object",
+                  "unevaluatedProperties": false,
+                  "required": [
+                      "call",
+                      "with"
+                  ],
+                  "allOf": [
+                      {
+                          "$ref": "#/$defs/taskBase"
+                      },
+                      {
+                          "properties": {
+                              "call": {
+                                  "type": "string",
+                                  "const": "openapi"
+                              },
+                              "with": {
+                                  "type": "object",
+                                  "title": "OpenAPIArguments",
+                                  "description": "The OpenAPI call arguments.",
+                                  "properties": {
+                                      "document": {
+                                          "$ref": "#/$defs/externalResource",
+                                          "title": "WithOpenAPIDocument",
+                                          "description": "The document that defines the OpenAPI operation to call."
+                                      },
+                                      "operationId": {
+                                          "type": "string",
+                                          "title": "WithOpenAPIOperation",
+                                          "description": "The id of the OpenAPI operation to call."
+                                      },
+                                      "parameters": {
+                                          "type": "object",
+                                          "title": "WithOpenAPIParameters",
+                                          "description": "A name/value mapping of the parameters of the OpenAPI operation to call.",
+                                          "additionalProperties": true
+                                      },
+                                      "authentication": {
+                                          "$ref": "#/$defs/referenceableAuthenticationPolicy",
+                                          "title": "WithOpenAPIAuthentication",
+                                          "description": "The authentication policy, if any, to use when calling the OpenAPI operation."
+                                      },
+                                      "output": {
+                                          "type": "string",
+                                          "enum": [
+                                              "raw",
+                                              "content",
+                                              "response"
+                                          ],
+                                          "title": "WithOpenAPIOutput",
+                                          "description": "The http call output format. Defaults to 'content'."
+                                      },
+                                      "redirect": {
+                                          "type": "boolean",
+                                          "title": "HttpRedirect",
+                                          "description": "Specifies whether redirection status codes (`300–399`) should be treated as errors."
+                                      }
+                                  },
+                                  "required": [
+                                      "document",
+                                      "operationId"
+                                  ],
+                                  "unevaluatedProperties": false
+                              }
+                          }
+                      }
+                  ]
+              },
+              {
+                  "title": "CallFunction",
+                  "description": "Defines the function call to perform.",
+                  "type": "object",
+                  "unevaluatedProperties": false,
+                  "required": [
+                      "call"
+                  ],
+                  "allOf": [
+                      {
+                          "$ref": "#/$defs/taskBase"
+                      },
+                      {
+                          "properties": {
+                              "call": {
+                                  "type": "string",
+                                  "not": {
+                                      "enum": [
+                                          "asyncapi",
+                                          "grpc",
+                                          "http",
+                                          "openapi"
+                                      ]
+                                  },
+                                  "description": "The name of the function to call."
+                              },
+                              "with": {
+                                  "type": "object",
+                                  "title": "FunctionArguments",
+                                  "description": "A name/value mapping of the parameters, if any, to call the function with.",
+                                  "additionalProperties": true
+                              }
+                          }
+                      }
+                  ]
+              }
+          ]
+      },
+      "forkTask": {
+          "type": "object",
+          "title": "ForkTask",
+          "description": "Allows workflows to execute multiple tasks concurrently and optionally race them against each other, with a single possible winner, which sets the task's output.",
+          "unevaluatedProperties": false,
+          "required": [
+              "fork"
+          ],
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "fork": {
+                          "type": "object",
+                          "title": "ForkTaskConfiguration",
+                          "description": "The configuration of the branches to perform concurrently.",
+                          "unevaluatedProperties": false,
+                          "required": [
+                              "branches"
+                          ],
+                          "properties": {
+                              "branches": {
+                                  "$ref": "#/$defs/taskList",
+                                  "title": "ForkBranches"
+                              },
+                              "compete": {
+                                  "type": "boolean",
+                                  "title": "ForkCompete",
+                                  "description": "Indicates whether or not the concurrent tasks are racing against each other, with a single possible winner, which sets the composite task's output.",
+                                  "default": false
+                              }
+                          }
+                      }
+                  }
+              }
+          ]
+      },
+      "doTask": {
+          "type": "object",
+          "title": "DoTask",
+          "description": "Allows to execute a list of tasks in sequence.",
+          "unevaluatedProperties": false,
+          "required": [
+              "do"
+          ],
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "do": {
+                          "$ref": "#/$defs/taskList",
+                          "title": "DoTaskConfiguration",
+                          "description": "The configuration of the tasks to perform sequentially."
+                      }
+                  }
+              }
+          ]
+      },
+      "emitTask": {
+          "type": "object",
+          "title": "EmitTask",
+          "description": "Allows workflows to publish events to event brokers or messaging systems, facilitating communication and coordination between different components and services.",
+          "required": [
+              "emit"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "emit": {
+                          "type": "object",
+                          "title": "EmitTaskConfiguration",
+                          "description": "The configuration of an event's emission.",
+                          "unevaluatedProperties": false,
+                          "properties": {
+                              "event": {
+                                  "type": "object",
+                                  "title": "EmitEventDefinition",
+                                  "description": "The definition of the event to emit.",
+                                  "properties": {
+                                      "with": {
+                                          "$ref": "#/$defs/eventProperties",
+                                          "title": "EmitEventWith",
+                                          "description": "Defines the properties of event to emit.",
+                                          "required": [
+                                              "source",
+                                              "type"
+                                          ]
+                                      }
+                                  },
+                                  "additionalProperties": true
+                              }
+                          },
+                          "required": [
+                              "event"
+                          ]
+                      }
+                  }
+              }
+          ]
+      },
+      "forTask": {
+          "type": "object",
+          "title": "ForTask",
+          "description": "Allows workflows to iterate over a collection of items, executing a defined set of subtasks for each item in the collection. This task type is instrumental in handling scenarios such as batch processing, data transformation, and repetitive operations across datasets.",
+          "required": [
+              "for",
+              "do"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "for": {
+                          "type": "object",
+                          "title": "ForTaskConfiguration",
+                          "description": "The definition of the loop that iterates over a range of values.",
+                          "unevaluatedProperties": false,
+                          "properties": {
+                              "each": {
+                                  "type": "string",
+                                  "title": "ForEach",
+                                  "description": "The name of the variable used to store the current item being enumerated.",
+                                  "default": "item"
+                              },
+                              "in": {
+                                  "type": "string",
+                                  "title": "ForIn",
+                                  "description": "A runtime expression used to get the collection to enumerate."
+                              },
+                              "at": {
+                                  "type": "string",
+                                  "title": "ForAt",
+                                  "description": "The name of the variable used to store the index of the current item being enumerated.",
+                                  "default": "index"
+                              }
+                          },
+                          "required": [
+                              "in"
+                          ]
+                      },
+                      "while": {
+                          "type": "string",
+                          "title": "While",
+                          "description": "A runtime expression that represents the condition, if any, that must be met for the iteration to continue."
+                      },
+                      "do": {
+                          "$ref": "#/$defs/taskList",
+                          "title": "ForTaskDo"
+                      }
+                  }
+              }
+          ]
+      },
+      "listenTask": {
+          "type": "object",
+          "title": "ListenTask",
+          "description": "Provides a mechanism for workflows to await and react to external events, enabling event-driven behavior within workflow systems.",
+          "required": [
+              "listen"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "listen": {
+                          "type": "object",
+                          "title": "ListenTaskConfiguration",
+                          "description": "The configuration of the listener to use.",
+                          "unevaluatedProperties": false,
+                          "properties": {
+                              "to": {
+                                  "$ref": "#/$defs/eventConsumptionStrategy",
+                                  "title": "ListenTo",
+                                  "description": "Defines the event(s) to listen to."
+                              },
+                              "read": {
+                                  "type": "string",
+                                  "enum": [
+                                      "data",
+                                      "envelope",
+                                      "raw"
+                                  ],
+                                  "default": "data",
+                                  "title": "ListenAndReadAs",
+                                  "description": "Specifies how events are read during the listen operation."
+                              }
+                          },
+                          "required": [
+                              "to"
+                          ]
+                      },
+                      "foreach": {
+                          "$ref": "#/$defs/subscriptionIterator",
+                          "title": "ListenIterator",
+                          "description": "Configures the iterator, if any, for processing consumed event(s)."
+                      }
+                  }
+              }
+          ]
+      },
+      "raiseTask": {
+          "type": "object",
+          "title": "RaiseTask",
+          "description": "Intentionally triggers and propagates errors.",
+          "required": [
+              "raise"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "raise": {
+                          "type": "object",
+                          "title": "RaiseTaskConfiguration",
+                          "description": "The definition of the error to raise.",
+                          "unevaluatedProperties": false,
+                          "properties": {
+                              "error": {
+                                  "title": "RaiseTaskError",
+                                  "oneOf": [
+                                      {
+                                          "$ref": "#/$defs/error",
+                                          "title": "RaiseErrorDefinition",
+                                          "description": "Defines the error to raise."
+                                      },
+                                      {
+                                          "type": "string",
+                                          "title": "RaiseErrorReference",
+                                          "description": "The name of the error to raise"
+                                      }
+                                  ]
+                              }
+                          },
+                          "required": [
+                              "error"
+                          ]
+                      }
+                  }
+              }
+          ]
+      },
+      "runTask": {
+          "type": "object",
+          "title": "RunTask",
+          "description": "Provides the capability to execute external containers, shell commands, scripts, or workflows.",
+          "required": [
+              "run"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "run": {
+                          "type": "object",
+                          "title": "RunTaskConfiguration",
+                          "description": "The configuration of the process to execute.",
+                          "unevaluatedProperties": false,
+                          "properties": {
+                              "await": {
+                                  "type": "boolean",
+                                  "default": true,
+                                  "title": "AwaitProcessCompletion",
+                                  "description": "Whether to await the process completion before continuing."
+                              },
+                              "return": {
+                                  "type": "string",
+                                  "title": "ProcessReturnType",
+                                  "description": "Configures the output of the process.",
+                                  "enum": [
+                                      "stdout",
+                                      "stderr",
+                                      "code",
+                                      "all",
+                                      "none"
+                                  ],
+                                  "default": "stdout"
+                              }
+                          },
+                          "oneOf": [
+                              {
+                                  "title": "RunContainer",
+                                  "description": "Enables the execution of external processes encapsulated within a containerized environment.",
+                                  "properties": {
+                                      "container": {
+                                          "type": "object",
+                                          "title": "Container",
+                                          "description": "The configuration of the container to run.",
+                                          "unevaluatedProperties": false,
+                                          "properties": {
+                                              "image": {
+                                                  "type": "string",
+                                                  "title": "ContainerImage",
+                                                  "description": "The name of the container image to run."
+                                              },
+                                              "name": {
+                                                  "type": "string",
+                                                  "title": "ContainerName",
+                                                  "description": "A runtime expression, if any, used to give specific name to the container."
+                                              },
+                                              "command": {
+                                                  "type": "string",
+                                                  "title": "ContainerCommand",
+                                                  "description": "The command, if any, to execute on the container."
+                                              },
+                                              "ports": {
+                                                  "type": "object",
+                                                  "title": "ContainerPorts",
+                                                  "description": "The container's port mappings, if any."
+                                              },
+                                              "volumes": {
+                                                  "type": "object",
+                                                  "title": "ContainerVolumes",
+                                                  "description": "The container's volume mappings, if any."
+                                              },
+                                              "environment": {
+                                                  "type": "object",
+                                                  "title": "ContainerEnvironment",
+                                                  "description": "A key/value mapping of the environment variables, if any, to use when running the configured process."
+                                              },
+                                              "lifetime": {
+                                                  "$ref": "#/$defs/containerLifetime",
+                                                  "title": "ContainerLifetime",
+                                                  "description": "An object, if any, used to configure the container's lifetime"
+                                              }
+                                          },
+                                          "required": [
+                                              "image"
+                                          ]
+                                      }
+                                  },
+                                  "required": [
+                                      "container"
+                                  ]
+                              },
+                              {
+                                  "title": "RunScript",
+                                  "description": "Enables the execution of custom scripts or code within a workflow, empowering workflows to perform specialized logic, data processing, or integration tasks by executing user-defined scripts written in various programming languages.",
+                                  "properties": {
+                                      "script": {
+                                          "type": "object",
+                                          "title": "Script",
+                                          "description": "The configuration of the script to run.",
+                                          "unevaluatedProperties": false,
+                                          "properties": {
+                                              "language": {
+                                                  "type": "string",
+                                                  "title": "ScriptLanguage",
+                                                  "description": "The language of the script to run."
+                                              },
+                                              "arguments": {
+                                                  "type": "object",
+                                                  "title": "ScriptArguments",
+                                                  "description": "A key/value mapping of the arguments, if any, to use when running the configured script.",
+                                                  "additionalProperties": true
+                                              },
+                                              "environment": {
+                                                  "type": "object",
+                                                  "title": "ScriptEnvironment",
+                                                  "description": "A key/value mapping of the environment variables, if any, to use when running the configured script process.",
+                                                  "additionalProperties": true
+                                              }
+                                          },
+                                          "oneOf": [
+                                              {
+                                                  "title": "InlineScript",
+                                                  "type": "object",
+                                                  "description": "The script's code.",
+                                                  "properties": {
+                                                      "code": {
+                                                          "type": "string",
+                                                          "title": "InlineScriptCode"
+                                                      }
+                                                  },
+                                                  "required": [
+                                                      "code"
+                                                  ]
+                                              },
+                                              {
+                                                  "title": "ExternalScript",
+                                                  "type": "object",
+                                                  "description": "The script's resource.",
+                                                  "properties": {
+                                                      "source": {
+                                                          "$ref": "#/$defs/externalResource",
+                                                          "title": "ExternalScriptResource"
+                                                      }
+                                                  },
+                                                  "required": [
+                                                      "source"
+                                                  ]
+                                              }
+                                          ],
+                                          "required": [
+                                              "language"
+                                          ]
+                                      }
+                                  },
+                                  "required": [
+                                      "script"
+                                  ]
+                              },
+                              {
+                                  "title": "RunShell",
+                                  "description": "Enables the execution of shell commands within a workflow, enabling workflows to interact with the underlying operating system and perform system-level operations, such as file manipulation, environment configuration, or system administration tasks.",
+                                  "properties": {
+                                      "shell": {
+                                          "type": "object",
+                                          "title": "Shell",
+                                          "description": "The configuration of the shell command to run.",
+                                          "unevaluatedProperties": false,
+                                          "properties": {
+                                              "command": {
+                                                  "type": "string",
+                                                  "title": "ShellCommand",
+                                                  "description": "The shell command to run."
+                                              },
+                                              "arguments": {
+                                                  "type": "object",
+                                                  "title": "ShellArguments",
+                                                  "description": "A list of the arguments of the shell command to run.",
+                                                  "additionalProperties": true
+                                              },
+                                              "environment": {
+                                                  "type": "object",
+                                                  "title": "ShellEnvironment",
+                                                  "description": "A key/value mapping of the environment variables, if any, to use when running the configured process.",
+                                                  "additionalProperties": true
+                                              }
+                                          },
+                                          "required": [
+                                              "command"
+                                          ]
+                                      }
+                                  },
+                                  "required": [
+                                      "shell"
+                                  ]
+                              },
+                              {
+                                  "title": "RunWorkflow",
+                                  "description": "Enables the invocation and execution of nested workflows within a parent workflow, facilitating modularization, reusability, and abstraction of complex logic or business processes by encapsulating them into standalone workflow units.",
+                                  "properties": {
+                                      "workflow": {
+                                          "type": "object",
+                                          "title": "SubflowConfiguration",
+                                          "description": "The configuration of the workflow to run.",
+                                          "unevaluatedProperties": false,
+                                          "properties": {
+                                              "namespace": {
+                                                  "type": "string",
+                                                  "title": "SubflowNamespace",
+                                                  "description": "The namespace the workflow to run belongs to."
+                                              },
+                                              "name": {
+                                                  "type": "string",
+                                                  "title": "SubflowName",
+                                                  "description": "The name of the workflow to run."
+                                              },
+                                              "version": {
+                                                  "type": "string",
+                                                  "default": "latest",
+                                                  "title": "SubflowVersion",
+                                                  "description": "The version of the workflow to run. Defaults to latest."
+                                              },
+                                              "input": {
+                                                  "type": "object",
+                                                  "title": "SubflowInput",
+                                                  "description": "The data, if any, to pass as input to the workflow to execute. The value should be validated against the target workflow's input schema, if specified.",
+                                                  "additionalProperties": true
+                                              }
+                                          },
+                                          "required": [
+                                              "namespace",
+                                              "name",
+                                              "version"
+                                          ]
+                                      }
+                                  },
+                                  "required": [
+                                      "workflow"
+                                  ]
+                              }
+                          ]
+                      }
+                  }
+              }
+          ]
+      },
+      "setTask": {
+          "type": "object",
+          "title": "SetTask",
+          "description": "A task used to set data.",
+          "required": [
+              "set"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "set": {
+                          "oneOf": [
+                              {
+                                  "type": "object",
+                                  "minProperties": 1,
+                                  "additionalProperties": true
+                              },
+                              {
+                                  "type": "string"
+                              }
+                          ],
+                          "title": "SetTaskConfiguration",
+                          "description": "The data to set."
+                      }
+                  }
+              }
+          ]
+      },
+      "switchTask": {
+          "type": "object",
+          "title": "SwitchTask",
+          "description": "Enables conditional branching within workflows, allowing them to dynamically select different paths based on specified conditions or criteria.",
+          "required": [
+              "switch"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "switch": {
+                          "type": "array",
+                          "title": "SwitchTaskConfiguration",
+                          "description": "The definition of the switch to use.",
+                          "minItems": 1,
+                          "items": {
+                              "type": "object",
+                              "title": "SwitchItem",
+                              "minProperties": 1,
+                              "maxProperties": 1,
+                              "additionalProperties": {
+                                  "type": "object",
+                                  "title": "SwitchCase",
+                                  "description": "The definition of a case within a switch task, defining a condition and corresponding tasks to execute if the condition is met.",
+                                  "unevaluatedProperties": false,
+                                  "required": [
+                                      "then"
+                                  ],
+                                  "properties": {
+                                      "when": {
+                                          "type": "string",
+                                          "title": "SwitchCaseCondition",
+                                          "description": "A runtime expression used to determine whether or not the case matches."
+                                      },
+                                      "then": {
+                                          "$ref": "#/$defs/flowDirective",
+                                          "title": "SwitchCaseOutcome",
+                                          "description": "The flow directive to execute when the case matches."
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
+          ]
+      },
+      "tryTask": {
+          "type": "object",
+          "title": "TryTask",
+          "description": "Serves as a mechanism within workflows to handle errors gracefully, potentially retrying failed tasks before proceeding with alternate ones.",
+          "required": [
+              "try",
+              "catch"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "try": {
+                          "$ref": "#/$defs/taskList",
+                          "title": "TryTaskConfiguration",
+                          "description": "The task(s) to perform."
+                      },
+                      "catch": {
+                          "type": "object",
+                          "title": "TryTaskCatch",
+                          "description": "The object used to define the errors to catch.",
+                          "unevaluatedProperties": false,
+                          "properties": {
+                              "errors": {
+                                  "type": "object",
+                                  "title": "CatchErrors",
+                                  "properties": {
+                                      "with": {
+                                          "$ref": "#/$defs/errorFilter"
+                                      }
+                                  },
+                                  "description": "static error filter"
+                              },
+                              "as": {
+                                  "type": "string",
+                                  "title": "CatchAs",
+                                  "description": "The name of the runtime expression variable to save the error as. Defaults to 'error'."
+                              },
+                              "when": {
+                                  "type": "string",
+                                  "title": "CatchWhen",
+                                  "description": "A runtime expression used to determine whether to catch the filtered error."
+                              },
+                              "exceptWhen": {
+                                  "type": "string",
+                                  "title": "CatchExceptWhen",
+                                  "description": "A runtime expression used to determine whether not to catch the filtered error."
+                              },
+                              "retry": {
+                                  "oneOf": [
+                                      {
+                                          "$ref": "#/$defs/retryPolicy",
+                                          "title": "RetryPolicyDefinition",
+                                          "description": "The retry policy to use, if any, when catching errors."
+                                      },
+                                      {
+                                          "type": "string",
+                                          "title": "RetryPolicyReference",
+                                          "description": "The name of the retry policy to use, if any, when catching errors."
+                                      }
+                                  ]
+                              },
+                              "do": {
+                                  "$ref": "#/$defs/taskList",
+                                  "title": "TryTaskCatchDo",
+                                  "description": "The definition of the task(s) to run when catching an error."
+                              }
+                          }
+                      }
+                  }
+              }
+          ]
+      },
+      "waitTask": {
+          "type": "object",
+          "title": "WaitTask",
+          "description": "Allows workflows to pause or delay their execution for a specified period of time.",
+          "required": [
+              "wait"
+          ],
+          "unevaluatedProperties": false,
+          "allOf": [
+              {
+                  "$ref": "#/$defs/taskBase"
+              },
+              {
+                  "properties": {
+                      "wait": {
+                          "$ref": "#/$defs/duration",
+                          "title": "WaitTaskConfiguration",
+                          "description": "The amount of time to wait."
+                      }
+                  }
+              }
+          ]
+      },
+      "flowDirective": {
+          "title": "FlowDirective",
+          "description": "Represents different transition options for a workflow.",
+          "anyOf": [
+              {
+                  "title": "FlowDirectiveEnum",
+                  "type": "string",
+                  "enum": [
+                      "continue",
+                      "exit",
+                      "end"
+                  ],
+                  "default": "continue"
+              },
+              {
+                  "type": "string"
+              }
+          ]
+      },
+      "referenceableAuthenticationPolicy": {
+          "type": "object",
+          "title": "ReferenceableAuthenticationPolicy",
+          "description": "Represents a referenceable authentication policy.",
+          "unevaluatedProperties": false,
+          "oneOf": [
+              {
+                  "title": "AuthenticationPolicyReference",
+                  "description": "The reference of the authentication policy to use.",
+                  "properties": {
+                      "use": {
+                          "type": "string",
+                          "minLength": 1,
+                          "title": "ReferenceableAuthenticationPolicyName",
+                          "description": "The name of the authentication policy to use."
+                      }
+                  },
+                  "required": [
+                      "use"
+                  ]
+              },
+              {
+                  "$ref": "#/$defs/authenticationPolicy"
+              }
+          ]
+      },
+      "secretBasedAuthenticationPolicy": {
+          "type": "object",
+          "title": "SecretBasedAuthenticationPolicy",
+          "description": "Represents an authentication policy based on secrets.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "use": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "SecretBasedAuthenticationPolicyName",
+                  "description": "The name of the authentication policy to use."
+              }
+          },
+          "required": [
+              "use"
+          ]
+      },
+      "authenticationPolicy": {
+          "type": "object",
+          "title": "AuthenticationPolicy",
+          "description": "Defines an authentication policy.",
+          "oneOf": [
+              {
+                  "title": "BasicAuthenticationPolicy",
+                  "description": "Use basic authentication.",
+                  "properties": {
+                      "basic": {
+                          "type": "object",
+                          "title": "BasicAuthenticationPolicyConfiguration",
+                          "description": "The configuration of the basic authentication policy.",
+                          "unevaluatedProperties": false,
+                          "oneOf": [
+                              {
+                                  "title": "BasicAuthenticationProperties",
+                                  "description": "Inline configuration of the basic authentication policy.",
+                                  "properties": {
+                                      "username": {
+                                          "type": "string",
+                                          "description": "The username to use."
+                                      },
+                                      "password": {
+                                          "type": "string",
+                                          "description": "The password to use."
+                                      }
+                                  },
+                                  "required": [
+                                      "username",
+                                      "password"
+                                  ]
+                              },
+                              {
+                                  "$ref": "#/$defs/secretBasedAuthenticationPolicy",
+                                  "title": "BasicAuthenticationPolicySecret",
+                                  "description": "Secret based configuration of the basic authentication policy."
+                              }
+                          ]
+                      }
+                  },
+                  "required": [
+                      "basic"
+                  ]
+              },
+              {
+                  "title": "BearerAuthenticationPolicy",
+                  "description": "Use bearer authentication.",
+                  "properties": {
+                      "bearer": {
+                          "type": "object",
+                          "title": "BearerAuthenticationPolicyConfiguration",
+                          "description": "The configuration of the bearer authentication policy.",
+                          "unevaluatedProperties": false,
+                          "oneOf": [
+                              {
+                                  "title": "BearerAuthenticationProperties",
+                                  "description": "Inline configuration of the bearer authentication policy.",
+                                  "properties": {
+                                      "token": {
+                                          "type": "string",
+                                          "description": "The bearer token to use."
+                                      }
+                                  },
+                                  "required": [
+                                      "token"
+                                  ]
+                              },
+                              {
+                                  "$ref": "#/$defs/secretBasedAuthenticationPolicy",
+                                  "title": "BearerAuthenticationPolicySecret",
+                                  "description": "Secret based configuration of the bearer authentication policy."
+                              }
+                          ]
+                      }
+                  },
+                  "required": [
+                      "bearer"
+                  ]
+              },
+              {
+                  "title": "DigestAuthenticationPolicy",
+                  "description": "Use digest authentication.",
+                  "properties": {
+                      "digest": {
+                          "type": "object",
+                          "title": "DigestAuthenticationPolicyConfiguration",
+                          "description": "The configuration of the digest authentication policy.",
+                          "unevaluatedProperties": false,
+                          "oneOf": [
+                              {
+                                  "title": "DigestAuthenticationProperties",
+                                  "description": "Inline configuration of the digest authentication policy.",
+                                  "properties": {
+                                      "username": {
+                                          "type": "string",
+                                          "description": "The username to use."
+                                      },
+                                      "password": {
+                                          "type": "string",
+                                          "description": "The password to use."
+                                      }
+                                  },
+                                  "required": [
+                                      "username",
+                                      "password"
+                                  ]
+                              },
+                              {
+                                  "$ref": "#/$defs/secretBasedAuthenticationPolicy",
+                                  "title": "DigestAuthenticationPolicySecret",
+                                  "description": "Secret based configuration of the digest authentication policy."
+                              }
+                          ]
+                      }
+                  },
+                  "required": [
+                      "digest"
+                  ]
+              },
+              {
+                  "title": "OAuth2AuthenticationPolicy",
+                  "description": "Use OAuth2 authentication.",
+                  "properties": {
+                      "oauth2": {
+                          "type": "object",
+                          "title": "OAuth2AuthenticationPolicyConfiguration",
+                          "description": "The configuration of the OAuth2 authentication policy.",
+                          "unevaluatedProperties": false,
+                          "oneOf": [
+                              {
+                                  "type": "object",
+                                  "title": "OAuth2ConnectAuthenticationProperties",
+                                  "description": "The inline configuration of the OAuth2 authentication policy.",
+                                  "unevaluatedProperties": false,
+                                  "allOf": [
+                                      {
+                                          "$ref": "#/$defs/oauth2AuthenticationProperties"
+                                      },
+                                      {
+                                          "type": "object",
+                                          "properties": {
+                                              "endpoints": {
+                                                  "type": "object",
+                                                  "title": "OAuth2AuthenticationPropertiesEndpoints",
+                                                  "description": "The endpoint configurations for OAuth2.",
+                                                  "properties": {
+                                                      "token": {
+                                                          "type": "string",
+                                                          "format": "uri-template",
+                                                          "default": "/oauth2/token",
+                                                          "title": "OAuth2TokenEndpoint",
+                                                          "description": "The relative path to the token endpoint. Defaults to `/oauth2/token`."
+                                                      },
+                                                      "revocation": {
+                                                          "type": "string",
+                                                          "format": "uri-template",
+                                                          "default": "/oauth2/revoke",
+                                                          "title": "OAuth2RevocationEndpoint",
+                                                          "description": "The relative path to the revocation endpoint. Defaults to `/oauth2/revoke`."
+                                                      },
+                                                      "introspection": {
+                                                          "type": "string",
+                                                          "format": "uri-template",
+                                                          "default": "/oauth2/introspect",
+                                                          "title": "OAuth2IntrospectionEndpoint",
+                                                          "description": "The relative path to the introspection endpoint. Defaults to `/oauth2/introspect`."
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  ]
+                              },
+                              {
+                                  "$ref": "#/$defs/secretBasedAuthenticationPolicy",
+                                  "title": "OAuth2AuthenticationPolicySecret",
+                                  "description": "Secret based configuration of the OAuth2 authentication policy."
+                              }
+                          ]
+                      }
+                  },
+                  "required": [
+                      "oauth2"
+                  ]
+              },
+              {
+                  "title": "OpenIdConnectAuthenticationPolicy",
+                  "description": "Use OpenIdConnect authentication.",
+                  "properties": {
+                      "oidc": {
+                          "type": "object",
+                          "title": "OpenIdConnectAuthenticationPolicyConfiguration",
+                          "description": "The configuration of the OpenIdConnect authentication policy.",
+                          "unevaluatedProperties": false,
+                          "oneOf": [
+                              {
+                                  "$ref": "#/$defs/oauth2AuthenticationProperties",
+                                  "title": "OpenIdConnectAuthenticationProperties",
+                                  "description": "The inline configuration of the OpenIdConnect authentication policy.",
+                                  "unevaluatedProperties": false
+                              },
+                              {
+                                  "$ref": "#/$defs/secretBasedAuthenticationPolicy",
+                                  "title": "OpenIdConnectAuthenticationPolicySecret",
+                                  "description": "Secret based configuration of the OpenIdConnect authentication policy."
+                              }
+                          ]
+                      }
+                  },
+                  "required": [
+                      "oidc"
+                  ]
+              }
+          ]
+      },
+      "oauth2AuthenticationProperties": {
+          "type": "object",
+          "title": "OAuth2AutenthicationData",
+          "description": "Inline configuration of the OAuth2 authentication policy.",
+          "properties": {
+              "authority": {
+                  "$ref": "#/$defs/uriTemplate",
+                  "title": "OAuth2AutenthicationDataAuthority",
+                  "description": "The URI that references the OAuth2 authority to use."
+              },
+              "grant": {
+                  "type": "string",
+                  "enum": [
+                      "authorization_code",
+                      "client_credentials",
+                      "password",
+                      "refresh_token",
+                      "urn:ietf:params:oauth:grant-type:token-exchange"
+                  ],
+                  "title": "OAuth2AutenthicationDataGrant",
+                  "description": "The grant type to use."
+              },
+              "client": {
+                  "type": "object",
+                  "title": "OAuth2AutenthicationDataClient",
+                  "description": "The definition of an OAuth2 client.",
+                  "unevaluatedProperties": false,
+                  "properties": {
+                      "id": {
+                          "type": "string",
+                          "title": "ClientId",
+                          "description": "The client id to use."
+                      },
+                      "secret": {
+                          "type": "string",
+                          "title": "ClientSecret",
+                          "description": "The client secret to use, if any."
+                      },
+                      "assertion": {
+                          "type": "string",
+                          "title": "ClientAssertion",
+                          "description": "A JWT containing a signed assertion with your application credentials."
+                      },
+                      "authentication": {
+                          "type": "string",
+                          "enum": [
+                              "client_secret_basic",
+                              "client_secret_post",
+                              "client_secret_jwt",
+                              "private_key_jwt",
+                              "none"
+                          ],
+                          "default": "client_secret_post",
+                          "title": "ClientAuthentication",
+                          "description": "The authentication method to use to authenticate the client."
+                      }
+                  }
+              },
+              "request": {
+                  "type": "object",
+                  "title": "OAuth2TokenRequest",
+                  "description": "The configuration of an OAuth2 token request",
+                  "properties": {
+                      "encoding": {
+                          "type": "string",
+                          "enum": [
+                              "application/x-www-form-urlencoded",
+                              "application/json"
+                          ],
+                          "default": "application/x-www-form-urlencoded",
+                          "title": "Oauth2TokenRequestEncoding"
+                      }
+                  }
+              },
+              "issuers": {
+                  "type": "array",
+                  "title": "OAuth2Issuers",
+                  "description": "A list that contains that contains valid issuers that will be used to check against the issuer of generated tokens.",
+                  "items": {
+                      "type": "string"
+                  }
+              },
+              "scopes": {
+                  "type": "array",
+                  "title": "OAuth2AutenthicationDataScopes",
+                  "description": "The scopes, if any, to request the token for.",
+                  "items": {
+                      "type": "string"
+                  }
+              },
+              "audiences": {
+                  "type": "array",
+                  "title": "OAuth2AutenthicationDataAudiences",
+                  "description": "The audiences, if any, to request the token for.",
+                  "items": {
+                      "type": "string"
+                  }
+              },
+              "username": {
+                  "type": "string",
+                  "title": "OAuth2AutenthicationDataUsername",
+                  "description": "The username to use. Used only if the grant type is Password."
+              },
+              "password": {
+                  "type": "string",
+                  "title": "OAuth2AutenthicationDataPassword",
+                  "description": "The password to use. Used only if the grant type is Password."
+              },
+              "subject": {
+                  "$ref": "#/$defs/oauth2Token",
+                  "title": "OAuth2AutenthicationDataSubject",
+                  "description": "The security token that represents the identity of the party on behalf of whom the request is being made."
+              },
+              "actor": {
+                  "$ref": "#/$defs/oauth2Token",
+                  "title": "OAuth2AutenthicationDataActor",
+                  "description": "The security token that represents the identity of the acting party."
+              }
+          }
+      },
+      "oauth2Token": {
+          "type": "object",
+          "title": "OAuth2TokenDefinition",
+          "description": "Represents an OAuth2 token.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "token": {
+                  "type": "string",
+                  "title": "OAuth2Token",
+                  "description": "The security token to use."
+              },
+              "type": {
+                  "type": "string",
+                  "title": "OAuth2TokenType",
+                  "description": "The type of the security token to use."
+              }
+          },
+          "required": [
+              "token",
+              "type"
+          ]
+      },
+      "duration": {
+          "oneOf": [
+              {
+                  "type": "object",
+                  "minProperties": 1,
+                  "unevaluatedProperties": false,
+                  "properties": {
+                      "days": {
+                          "type": "integer",
+                          "title": "DurationDays",
+                          "description": "Number of days, if any."
+                      },
+                      "hours": {
+                          "type": "integer",
+                          "title": "DurationHours",
+                          "description": "Number of days, if any."
+                      },
+                      "minutes": {
+                          "type": "integer",
+                          "title": "DurationMinutes",
+                          "description": "Number of minutes, if any."
+                      },
+                      "seconds": {
+                          "type": "integer",
+                          "title": "DurationSeconds",
+                          "description": "Number of seconds, if any."
+                      },
+                      "milliseconds": {
+                          "type": "integer",
+                          "title": "DurationMilliseconds",
+                          "description": "Number of milliseconds, if any."
+                      }
+                  },
+                  "title": "DurationInline",
+                  "description": "The inline definition of a duration."
+              },
+              {
+                  "type": "string",
+                  "pattern": "^P(?!$)(\\d+(?:\\.\\d+)?Y)?(\\d+(?:\\.\\d+)?M)?(\\d+(?:\\.\\d+)?W)?(\\d+(?:\\.\\d+)?D)?(T(?=\\d)(\\d+(?:\\.\\d+)?H)?(\\d+(?:\\.\\d+)?M)?(\\d+(?:\\.\\d+)?S)?)?$",
+                  "title": "DurationExpression",
+                  "description": "The ISO 8601 expression of a duration."
+              }
+          ]
+      },
+      "error": {
+          "type": "object",
+          "title": "Error",
+          "description": "Represents an error.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "type": {
+                  "title": "ErrorType",
+                  "description": "A URI reference that identifies the error type.",
+                  "oneOf": [
+                      {
+                          "title": "LiteralErrorType",
+                          "$ref": "#/$defs/uriTemplate",
+                          "description": "The literal error type."
+                      },
+                      {
+                          "title": "ExpressionErrorType",
+                          "$ref": "#/$defs/runtimeExpression",
+                          "description": "An expression based error type."
+                      }
+                  ]
+              },
+              "status": {
+                  "type": "integer",
+                  "title": "ErrorStatus",
+                  "description": "The status code generated by the origin for this occurrence of the error."
+              },
+              "instance": {
+                  "title": "ErrorInstance",
+                  "description": "A JSON Pointer used to reference the component the error originates from.",
+                  "oneOf": [
+                      {
+                          "title": "LiteralErrorInstance",
+                          "description": "The literal error instance.",
+                          "type": "string",
+                          "format": "json-pointer"
+                      },
+                      {
+                          "$ref": "#/$defs/runtimeExpression",
+                          "title": "ExpressionErrorInstance",
+                          "description": "An expression based error instance."
+                      }
+                  ]
+              },
+              "title": {
+                  "description": "A short, human-readable summary of the error.",
+                  "title": "ErrorTitle",
+                  "anyOf": [
+                      {
+                          "$ref": "#/$defs/runtimeExpression",
+                          "title": "ExpressionErrorTitle"
+                      },
+                      {
+                          "type": "string",
+                          "title": "LiteralErrorTitle"
+                      }
+                  ]
+              },
+              "detail": {
+                  "title": "ErrorDetails",
+                  "description": "A human-readable explanation specific to this occurrence of the error.",
+                  "anyOf": [
+                      {
+                          "$ref": "#/$defs/runtimeExpression",
+                          "title": "ExpressionErrorDetails"
+                      },
+                      {
+                          "type": "string",
+                          "title": "LiteralErrorDetails"
+                      }
+                  ]
+              }
+          },
+          "required": [
+              "type",
+              "status"
+          ]
+      },
+      "errorFilter": {
+          "type": "object",
+          "title": "ErrorFilter",
+          "description": "Error filtering base on static values. For error filtering on dynamic values, use catch.when property",
+          "minProperties": 1,
+          "properties": {
+              "type": {
+                  "type": "string",
+                  "description": "if present, means this value should be used for filtering"
+              },
+              "status": {
+                  "type": "integer",
+                  "description": "if present, means this value should be used for filtering"
+              },
+              "instance": {
+                  "type": "string",
+                  "description": "if present, means this value should be used for filtering"
+              },
+              "title": {
+                  "type": "string",
+                  "description": "if present, means this value should be used for filtering"
+              },
+              "details": {
+                  "type": "string",
+                  "description": "if present, means this value should be used for filtering"
+              }
+          }
+      },
+      "uriTemplate": {
+          "title": "UriTemplate",
+          "anyOf": [
+              {
+                  "title": "LiteralUriTemplate",
+                  "type": "string",
+                  "format": "uri-template",
+                  "pattern": "^[A-Za-z][A-Za-z0-9+\\-.]*://.*"
+              },
+              {
+                  "title": "LiteralUri",
+                  "type": "string",
+                  "format": "uri",
+                  "pattern": "^[A-Za-z][A-Za-z0-9+\\-.]*://.*"
+              }
+          ]
+      },
+      "endpoint": {
+          "title": "Endpoint",
+          "description": "Represents an endpoint.",
+          "oneOf": [
+              {
+                  "$ref": "#/$defs/runtimeExpression"
+              },
+              {
+                  "$ref": "#/$defs/uriTemplate"
+              },
+              {
+                  "title": "EndpointConfiguration",
+                  "type": "object",
+                  "unevaluatedProperties": false,
+                  "properties": {
+                      "uri": {
+                          "title": "EndpointUri",
+                          "description": "The endpoint's URI.",
+                          "oneOf": [
+                              {
+                                  "title": "LiteralEndpointURI",
+                                  "description": "The literal endpoint's URI.",
+                                  "$ref": "#/$defs/uriTemplate"
+                              },
+                              {
+                                  "title": "ExpressionEndpointURI",
+                                  "$ref": "#/$defs/runtimeExpression",
+                                  "description": "An expression based endpoint's URI."
+                              }
+                          ]
+                      },
+                      "authentication": {
+                          "$ref": "#/$defs/referenceableAuthenticationPolicy",
+                          "title": "EndpointAuthentication",
+                          "description": "The authentication policy to use."
+                      }
+                  },
+                  "required": [
+                      "uri"
+                  ]
+              }
+          ]
+      },
+      "eventProperties": {
+          "type": "object",
+          "title": "EventProperties",
+          "description": "Describes the properties of an event.",
+          "properties": {
+              "id": {
+                  "type": "string",
+                  "title": "EventId",
+                  "description": "The event's unique identifier."
+              },
+              "source": {
+                  "title": "EventSource",
+                  "description": "Identifies the context in which an event happened.",
+                  "oneOf": [
+                      {
+                          "$ref": "#/$defs/uriTemplate"
+                      },
+                      {
+                          "$ref": "#/$defs/runtimeExpression"
+                      }
+                  ]
+              },
+              "type": {
+                  "type": "string",
+                  "title": "EventType",
+                  "description": "This attribute contains a value describing the type of event related to the originating occurrence."
+              },
+              "time": {
+                  "title": "EventTime",
+                  "description": "When the event occured.",
+                  "oneOf": [
+                      {
+                          "title": "LiteralTime",
+                          "type": "string",
+                          "format": "date-time"
+                      },
+                      {
+                          "$ref": "#/$defs/runtimeExpression"
+                      }
+                  ]
+              },
+              "subject": {
+                  "type": "string",
+                  "title": "EventSubject",
+                  "description": "The subject of the event."
+              },
+              "datacontenttype": {
+                  "type": "string",
+                  "title": "EventDataContentType",
+                  "description": "Content type of data value. This attribute enables data to carry any type of content, whereby format and encoding might differ from that of the chosen event format."
+              },
+              "dataschema": {
+                  "title": "EventDataschema",
+                  "description": "The schema describing the event format.",
+                  "oneOf": [
+                      {
+                          "title": "LiteralDataSchema",
+                          "$ref": "#/$defs/uriTemplate",
+                          "description": "The literal event data schema."
+                      },
+                      {
+                          "title": "ExpressionDataSchema",
+                          "$ref": "#/$defs/runtimeExpression",
+                          "description": "An expression based event data schema."
+                      }
+                  ]
+              },
+              "data": {
+                  "title": "EventData",
+                  "description": "The event's payload data",
+                  "anyOf": [
+                      {
+                          "$ref": "#/$defs/runtimeExpression"
+                      },
+                      {}
+                  ]
+              }
+          },
+          "additionalProperties": true
+      },
+      "eventConsumptionStrategy": {
+          "type": "object",
+          "title": "EventConsumptionStrategy",
+          "description": "Describe the event consumption strategy to adopt.",
+          "unevaluatedProperties": false,
+          "oneOf": [
+              {
+                  "title": "AllEventConsumptionStrategy",
+                  "properties": {
+                      "all": {
+                          "type": "array",
+                          "title": "AllEventConsumptionStrategyConfiguration",
+                          "description": "A list containing all the events that must be consumed.",
+                          "items": {
+                              "$ref": "#/$defs/eventFilter"
+                          }
+                      }
+                  },
+                  "required": [
+                      "all"
+                  ]
+              },
+              {
+                  "title": "AnyEventConsumptionStrategy",
+                  "properties": {
+                      "any": {
+                          "type": "array",
+                          "title": "AnyEventConsumptionStrategyConfiguration",
+                          "description": "A list containing any of the events to consume.",
+                          "items": {
+                              "$ref": "#/$defs/eventFilter"
+                          }
+                      },
+                      "until": {
+                          "oneOf": [
+                              {
+                                  "type": "string",
+                                  "title": "AnyEventUntilCondition",
+                                  "description": "A runtime expression condition evaluated after consuming an event and which determines whether or not to continue listening."
+                              },
+                              {
+                                  "allOf": [
+                                      {
+                                          "$ref": "#/$defs/eventConsumptionStrategy",
+                                          "description": "The strategy that defines the event(s) to consume to stop listening."
+                                      },
+                                      {
+                                          "properties": {
+                                              "until": false
+                                          }
+                                      }
+                                  ],
+                                  "title": "AnyEventUntilConsumed"
+                              }
+                          ]
+                      }
+                  },
+                  "required": [
+                      "any"
+                  ]
+              },
+              {
+                  "title": "OneEventConsumptionStrategy",
+                  "properties": {
+                      "one": {
+                          "$ref": "#/$defs/eventFilter",
+                          "title": "OneEventConsumptionStrategyConfiguration",
+                          "description": "The single event to consume."
+                      }
+                  },
+                  "required": [
+                      "one"
+                  ]
+              }
+          ]
+      },
+      "eventFilter": {
+          "type": "object",
+          "title": "EventFilter",
+          "description": "An event filter is a mechanism used to selectively process or handle events based on predefined criteria, such as event type, source, or specific attributes.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "with": {
+                  "$ref": "#/$defs/eventProperties",
+                  "minProperties": 1,
+                  "title": "WithEvent",
+                  "description": "An event filter is a mechanism used to selectively process or handle events based on predefined criteria, such as event type, source, or specific attributes."
+              },
+              "correlate": {
+                  "type": "object",
+                  "title": "EventFilterCorrelate",
+                  "description": "A correlation is a link between events and data, established by mapping event attributes to specific data attributes, allowing for coordinated processing or handling based on event characteristics.",
+                  "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                          "from": {
+                              "type": "string",
+                              "title": "CorrelateFrom",
+                              "description": "A runtime expression used to extract the correlation value from the filtered event."
+                          },
+                          "expect": {
+                              "type": "string",
+                              "title": "CorrelateExpect",
+                              "description": "A constant or a runtime expression, if any, used to determine whether or not the extracted correlation value matches expectations. If not set, the first extracted value will be used as the correlation's expectation."
+                          }
+                      },
+                      "required": [
+                          "from"
+                      ]
+                  }
+              }
+          },
+          "required": [
+              "with"
+          ]
+      },
+      "extension": {
+          "type": "object",
+          "title": "Extension",
+          "description": "The definition of an extension.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "extend": {
+                  "type": "string",
+                  "enum": [
+                      "call",
+                      "composite",
+                      "emit",
+                      "for",
+                      "listen",
+                      "raise",
+                      "run",
+                      "set",
+                      "switch",
+                      "try",
+                      "wait",
+                      "all"
+                  ],
+                  "title": "ExtensionTarget",
+                  "description": "The type of task to extend."
+              },
+              "when": {
+                  "type": "string",
+                  "title": "ExtensionCondition",
+                  "description": "A runtime expression, if any, used to determine whether or not the extension should apply in the specified context."
+              },
+              "before": {
+                  "$ref": "#/$defs/taskList",
+                  "title": "ExtensionDoBefore",
+                  "description": "The task(s) to execute before the extended task, if any."
+              },
+              "after": {
+                  "$ref": "#/$defs/taskList",
+                  "title": "ExtensionDoAfter",
+                  "description": "The task(s) to execute after the extended task, if any."
+              }
+          },
+          "required": [
+              "extend"
+          ]
+      },
+      "externalResource": {
+          "type": "object",
+          "title": "ExternalResource",
+          "description": "Represents an external resource.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "name": {
+                  "type": "string",
+                  "title": "ExternalResourceName",
+                  "description": "The name of the external resource, if any."
+              },
+              "endpoint": {
+                  "$ref": "#/$defs/endpoint",
+                  "title": "ExternalResourceEndpoint",
+                  "description": "The endpoint of the external resource."
+              }
+          },
+          "required": [
+              "endpoint"
+          ]
+      },
+      "input": {
+          "type": "object",
+          "title": "Input",
+          "description": "Configures the input of a workflow or task.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "schema": {
+                  "$ref": "#/$defs/schema",
+                  "title": "InputSchema",
+                  "description": "The schema used to describe and validate the input of the workflow or task."
+              },
+              "from": {
+                  "title": "InputFrom",
+                  "description": "A runtime expression, if any, used to mutate and/or filter the input of the workflow or task.",
+                  "oneOf": [
+                      {
+                          "type": "string"
+                      },
+                      {
+                          "type": "object"
+                      }
+                  ]
+              }
+          }
+      },
+      "output": {
+          "type": "object",
+          "title": "Output",
+          "description": "Configures the output of a workflow or task.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "schema": {
+                  "$ref": "#/$defs/schema",
+                  "title": "OutputSchema",
+                  "description": "The schema used to describe and validate the output of the workflow or task."
+              },
+              "as": {
+                  "title": "OutputAs",
+                  "description": "A runtime expression, if any, used to mutate and/or filter the output of the workflow or task.",
+                  "oneOf": [
+                      {
+                          "type": "string"
+                      },
+                      {
+                          "type": "object"
+                      }
+                  ]
+              }
+          }
+      },
+      "export": {
+          "type": "object",
+          "title": "Export",
+          "description": "Set the content of the context. .",
+          "unevaluatedProperties": false,
+          "properties": {
+              "schema": {
+                  "$ref": "#/$defs/schema",
+                  "title": "ExportSchema",
+                  "description": "The schema used to describe and validate the workflow context."
+              },
+              "as": {
+                  "title": "ExportAs",
+                  "description": "A runtime expression, if any, used to export the output data to the context.",
+                  "oneOf": [
+                      {
+                          "type": "string"
+                      },
+                      {
+                          "type": "object"
+                      }
+                  ]
+              }
+          }
+      },
+      "retryPolicy": {
+          "type": "object",
+          "title": "RetryPolicy",
+          "description": "Defines a retry policy.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "when": {
+                  "type": "string",
+                  "title": "RetryWhen",
+                  "description": "A runtime expression, if any, used to determine whether or not to retry running the task, in a given context."
+              },
+              "exceptWhen": {
+                  "type": "string",
+                  "title": "RetryExcepWhen",
+                  "description": "A runtime expression used to determine whether or not to retry running the task, in a given context."
+              },
+              "delay": {
+                  "$ref": "#/$defs/duration",
+                  "title": "RetryDelay",
+                  "description": "The duration to wait between retry attempts."
+              },
+              "backoff": {
+                  "type": "object",
+                  "title": "RetryBackoff",
+                  "description": "The retry duration backoff.",
+                  "unevaluatedProperties": false,
+                  "oneOf": [
+                      {
+                          "title": "ConstantBackoff",
+                          "properties": {
+                              "constant": {
+                                  "type": "object",
+                                  "description": "The definition of the constant backoff to use, if any."
+                              }
+                          },
+                          "required": [
+                              "constant"
+                          ]
+                      },
+                      {
+                          "title": "ExponentialBackOff",
+                          "properties": {
+                              "exponential": {
+                                  "type": "object",
+                                  "description": "The definition of the exponential backoff to use, if any."
+                              }
+                          },
+                          "required": [
+                              "exponential"
+                          ]
+                      },
+                      {
+                          "title": "LinearBackoff",
+                          "properties": {
+                              "linear": {
+                                  "type": "object",
+                                  "description": "The definition of the linear backoff to use, if any."
+                              }
+                          },
+                          "required": [
+                              "linear"
+                          ]
+                      }
+                  ]
+              },
+              "limit": {
+                  "type": "object",
+                  "title": "RetryLimit",
+                  "unevaluatedProperties": false,
+                  "properties": {
+                      "attempt": {
+                          "type": "object",
+                          "title": "RetryLimitAttempt",
+                          "unevaluatedProperties": false,
+                          "properties": {
+                              "count": {
+                                  "type": "integer",
+                                  "title": "RetryLimitAttemptCount",
+                                  "description": "The maximum amount of retry attempts, if any."
+                              },
+                              "duration": {
+                                  "$ref": "#/$defs/duration",
+                                  "title": "RetryLimitAttemptDuration",
+                                  "description": "The maximum duration for each retry attempt."
+                              }
+                          }
+                      },
+                      "duration": {
+                          "$ref": "#/$defs/duration",
+                          "title": "RetryLimitDuration",
+                          "description": "The duration limit, if any, for all retry attempts."
+                      }
+                  },
+                  "description": "The retry limit, if any."
+              },
+              "jitter": {
+                  "type": "object",
+                  "title": "RetryPolicyJitter",
+                  "description": "The parameters, if any, that control the randomness or variability of the delay between retry attempts.",
+                  "unevaluatedProperties": false,
+                  "properties": {
+                      "from": {
+                          "$ref": "#/$defs/duration",
+                          "title": "RetryPolicyJitterFrom",
+                          "description": "The minimum duration of the jitter range."
+                      },
+                      "to": {
+                          "$ref": "#/$defs/duration",
+                          "title": "RetryPolicyJitterTo",
+                          "description": "The maximum duration of the jitter range."
+                      }
+                  },
+                  "required": [
+                      "from",
+                      "to"
+                  ]
+              }
+          }
+      },
+      "schema": {
+          "type": "object",
+          "title": "Schema",
+          "description": "Represents the definition of a schema.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "format": {
+                  "type": "string",
+                  "default": "json",
+                  "title": "SchemaFormat",
+                  "description": "The schema's format. Defaults to 'json'. The (optional) version of the format can be set using `{format}:{version}`."
+              }
+          },
+          "oneOf": [
+              {
+                  "title": "SchemaInline",
+                  "properties": {
+                      "document": {
+                          "description": "The schema's inline definition."
+                      }
+                  },
+                  "required": [
+                      "document"
+                  ]
+              },
+              {
+                  "title": "SchemaExternal",
+                  "properties": {
+                      "resource": {
+                          "$ref": "#/$defs/externalResource",
+                          "title": "SchemaExternalResource",
+                          "description": "The schema's external resource."
+                      }
+                  },
+                  "required": [
+                      "resource"
+                  ]
+              }
+          ]
+      },
+      "timeout": {
+          "type": "object",
+          "title": "Timeout",
+          "description": "The definition of a timeout.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "after": {
+                  "$ref": "#/$defs/duration",
+                  "title": "TimeoutAfter",
+                  "description": "The duration after which to timeout."
+              }
+          },
+          "required": [
+              "after"
+          ]
+      },
+      "catalog": {
+          "type": "object",
+          "title": "Catalog",
+          "description": "The definition of a resource catalog.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "endpoint": {
+                  "$ref": "#/$defs/endpoint",
+                  "title": "CatalogEndpoint",
+                  "description": "The root URL where the catalog is hosted."
+              }
+          },
+          "required": [
+              "endpoint"
+          ]
+      },
+      "runtimeExpression": {
+          "type": "string",
+          "title": "RuntimeExpression",
+          "description": "A runtime expression.",
+          "pattern": "^\\s*\\$\\{.+\\}\\s*$"
+      },
+      "containerLifetime": {
+          "type": "object",
+          "title": "ContainerLifetime",
+          "description": "The configuration of a container's lifetime",
+          "unevaluatedProperties": false,
+          "properties": {
+              "cleanup": {
+                  "type": "string",
+                  "title": "ContainerCleanupPolicy",
+                  "description": "The container cleanup policy to use",
+                  "enum": [
+                      "always",
+                      "never",
+                      "eventually"
+                  ],
+                  "default": "never"
+              },
+              "after": {
+                  "$ref": "#/$defs/duration",
+                  "title": "ContainerLifetimeDuration",
+                  "description": "The duration after which to cleanup the container, in case the cleanup policy has been set to 'eventually'"
+              }
+          },
+          "required": [
+              "cleanup"
+          ],
+          "if": {
+              "properties": {
+                  "cleanup": {
+                      "const": "eventually"
+                  }
+              }
+          },
+          "then": {
+              "required": [
+                  "after"
+              ]
+          },
+          "else": {
+              "not": {
+                  "required": [
+                      "after"
+                  ]
+              }
+          }
+      },
+      "processResult": {
+          "type": "object",
+          "title": "ProcessResult",
+          "description": "The object returned by a run task when its return type has been set 'all'.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "code": {
+                  "type": "integer",
+                  "title": "ProcessExitCode",
+                  "description": "The process's exit code."
+              },
+              "stdout": {
+                  "type": "string",
+                  "title": "ProcessStandardOutput",
+                  "description": "The content of the process's STDOUT."
+              },
+              "stderr": {
+                  "type": "string",
+                  "title": "ProcessStandardError",
+                  "description": "The content of the process's STDERR."
+              }
+          },
+          "required": [
+              "code",
+              "stdout",
+              "stderr"
+          ]
+      },
+      "asyncApiServer": {
+          "type": "object",
+          "title": "AsyncApiServer",
+          "description": "Configures the target server of an AsyncAPI operation.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "name": {
+                  "type": "string",
+                  "title": "AsyncApiServerName",
+                  "description": "The target server's name."
+              },
+              "variables": {
+                  "type": "object",
+                  "title": "AsyncApiServerVariables",
+                  "description": "The target server's variables, if any."
+              }
+          },
+          "required": [
+              "name"
+          ]
+      },
+      "asyncApiOutboundMessage": {
+          "type": "object",
+          "title": "AsyncApiOutboundMessage",
+          "description": "An object used to configure the message to publish using the target operation.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "payload": {
+                  "type": "object",
+                  "title": "AsyncApiMessagePayload",
+                  "description": "The message's payload, if any.",
+                  "additionalProperties": true
+              },
+              "headers": {
+                  "type": "object",
+                  "title": "AsyncApiMessageHeaders",
+                  "description": "The message's headers, if any.",
+                  "additionalProperties": true
+              }
+          }
+      },
+      "asyncApiInboundMessage": {
+          "type": "object",
+          "title": "AsyncApiInboundMessage",
+          "description": "Represents a message counsumed by an AsyncAPI subscription.",
+          "allOf": [
+              {
+                  "$ref": "#/$defs/asyncApiOutboundMessage"
+              }
+          ],
+          "properties": {
+              "correlationId": {
+                  "type": "string",
+                  "title": "AsyncApiMessageCorrelationId",
+                  "description": "The message's correlation id, if any."
+              }
+          }
+      },
+      "asyncApiSubscription": {
+          "type": "object",
+          "title": "AsyncApiSubscription",
+          "description": "An object used to configure the subscription to messages consumed using the target operation.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "filter": {
+                  "$ref": "#/$defs/runtimeExpression",
+                  "title": "AsyncApiSubscriptionCorrelation",
+                  "description": "A runtime expression, if any, used to filter consumed messages."
+              },
+              "consume": {
+                  "$ref": "#/$defs/asyncApiMessageConsumptionPolicy",
+                  "title": "AsyncApiMessageConsumptionPolicy",
+                  "description": "An object used to configure the subscription's message consumption policy."
+              },
+              "foreach": {
+                  "$ref": "#/$defs/subscriptionIterator",
+                  "title": "AsyncApiSubscriptionIterator",
+                  "description": "Configures the iterator, if any, for processing consumed messages(s)."
+              }
+          },
+          "required": [
+              "consume"
+          ]
+      },
+      "asyncApiMessageConsumptionPolicy": {
+          "type": "object",
+          "title": "AsyncApiMessageConsumptionPolicy",
+          "description": "An object used to configure a subscription's message consumption policy.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "for": {
+                  "$ref": "#/$defs/duration",
+                  "title": "AsyncApiMessageConsumptionPolicyFor",
+                  "description": "Specifies the time period over which messages will be consumed."
+              }
+          },
+          "oneOf": [
+              {
+                  "properties": {
+                      "amount": {
+                          "type": "integer",
+                          "description": "The amount of (filtered) messages to consume before disposing of the subscription."
+                      }
+                  },
+                  "title": "AsyncApiMessageConsumptionPolicyAmount",
+                  "required": [
+                      "amount"
+                  ]
+              },
+              {
+                  "properties": {
+                      "while": {
+                          "$ref": "#/$defs/runtimeExpression",
+                          "description": "A runtime expression evaluated after each consumed (filtered) message to decide if message consumption should continue."
+                      }
+                  },
+                  "title": "AsyncApiMessageConsumptionPolicyWhile",
+                  "required": [
+                      "while"
+                  ]
+              },
+              {
+                  "properties": {
+                      "until": {
+                          "$ref": "#/$defs/runtimeExpression",
+                          "description": "A runtime expression evaluated before each consumed (filtered) message to decide if message consumption should continue."
+                      }
+                  },
+                  "title": "AsyncApiMessageConsumptionPolicyUntil",
+                  "required": [
+                      "until"
+                  ]
+              }
+          ]
+      },
+      "subscriptionIterator": {
+          "type": "object",
+          "title": "SubscriptionIterator",
+          "description": "Configures the iteration over each item (event or message) consumed by a subscription.",
+          "unevaluatedProperties": false,
+          "properties": {
+              "item": {
+                  "type": "string",
+                  "title": "SubscriptionIteratorItem",
+                  "description": "The name of the variable used to store the current item being enumerated.",
+                  "default": "item"
+              },
+              "at": {
+                  "type": "string",
+                  "title": "SubscriptionIteratorIndex",
+                  "description": "The name of the variable used to store the index of the current item being enumerated.",
+                  "default": "index"
+              },
+              "do": {
+                  "$ref": "#/$defs/taskList",
+                  "title": "SubscriptionIteratorTasks",
+                  "description": "The tasks to perform for each consumed item."
+              },
+              "output": {
+                  "$ref": "#/$defs/output",
+                  "title": "SubscriptionIteratorOutput",
+                  "description": "An object, if any, used to customize the item's output and to document its schema."
+              },
+              "export": {
+                  "$ref": "#/$defs/export",
+                  "title": "SubscriptionIteratorExport",
+                  "description": "An object, if any, used to customize the content of the workflow context."
+              }
+          }
+      }
+  }
+}

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0/workflow.yaml
+$id: https://serverlessworkflow.io/schemas/1.0.1/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object
@@ -226,648 +226,664 @@ $defs:
     oneOf:
       - title: CallAsyncAPI
         description: Defines the AsyncAPI call to perform.
-        $ref: '#/$defs/taskBase'
         type: object
         required: [ call, with ]
         unevaluatedProperties: false
-        properties:
-          call:
-            type: string
-            const: asyncapi
-          with:
-            type: object
-            title: AsyncApiArguments
-            description: The Async API call arguments.
-            properties:
-              document:
-                $ref: '#/$defs/externalResource'
-                title: AsyncAPIDocument
-                description: The document that defines the AsyncAPI operation to call.
-              channel:
-                type: string
-                title: With
-                description: The name of the channel on which to perform the operation. Used only in case the referenced document uses AsyncAPI v2.6.0.
-              operation:
-                type: string
-                title: AsyncAPIOperation
-                description: A reference to the AsyncAPI operation to call.
-              server:
-                $ref: '#/$defs/asyncApiServer'
-                title: AsyncAPIServer
-                description: An object used to configure to the server to call the specified AsyncAPI operation on.
-              protocol:
-                type: string
-                title: AsyncApiProtocol
-                description: The protocol to use to select the target server.
-                enum: [ amqp, amqp1, anypointmq, googlepubsub, http, ibmmq, jms, kafka, mercure, mqtt, mqtt5, nats, pulsar, redis, sns, solace, sqs, stomp, ws ]
-              message:
-                $ref: '#/$defs/asyncApiOutboundMessage'
-                title: AsyncApiMessage
-                description: An object used to configure the message to publish using the target operation.
-              subscription:
-                $ref: '#/$defs/asyncApiSubscription'
-                title: AsyncApiSubscription
-                description: An object used to configure the subscription to messages consumed using the target operation.
-              authentication:
-                $ref: '#/$defs/referenceableAuthenticationPolicy'
-                title: AsyncAPIAuthentication
-                description: The authentication policy, if any, to use when calling the AsyncAPI operation.
-            oneOf:
-              - required: [ document, operation, message ]
-              - required: [ document, operation, subscription ]
-              - required: [ document, channel, message ]
-              - required: [ document, channel, subscription ]
-            unevaluatedProperties: false
+        allOf:
+        - $ref: '#/$defs/taskBase'
+        - properties:
+            call:
+              type: string
+              const: asyncapi
+            with:
+              type: object
+              title: AsyncApiArguments
+              description: The Async API call arguments.
+              properties:
+                document:
+                  $ref: '#/$defs/externalResource'
+                  title: AsyncAPIDocument
+                  description: The document that defines the AsyncAPI operation to call.
+                channel:
+                  type: string
+                  title: With
+                  description: The name of the channel on which to perform the operation. Used only in case the referenced document uses AsyncAPI v2.6.0.
+                operation:
+                  type: string
+                  title: AsyncAPIOperation
+                  description: A reference to the AsyncAPI operation to call.
+                server:
+                  $ref: '#/$defs/asyncApiServer'
+                  title: AsyncAPIServer
+                  description: An object used to configure to the server to call the specified AsyncAPI operation on.
+                protocol:
+                  type: string
+                  title: AsyncApiProtocol
+                  description: The protocol to use to select the target server.
+                  enum: [ amqp, amqp1, anypointmq, googlepubsub, http, ibmmq, jms, kafka, mercure, mqtt, mqtt5, nats, pulsar, redis, sns, solace, sqs, stomp, ws ]
+                message:
+                  $ref: '#/$defs/asyncApiOutboundMessage'
+                  title: AsyncApiMessage
+                  description: An object used to configure the message to publish using the target operation.
+                subscription:
+                  $ref: '#/$defs/asyncApiSubscription'
+                  title: AsyncApiSubscription
+                  description: An object used to configure the subscription to messages consumed using the target operation.
+                authentication:
+                  $ref: '#/$defs/referenceableAuthenticationPolicy'
+                  title: AsyncAPIAuthentication
+                  description: The authentication policy, if any, to use when calling the AsyncAPI operation.
+              oneOf:
+                - required: [ document, operation, message ]
+                - required: [ document, operation, subscription ]
+                - required: [ document, channel, message ]
+                - required: [ document, channel, subscription ]
+              unevaluatedProperties: false
       - title: CallGRPC
         description: Defines the GRPC call to perform.
-        $ref: '#/$defs/taskBase'
         type: object
         unevaluatedProperties: false
         required: [ call, with ]
-        properties:
-          call:
-            type: string
-            const: grpc
-          with:
-            type: object
-            title: GRPCArguments
-            description: The GRPC call arguments.
-            properties:
-              proto:
-                $ref: '#/$defs/externalResource'
-                title: WithGRPCProto
-                description: The proto resource that describes the GRPC service to call.
-              service:
-                type: object
-                title: WithGRPCService
-                unevaluatedProperties: false
-                properties:
-                  name:
-                    type: string
-                    title: WithGRPCServiceName
-                    description: The name of the GRPC service to call.
-                  host:
-                    type: string
-                    title: WithGRPCServiceHost
-                    description: The hostname of the GRPC service to call.
-                    pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
-                  port:
-                    type: integer
-                    title: WithGRPCServicePost
-                    description: The port number of the GRPC service to call.
-                    minimum: 0
-                    maximum: 65535
-                  authentication:
-                    $ref: '#/$defs/referenceableAuthenticationPolicy'
-                    title: WithGRPCServiceAuthentication
-                    description: The endpoint's authentication policy, if any.
-                required: [ name, host ]
-              method:
-                type: string
-                title: WithGRPCMethod
-                description: The name of the method to call on the defined GRPC service.
-              arguments:
-                type: object
-                title: WithGRPCArguments
-                description: The arguments, if any, to call the method with.
-                additionalProperties: true
-            required: [ proto, service, method ]
-            unevaluatedProperties: false
+        allOf:
+        - $ref: '#/$defs/taskBase'
+        - properties:
+            call:
+              type: string
+              const: grpc
+            with:
+              type: object
+              title: GRPCArguments
+              description: The GRPC call arguments.
+              properties:
+                proto:
+                  $ref: '#/$defs/externalResource'
+                  title: WithGRPCProto
+                  description: The proto resource that describes the GRPC service to call.
+                service:
+                  type: object
+                  title: WithGRPCService
+                  unevaluatedProperties: false
+                  properties:
+                    name:
+                      type: string
+                      title: WithGRPCServiceName
+                      description: The name of the GRPC service to call.
+                    host:
+                      type: string
+                      title: WithGRPCServiceHost
+                      description: The hostname of the GRPC service to call.
+                      pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
+                    port:
+                      type: integer
+                      title: WithGRPCServicePost
+                      description: The port number of the GRPC service to call.
+                      minimum: 0
+                      maximum: 65535
+                    authentication:
+                      $ref: '#/$defs/referenceableAuthenticationPolicy'
+                      title: WithGRPCServiceAuthentication
+                      description: The endpoint's authentication policy, if any.
+                  required: [ name, host ]
+                method:
+                  type: string
+                  title: WithGRPCMethod
+                  description: The name of the method to call on the defined GRPC service.
+                arguments:
+                  type: object
+                  title: WithGRPCArguments
+                  description: The arguments, if any, to call the method with.
+                  additionalProperties: true
+              required: [ proto, service, method ]
+              unevaluatedProperties: false
       - title: CallHTTP
         description: Defines the HTTP call to perform.
-        $ref: '#/$defs/taskBase'
         type: object
         unevaluatedProperties: false
         required: [ call, with ]
-        properties:
-          call:
-            type: string
-            const: http
-          with:
-            type: object
-            title: HTTPArguments
-            description: The HTTP call arguments.
-            properties:
-              method:
-                type: string
-                title: HTTPMethod
-                description: The HTTP method of the HTTP request to perform.
-              endpoint:
-                title: HTTPEndpoint
-                description: The HTTP endpoint to send the request to.
-                $ref: '#/$defs/endpoint'
-              headers:
-                oneOf:
-                  - type: object
-                    additionalProperties:
-                      type: string
-                  - $ref: '#/$defs/runtimeExpression'
-                title: HTTPHeaders
-                description: A name/value mapping of the headers, if any, of the HTTP request to perform.
-              body:
-                title: HTTPBody
-                description: The body, if any, of the HTTP request to perform.
-              query:
-                oneOf:
-                  - type: object
-                    additionalProperties:
-                      type: string
-                  - $ref: '#/$defs/runtimeExpression'
-                title: HTTPQuery
-                description: A name/value mapping of the query parameters, if any, of the HTTP request to perform.
-                additionalProperties: true
-              output:
-                type: string
-                title: HTTPOutput
-                description: The http call output format. Defaults to 'content'.
-                enum: [ raw, content, response ]
-              redirect:
-                type: boolean
-                title: HttpRedirect
-                description: Specifies whether redirection status codes (`300–399`) should be treated as errors.
-            required: [ method, endpoint ]
-            unevaluatedProperties: false
+        allOf:
+        - $ref: '#/$defs/taskBase'
+        - properties:
+            call:
+              type: string
+              const: http
+            with:
+              type: object
+              title: HTTPArguments
+              description: The HTTP call arguments.
+              properties:
+                method:
+                  type: string
+                  title: HTTPMethod
+                  description: The HTTP method of the HTTP request to perform.
+                endpoint:
+                  title: HTTPEndpoint
+                  description: The HTTP endpoint to send the request to.
+                  $ref: '#/$defs/endpoint'
+                headers:
+                  oneOf:
+                    - type: object
+                      additionalProperties:
+                        type: string
+                    - $ref: '#/$defs/runtimeExpression'
+                  title: HTTPHeaders
+                  description: A name/value mapping of the headers, if any, of the HTTP request to perform.
+                body:
+                  title: HTTPBody
+                  description: The body, if any, of the HTTP request to perform.
+                query:
+                  oneOf:
+                    - type: object
+                      additionalProperties:
+                        type: string
+                    - $ref: '#/$defs/runtimeExpression'
+                  title: HTTPQuery
+                  description: A name/value mapping of the query parameters, if any, of the HTTP request to perform.
+                  additionalProperties: true
+                output:
+                  type: string
+                  title: HTTPOutput
+                  description: The http call output format. Defaults to 'content'.
+                  enum: [ raw, content, response ]
+                redirect:
+                  type: boolean
+                  title: HttpRedirect
+                  description: Specifies whether redirection status codes (`300–399`) should be treated as errors.
+              required: [ method, endpoint ]
+              unevaluatedProperties: false
       - title: CallOpenAPI
         description: Defines the OpenAPI call to perform.
-        $ref: '#/$defs/taskBase'
         type: object
         unevaluatedProperties: false
         required: [ call, with ]
-        properties:
-          call:
-            type: string
-            const: openapi
-          with:
-            type: object
-            title: OpenAPIArguments
-            description: The OpenAPI call arguments.
-            properties:
-              document:
-                $ref: '#/$defs/externalResource'
-                title: WithOpenAPIDocument
-                description: The document that defines the OpenAPI operation to call.
-              operationId:
-                type: string
-                title: WithOpenAPIOperation
-                description: The id of the OpenAPI operation to call.
-              parameters:
-                type: object
-                title: WithOpenAPIParameters
-                description: A name/value mapping of the parameters of the OpenAPI operation to call.
-                additionalProperties: true
-              authentication:
-                $ref: '#/$defs/referenceableAuthenticationPolicy'
-                title: WithOpenAPIAuthentication
-                description: The authentication policy, if any, to use when calling the OpenAPI operation.
-              output:
-                type: string
-                enum: [ raw, content, response ]
-                title: WithOpenAPIOutput
-                description: The http call output format. Defaults to 'content'.
-              redirect:
-                type: boolean
-                title: HttpRedirect
-                description: Specifies whether redirection status codes (`300–399`) should be treated as errors.
-            required: [ document, operationId ]
-            unevaluatedProperties: false
+        allOf:
+        - $ref: '#/$defs/taskBase'
+        - properties:
+            call:
+              type: string
+              const: openapi
+            with:
+              type: object
+              title: OpenAPIArguments
+              description: The OpenAPI call arguments.
+              properties:
+                document:
+                  $ref: '#/$defs/externalResource'
+                  title: WithOpenAPIDocument
+                  description: The document that defines the OpenAPI operation to call.
+                operationId:
+                  type: string
+                  title: WithOpenAPIOperation
+                  description: The id of the OpenAPI operation to call.
+                parameters:
+                  type: object
+                  title: WithOpenAPIParameters
+                  description: A name/value mapping of the parameters of the OpenAPI operation to call.
+                  additionalProperties: true
+                authentication:
+                  $ref: '#/$defs/referenceableAuthenticationPolicy'
+                  title: WithOpenAPIAuthentication
+                  description: The authentication policy, if any, to use when calling the OpenAPI operation.
+                output:
+                  type: string
+                  enum: [ raw, content, response ]
+                  title: WithOpenAPIOutput
+                  description: The http call output format. Defaults to 'content'.
+                redirect:
+                  type: boolean
+                  title: HttpRedirect
+                  description: Specifies whether redirection status codes (`300–399`) should be treated as errors.
+              required: [ document, operationId ]
+              unevaluatedProperties: false
       - title: CallFunction
         description: Defines the function call to perform.
-        $ref: '#/$defs/taskBase'
         type: object
         unevaluatedProperties: false
         required: [ call ]
-        properties:
-          call:
-            type: string
-            not:
-              enum: ["asyncapi", "grpc", "http", "openapi"]
-            description: The name of the function to call.
-          with:
-            type: object
-            title: FunctionArguments
-            description: A name/value mapping of the parameters, if any, to call the function with.
-            additionalProperties: true
+        allOf:
+        - $ref: '#/$defs/taskBase'
+        - properties:
+            call:
+              type: string
+              not:
+                enum: ["asyncapi", "grpc", "http", "openapi"]
+              description: The name of the function to call.
+            with:
+              type: object
+              title: FunctionArguments
+              description: A name/value mapping of the parameters, if any, to call the function with.
+              additionalProperties: true
   forkTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: ForkTask
     description: Allows workflows to execute multiple tasks concurrently and optionally race them against each other, with a single possible winner, which sets the task's output.
     unevaluatedProperties: false
     required: [ fork ]
-    properties:
-      fork:
-        type: object
-        title: ForkTaskConfiguration
-        description: The configuration of the branches to perform concurrently.
-        unevaluatedProperties: false
-        required: [ branches ]
-        properties:
-          branches:
-            $ref: '#/$defs/taskList'
-            title: ForkBranches
-          compete:
-            type: boolean
-            title: ForkCompete
-            description: Indicates whether or not the concurrent tasks are racing against each other, with a single possible winner, which sets the composite task's output.
-            default: false
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        fork:
+          type: object
+          title: ForkTaskConfiguration
+          description: The configuration of the branches to perform concurrently.
+          unevaluatedProperties: false
+          required: [ branches ]
+          properties:
+            branches:
+              $ref: '#/$defs/taskList'
+              title: ForkBranches
+            compete:
+              type: boolean
+              title: ForkCompete
+              description: Indicates whether or not the concurrent tasks are racing against each other, with a single possible winner, which sets the composite task's output.
+              default: false
   doTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: DoTask
     description: Allows to execute a list of tasks in sequence.
     unevaluatedProperties: false
     required: [ do ]
-    properties:
-      do:
-        $ref: '#/$defs/taskList'
-        title: DoTaskConfiguration
-        description: The configuration of the tasks to perform sequentially.
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        do:
+          $ref: '#/$defs/taskList'
+          title: DoTaskConfiguration
+          description: The configuration of the tasks to perform sequentially.
   emitTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: EmitTask
     description: Allows workflows to publish events to event brokers or messaging systems, facilitating communication and coordination between different components and services.
     required: [ emit ]
     unevaluatedProperties: false
-    properties:
-      emit:
-        type: object
-        title: EmitTaskConfiguration
-        description: The configuration of an event's emission.
-        unevaluatedProperties: false
-        properties:
-          event:
-            type: object
-            title: EmitEventDefinition
-            description: The definition of the event to emit.
-            properties:
-              with:
-                $ref: '#/$defs/eventProperties'
-                title: EmitEventWith
-                description: Defines the properties of event to emit.
-                required: [ source, type ]
-            additionalProperties: true
-        required: [ event ]
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        emit:
+          type: object
+          title: EmitTaskConfiguration
+          description: The configuration of an event's emission.
+          unevaluatedProperties: false
+          properties:
+            event:
+              type: object
+              title: EmitEventDefinition
+              description: The definition of the event to emit.
+              properties:
+                with:
+                  $ref: '#/$defs/eventProperties'
+                  title: EmitEventWith
+                  description: Defines the properties of event to emit.
+                  required: [ source, type ]
+              additionalProperties: true
+          required: [ event ]
   forTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: ForTask
     description: Allows workflows to iterate over a collection of items, executing a defined set of subtasks for each item in the collection. This task type is instrumental in handling scenarios such as batch processing, data transformation, and repetitive operations across datasets.
     required: [ for, do ]
     unevaluatedProperties: false
-    properties:
-      for:
-        type: object
-        title: ForTaskConfiguration
-        description: The definition of the loop that iterates over a range of values.
-        unevaluatedProperties: false
-        properties:
-          each:
-            type: string
-            title: ForEach
-            description: The name of the variable used to store the current item being enumerated.
-            default: item
-          in:
-            type: string
-            title: ForIn
-            description: A runtime expression used to get the collection to enumerate.
-          at:
-            type: string
-            title: ForAt
-            description: The name of the variable used to store the index of the current item being enumerated.
-            default: index
-        required: [ in ]
-      while:
-        type: string
-        title: While
-        description: A runtime expression that represents the condition, if any, that must be met for the iteration to continue.
-      do:
-        $ref: '#/$defs/taskList'
-        title: ForTaskDo
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        for:
+          type: object
+          title: ForTaskConfiguration
+          description: The definition of the loop that iterates over a range of values.
+          unevaluatedProperties: false
+          properties:
+            each:
+              type: string
+              title: ForEach
+              description: The name of the variable used to store the current item being enumerated.
+              default: item
+            in:
+              type: string
+              title: ForIn
+              description: A runtime expression used to get the collection to enumerate.
+            at:
+              type: string
+              title: ForAt
+              description: The name of the variable used to store the index of the current item being enumerated.
+              default: index
+          required: [ in ]
+        while:
+          type: string
+          title: While
+          description: A runtime expression that represents the condition, if any, that must be met for the iteration to continue.
+        do:
+          $ref: '#/$defs/taskList'
+          title: ForTaskDo
   listenTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: ListenTask
     description: Provides a mechanism for workflows to await and react to external events, enabling event-driven behavior within workflow systems.
     required: [ listen ]
     unevaluatedProperties: false
-    properties:
-      listen:
-        type: object
-        title: ListenTaskConfiguration
-        description: The configuration of the listener to use.
-        unevaluatedProperties: false
-        properties:
-          to:
-            $ref: '#/$defs/eventConsumptionStrategy'
-            title: ListenTo
-            description: Defines the event(s) to listen to.
-          read:
-            type: string
-            enum: [ data, envelope, raw ]
-            default: data
-            title: ListenAndReadAs
-            description: Specifies how events are read during the listen operation.
-        required: [ to ]
-      foreach:
-        $ref: '#/$defs/subscriptionIterator'
-        title: ListenIterator
-        description: Configures the iterator, if any, for processing consumed event(s).
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        listen:
+          type: object
+          title: ListenTaskConfiguration
+          description: The configuration of the listener to use.
+          unevaluatedProperties: false
+          properties:
+            to:
+              $ref: '#/$defs/eventConsumptionStrategy'
+              title: ListenTo
+              description: Defines the event(s) to listen to.
+            read:
+              type: string
+              enum: [ data, envelope, raw ]
+              default: data
+              title: ListenAndReadAs
+              description: Specifies how events are read during the listen operation.
+          required: [ to ]
+        foreach:
+          $ref: '#/$defs/subscriptionIterator'
+          title: ListenIterator
+          description: Configures the iterator, if any, for processing consumed event(s).
   raiseTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: RaiseTask
     description: Intentionally triggers and propagates errors.
     required: [ raise ]
     unevaluatedProperties: false
-    properties:
-      raise:
-        type: object
-        title: RaiseTaskConfiguration
-        description: The definition of the error to raise.
-        unevaluatedProperties: false
-        properties:
-          error:
-            title: RaiseTaskError
-            oneOf:
-              - $ref: '#/$defs/error'
-                title: RaiseErrorDefinition
-                description: Defines the error to raise.
-              - type: string
-                title: RaiseErrorReference
-                description: The name of the error to raise
-        required: [ error ]
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        raise:
+          type: object
+          title: RaiseTaskConfiguration
+          description: The definition of the error to raise.
+          unevaluatedProperties: false
+          properties:
+            error:
+              title: RaiseTaskError
+              oneOf:
+                - $ref: '#/$defs/error'
+                  title: RaiseErrorDefinition
+                  description: Defines the error to raise.
+                - type: string
+                  title: RaiseErrorReference
+                  description: The name of the error to raise
+          required: [ error ]
   runTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: RunTask
     description: Provides the capability to execute external containers, shell commands, scripts, or workflows.
     required: [ run ]
     unevaluatedProperties: false
-    properties:
-      run:
-        type: object
-        title: RunTaskConfiguration
-        description: The configuration of the process to execute.
-        unevaluatedProperties: false
-        properties:
-          await:
-            type: boolean
-            default: true
-            title: AwaitProcessCompletion
-            description: Whether to await the process completion before continuing.
-          return:
-            type: string
-            title: ProcessReturnType
-            description: Configures the output of the process.
-            enum: [ stdout, stderr, code, all, none ]
-            default: stdout
-        oneOf:
-          - title: RunContainer
-            description: Enables the execution of external processes encapsulated within a containerized environment.
-            properties:
-              container:
-                type: object
-                title: Container
-                description: The configuration of the container to run.
-                unevaluatedProperties: false
-                properties:
-                  image:
-                    type: string
-                    title: ContainerImage
-                    description: The name of the container image to run.
-                  name:
-                    type: string
-                    title: ContainerName
-                    description: A runtime expression, if any, used to give specific name to the container.
-                  command:
-                    type: string
-                    title: ContainerCommand
-                    description: The command, if any, to execute on the container.
-                  ports:
-                    type: object
-                    title: ContainerPorts
-                    description: The container's port mappings, if any.
-                  volumes:
-                    type: object
-                    title: ContainerVolumes
-                    description: The container's volume mappings, if any.
-                  environment:
-                    type: object
-                    title: ContainerEnvironment
-                    description: A key/value mapping of the environment variables, if any, to use when running the configured process.
-                  lifetime:
-                    $ref: '#/$defs/containerLifetime'
-                    title: ContainerLifetime
-                    description: An object, if any, used to configure the container's lifetime
-                required: [ image ]
-            required: [ container ]
-          - title: RunScript
-            description: Enables the execution of custom scripts or code within a workflow, empowering workflows to perform specialized logic, data processing, or integration tasks by executing user-defined scripts written in various programming languages.
-            properties:
-              script:
-                type: object
-                title: Script
-                description: The configuration of the script to run.
-                unevaluatedProperties: false
-                properties:
-                  language:
-                    type: string
-                    title: ScriptLanguage
-                    description: The language of the script to run.
-                  arguments:
-                    type: object
-                    title: ScriptArguments
-                    description: A key/value mapping of the arguments, if any, to use when running the configured script.
-                    additionalProperties: true
-                  environment:
-                    type: object
-                    title: ScriptEnvironment
-                    description: A key/value mapping of the environment variables, if any, to use when running the configured script process.
-                    additionalProperties: true
-                oneOf:
-                  - title: InlineScript
-                    type: object
-                    description: The script's code.
-                    properties:
-                      code:
-                        type: string
-                        title: InlineScriptCode
-                    required: [ code ]
-                  - title: ExternalScript
-                    type: object
-                    description: The script's resource.
-                    properties:
-                      source:
-                        $ref: '#/$defs/externalResource'
-                        title: ExternalScriptResource
-                    required: [ source ]
-                required: [ language ]
-            required: [ script ]
-          - title: RunShell
-            description: Enables the execution of shell commands within a workflow, enabling workflows to interact with the underlying operating system and perform system-level operations, such as file manipulation, environment configuration, or system administration tasks.
-            properties:
-              shell:
-                type: object
-                title: Shell
-                description: The configuration of the shell command to run.
-                unevaluatedProperties: false
-                properties:
-                  command:
-                    type: string
-                    title: ShellCommand
-                    description: The shell command to run.
-                  arguments:
-                    type: object
-                    title: ShellArguments
-                    description: A list of the arguments of the shell command to run.
-                    additionalProperties: true
-                  environment:
-                    type: object
-                    title: ShellEnvironment
-                    description: A key/value mapping of the environment variables, if any, to use when running the configured process.
-                    additionalProperties: true
-                required: [ command ]
-            required: [ shell ]
-          - title: RunWorkflow
-            description: Enables the invocation and execution of nested workflows within a parent workflow, facilitating modularization, reusability, and abstraction of complex logic or business processes by encapsulating them into standalone workflow units.
-            properties:
-              workflow:
-                type: object
-                title: SubflowConfiguration 
-                description: The configuration of the workflow to run.
-                unevaluatedProperties: false
-                properties:
-                  namespace:
-                    type: string
-                    title: SubflowNamespace
-                    description: The namespace the workflow to run belongs to.
-                  name:
-                    type: string
-                    title: SubflowName
-                    description: The name of the workflow to run.
-                  version:
-                    type: string
-                    default: latest
-                    title: SubflowVersion
-                    description: The version of the workflow to run. Defaults to latest.
-                  input:
-                    type: object
-                    title: SubflowInput
-                    description: The data, if any, to pass as input to the workflow to execute. The value should be validated against the target workflow's input schema, if specified.
-                    additionalProperties: true
-                required: [ namespace, name, version ]
-            required: [ workflow ]
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        run:
+          type: object
+          title: RunTaskConfiguration
+          description: The configuration of the process to execute.
+          unevaluatedProperties: false
+          properties:
+            await:
+              type: boolean
+              default: true
+              title: AwaitProcessCompletion
+              description: Whether to await the process completion before continuing.
+            return:
+              type: string
+              title: ProcessReturnType
+              description: Configures the output of the process.
+              enum: [ stdout, stderr, code, all, none ]
+              default: stdout
+          oneOf:
+            - title: RunContainer
+              description: Enables the execution of external processes encapsulated within a containerized environment.
+              properties:
+                container:
+                  type: object
+                  title: Container
+                  description: The configuration of the container to run.
+                  unevaluatedProperties: false
+                  properties:
+                    image:
+                      type: string
+                      title: ContainerImage
+                      description: The name of the container image to run.
+                    name:
+                      type: string
+                      title: ContainerName
+                      description: A runtime expression, if any, used to give specific name to the container.
+                    command:
+                      type: string
+                      title: ContainerCommand
+                      description: The command, if any, to execute on the container.
+                    ports:
+                      type: object
+                      title: ContainerPorts
+                      description: The container's port mappings, if any.
+                    volumes:
+                      type: object
+                      title: ContainerVolumes
+                      description: The container's volume mappings, if any.
+                    environment:
+                      type: object
+                      title: ContainerEnvironment
+                      description: A key/value mapping of the environment variables, if any, to use when running the configured process.
+                    lifetime:
+                      $ref: '#/$defs/containerLifetime'
+                      title: ContainerLifetime
+                      description: An object, if any, used to configure the container's lifetime
+                  required: [ image ]
+              required: [ container ]
+            - title: RunScript
+              description: Enables the execution of custom scripts or code within a workflow, empowering workflows to perform specialized logic, data processing, or integration tasks by executing user-defined scripts written in various programming languages.
+              properties:
+                script:
+                  type: object
+                  title: Script
+                  description: The configuration of the script to run.
+                  unevaluatedProperties: false
+                  properties:
+                    language:
+                      type: string
+                      title: ScriptLanguage
+                      description: The language of the script to run.
+                    arguments:
+                      type: object
+                      title: ScriptArguments
+                      description: A key/value mapping of the arguments, if any, to use when running the configured script.
+                      additionalProperties: true
+                    environment:
+                      type: object
+                      title: ScriptEnvironment
+                      description: A key/value mapping of the environment variables, if any, to use when running the configured script process.
+                      additionalProperties: true
+                  oneOf:
+                    - title: InlineScript
+                      type: object
+                      description: The script's code.
+                      properties:
+                        code:
+                          type: string
+                          title: InlineScriptCode
+                      required: [ code ]
+                    - title: ExternalScript
+                      type: object
+                      description: The script's resource.
+                      properties:
+                        source:
+                          $ref: '#/$defs/externalResource'
+                          title: ExternalScriptResource
+                      required: [ source ]
+                  required: [ language ]
+              required: [ script ]
+            - title: RunShell
+              description: Enables the execution of shell commands within a workflow, enabling workflows to interact with the underlying operating system and perform system-level operations, such as file manipulation, environment configuration, or system administration tasks.
+              properties:
+                shell:
+                  type: object
+                  title: Shell
+                  description: The configuration of the shell command to run.
+                  unevaluatedProperties: false
+                  properties:
+                    command:
+                      type: string
+                      title: ShellCommand
+                      description: The shell command to run.
+                    arguments:
+                      type: object
+                      title: ShellArguments
+                      description: A list of the arguments of the shell command to run.
+                      additionalProperties: true
+                    environment:
+                      type: object
+                      title: ShellEnvironment
+                      description: A key/value mapping of the environment variables, if any, to use when running the configured process.
+                      additionalProperties: true
+                  required: [ command ]
+              required: [ shell ]
+            - title: RunWorkflow
+              description: Enables the invocation and execution of nested workflows within a parent workflow, facilitating modularization, reusability, and abstraction of complex logic or business processes by encapsulating them into standalone workflow units.
+              properties:
+                workflow:
+                  type: object
+                  title: SubflowConfiguration 
+                  description: The configuration of the workflow to run.
+                  unevaluatedProperties: false
+                  properties:
+                    namespace:
+                      type: string
+                      title: SubflowNamespace
+                      description: The namespace the workflow to run belongs to.
+                    name:
+                      type: string
+                      title: SubflowName
+                      description: The name of the workflow to run.
+                    version:
+                      type: string
+                      default: latest
+                      title: SubflowVersion
+                      description: The version of the workflow to run. Defaults to latest.
+                    input:
+                      type: object
+                      title: SubflowInput
+                      description: The data, if any, to pass as input to the workflow to execute. The value should be validated against the target workflow's input schema, if specified.
+                      additionalProperties: true
+                  required: [ namespace, name, version ]
+              required: [ workflow ]
   setTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: SetTask
     description: A task used to set data.
     required: [ set ]
     unevaluatedProperties: false
-    properties:
-      set:
-        oneOf:
-          - type: object
-            minProperties: 1
-            additionalProperties: true
-          - type: string
-        title: SetTaskConfiguration
-        description: The data to set.
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        set:
+          oneOf:
+            - type: object
+              minProperties: 1
+              additionalProperties: true
+            - type: string
+          title: SetTaskConfiguration
+          description: The data to set.
   switchTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: SwitchTask
     description: Enables conditional branching within workflows, allowing them to dynamically select different paths based on specified conditions or criteria.
     required: [ switch ]
     unevaluatedProperties: false
-    properties:
-      switch:
-        type: array
-        title: SwitchTaskConfiguration
-        description: The definition of the switch to use.
-        minItems: 1
-        items:
-          type: object
-          title: SwitchItem
-          minProperties: 1
-          maxProperties: 1
-          additionalProperties:
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        switch:
+          type: array
+          title: SwitchTaskConfiguration
+          description: The definition of the switch to use.
+          minItems: 1
+          items:
             type: object
-            title: SwitchCase
-            description: The definition of a case within a switch task, defining a condition and corresponding tasks to execute if the condition is met.
-            unevaluatedProperties: false
-            required: [ then ]
-            properties:
-              when:
-                type: string
-                title: SwitchCaseCondition
-                description: A runtime expression used to determine whether or not the case matches.
-              then:
-                $ref: '#/$defs/flowDirective'
-                title: SwitchCaseOutcome
-                description: The flow directive to execute when the case matches.
+            title: SwitchItem
+            minProperties: 1
+            maxProperties: 1
+            additionalProperties:
+              type: object
+              title: SwitchCase
+              description: The definition of a case within a switch task, defining a condition and corresponding tasks to execute if the condition is met.
+              unevaluatedProperties: false
+              required: [ then ]
+              properties:
+                when:
+                  type: string
+                  title: SwitchCaseCondition
+                  description: A runtime expression used to determine whether or not the case matches.
+                then:
+                  $ref: '#/$defs/flowDirective'
+                  title: SwitchCaseOutcome
+                  description: The flow directive to execute when the case matches.
   tryTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: TryTask
     description: Serves as a mechanism within workflows to handle errors gracefully, potentially retrying failed tasks before proceeding with alternate ones.
     required: [ try, catch ]
     unevaluatedProperties: false
-    properties:
-      try:
-        $ref: '#/$defs/taskList'
-        title: TryTaskConfiguration
-        description: The task(s) to perform.
-      catch:
-        type: object
-        title: TryTaskCatch
-        description: The object used to define the errors to catch.
-        unevaluatedProperties: false
-        properties:
-          errors:
-            type: object
-            title: CatchErrors
-            properties:
-              with:
-                $ref: '#/$defs/errorFilter'
-            description: static error filter
-          as:
-            type: string
-            title: CatchAs
-            description: The name of the runtime expression variable to save the error as. Defaults to 'error'.
-          when:
-            type: string
-            title: CatchWhen
-            description: A runtime expression used to determine whether to catch the filtered error.
-          exceptWhen:
-            type: string
-            title: CatchExceptWhen
-            description: A runtime expression used to determine whether not to catch the filtered error.
-          retry:
-            oneOf:
-              - $ref: '#/$defs/retryPolicy'
-                title: RetryPolicyDefinition
-                description: The retry policy to use, if any, when catching errors.
-              - type: string
-                title: RetryPolicyReference
-                description: The name of the retry policy to use, if any, when catching errors.
-          do:
-            $ref: '#/$defs/taskList'
-            title: TryTaskCatchDo
-            description: The definition of the task(s) to run when catching an error.
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        try:
+          $ref: '#/$defs/taskList'
+          title: TryTaskConfiguration
+          description: The task(s) to perform.
+        catch:
+          type: object
+          title: TryTaskCatch
+          description: The object used to define the errors to catch.
+          unevaluatedProperties: false
+          properties:
+            errors:
+              type: object
+              title: CatchErrors
+              properties:
+                with:
+                  $ref: '#/$defs/errorFilter'
+              description: static error filter
+            as:
+              type: string
+              title: CatchAs
+              description: The name of the runtime expression variable to save the error as. Defaults to 'error'.
+            when:
+              type: string
+              title: CatchWhen
+              description: A runtime expression used to determine whether to catch the filtered error.
+            exceptWhen:
+              type: string
+              title: CatchExceptWhen
+              description: A runtime expression used to determine whether not to catch the filtered error.
+            retry:
+              oneOf:
+                - $ref: '#/$defs/retryPolicy'
+                  title: RetryPolicyDefinition
+                  description: The retry policy to use, if any, when catching errors.
+                - type: string
+                  title: RetryPolicyReference
+                  description: The name of the retry policy to use, if any, when catching errors.
+            do:
+              $ref: '#/$defs/taskList'
+              title: TryTaskCatchDo
+              description: The definition of the task(s) to run when catching an error.
   waitTask:
     type: object
-    $ref: '#/$defs/taskBase'
     title: WaitTask
     description: Allows workflows to pause or delay their execution for a specified period of time.
     required: [ wait ]
     unevaluatedProperties: false
-    properties:
-      wait:
-        $ref: '#/$defs/duration'
-        title: WaitTaskConfiguration
-        description: The amount of time to wait.
+    allOf:
+    - $ref: '#/$defs/taskBase'
+    - properties:
+        wait:
+          $ref: '#/$defs/duration'
+          title: WaitTaskConfiguration
+          description: The amount of time to wait.
   flowDirective:
     title: FlowDirective
     description: Represents different transition options for a workflow.

--- a/use-cases/automated-data-backup/README.md
+++ b/use-cases/automated-data-backup/README.md
@@ -54,7 +54,7 @@ The following diagram represents the high-level flow of the workflow:
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: sql-export-to-minio
   version: 0.1.2

--- a/use-cases/managing-ev-charging-stations/README.md
+++ b/use-cases/managing-ev-charging-stations/README.md
@@ -70,7 +70,7 @@ The following diagram represents the high-level flow of the workflow:
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: manage-ev-charging-stations
   version: '0.1.0'

--- a/use-cases/managing-github-issues/README.md
+++ b/use-cases/managing-github-issues/README.md
@@ -63,7 +63,7 @@ The following diagram represents the high-level flow of the workflow:
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: manage-github-issues
   version: '0.1.0'

--- a/use-cases/multi-agent-ai-content-generation/README.md
+++ b/use-cases/multi-agent-ai-content-generation/README.md
@@ -66,7 +66,7 @@ The following diagram represents the high-level flow of the workflow:
 
 ```yaml
 document:
-  dsl: '1.0.0'
+  dsl: '1.0.1'
   namespace: default
   name: multi-agent-collaboration-for-ai-content
   version: '0.1.0'


### PR DESCRIPTION
**Notes**
The schema in JSON format has been temporarily added. This allows some tools to use the JSON version as it's not accessible elsewhere otherwise.

<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [ ] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
https://github.com/serverlessworkflow/specification/discussions/1093

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
- use `allOf` instead of a combination of `$ref` and `properties` for inheritance.
- bump to version 1.0.1

**Additional information:**
<!-- Optional -->