### PR TITLE
[Fix #1119] Allowing runtime xpression for duration

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -2297,7 +2297,7 @@ timeout:
 
 ### Duration
 
-Defines a duration.
+Defines a duration. Durations can be defined through properties, with an ISO 8601 string or with a runtime expression that is evaluated to an ISO 8601 string
 
 #### Properties
 

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1215,10 +1215,13 @@ $defs:
             description: Number of milliseconds, if any.
         title: DurationInline
         description: The inline definition of a duration.
+      - $ref: '#/$defs/runtimeExpression'
+        title: DurationExpression
+        description: Runtime expression that generates an ISO 8601 
       - type: string
         pattern: '^P(?!$)(\d+(?:\.\d+)?Y)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?W)?(\d+(?:\.\d+)?D)?(T(?=\d)(\d+(?:\.\d+)?H)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?S)?)?$'
-        title: DurationExpression
-        description: The ISO 8601 expression of a duration.
+        title: DurationLiteral
+        description: The Literal ISO 8601 representation of a duration. 
   error:
     type: object
     title: Error


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [X] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
Fix https://github.com/serverlessworkflow/specification/issues/1119

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
Change the schema to allow runtime expression for durations

**Additional information:**
<!-- Optional -->