### PR TITLE
fix: sync "task.if" descriptor matrix with other specification

### DIFF
--- a/dsl.md
+++ b/dsl.md
@@ -448,8 +448,8 @@ The following table shows which arguments are available for each runtime express
 | Runtime Expression | Evaluated on | Produces | `$context` | `$input` | `$output` | `$secrets` | `$task` | `$workflow` | `$runtime` | `$authorization` |
 |:-------------------|:---------:|:---------:|:---------:|:---------:|:-------:|:---------:|:-------:|:----------:|:----------:|:----------:|
 | Workflow `input.from` | Raw workflow input | Transformed workflow input | | | | ✔ | | ✔ | ✔ | |
+| Task `if` | Raw task input (i.e. transformed workflow input for the first task, transformed output from previous task otherwise) | | ✔ | | | ✔ | ✔ | ✔ | ✔ | |
 | Task `input.from` | Raw task input (i.e. transformed workflow input for the first task, transformed output from previous task otherwise) | Transformed task input | ✔ | | | ✔ | ✔ | ✔ | ✔ | |
-| Task `if` | Transformed task input | | ✔ | ✔ | | ✔ | ✔ | ✔ | ✔ | |
 | Task definition | Transformed task input | | ✔ | ✔ | | ✔ | ✔ | ✔ | ✔ | ✔ |
 | Task `output.as` | Raw task output | Transformed task output | ✔ | ✔ | | ✔ | ✔ | ✔ | ✔ | ✔ |
 | Task `export.as` | Transformed task output | `$context` | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does**:
Sync "task.if" descriptor matrix with #1001 

**Additional information:**
<!-- Optional -->