### PR TITLE
Fix missing dot in grpc service host validation in the schema.

### DIFF
--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -313,7 +313,7 @@ $defs:
                     pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-.]{0,61}[a-zA-Z0-9])?$
                   port:
                     type: integer
-                    title: WithGRPCServicePost
+                    title: WithGRPCServicePort
                     description: The port number of the GRPC service to call.
                     minimum: 0
                     maximum: 65535

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -310,7 +310,7 @@ $defs:
                     type: string
                     title: WithGRPCServiceHost
                     description: The hostname of the GRPC service to call.
-                    pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
+                    pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-.]{0,61}[a-zA-Z0-9])?$
                   port:
                     type: integer
                     title: WithGRPCServicePost


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [ ] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
https://github.com/serverlessworkflow/specification/issues/1111

**What this PR does**:
This PR addresses the issue by allowing dots(.) in the service host. I've also fixed a typo in the title WithGRPCServicePost

**Additional information:**
<!-- Optional -->