### PR TITLE
Fix capitalization of 'ZigFlow' to 'Zigflow'

### DIFF
--- a/adr/v1.0-adr-shared-workflow-editor.md
+++ b/adr/v1.0-adr-shared-workflow-editor.md
@@ -8,7 +8,7 @@ Proposed
 
 There is a need for a shared editor for the CNCF Serverless Workflow Specification that
 can be used consistently by multiple implementations (e.g. Quarkus Flow,
-SonataFlow, ZigFlow, Synapse, Lemline), as different tools provide inconsistent
+SonataFlow, Zigflow, Synapse, Lemline), as different tools provide inconsistent
 authoring and visualization experiences, leading to duplicated effort and fragmented tooling.
 
 Today we have:
@@ -58,7 +58,7 @@ vendor.
    - Initial maintainers: representatives from at least:
      - CNCF Serverless Workflow Specification maintainers
      - Quarkus Flow / SonataFlow
-     - Other interested engine maintainers (e.g. ZigFlow / Synapse / Lemline etc.).
+     - Other interested engine maintainers (e.g. Zigflow / Synapse / Lemline etc.).
 
 - Decision process
 


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [x] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
Minor nit, but this corrects [ZigFlow to Zigflow](https://github.com/mrsimonemms/zigflow/issues/253)

**Additional information:**
<!-- Optional -->