### PR TITLE
Fix dsl-reference.md / schema/workflow.yaml mismatches (evaluate, certificate auth, MCP client version)

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -57,7 +57,6 @@
   + [Authentication](#authentication)
     - [Basic](#basic-authentication)
     - [Bearer](#bearer-authentication)
-    - [Certificate](#certificate-authentication)
     - [Digest](#digest-authentication)
     - [OAUTH2](#oauth2-authentication)
     - [OpenIdConnect](#openidconnect-authentication)
@@ -156,8 +155,8 @@ Configures a workflow's runtime expression evaluation.
 
 | Name | Type | Required | Description|
 |:--|:---:|:---:|:---|
-| language | `string` | `yes` | The language used for writting runtime expressions.<br>*Defaults to `jq`.* |
-| mode | `string` | `yes` | The runtime expression evaluation mode.<br>*Supported values are:*<br>- `strict`: requires all expressions to be enclosed within `${ }` for proper identification and evaluation.<br>- `loose`: evaluates any value provided. If the evaluation fails, it results in a string with the expression as its content.<br>*Defaults to `strict`.*
+| language | `string` | `no` | The language used for writting runtime expressions.<br>*Defaults to `jq`.* |
+| mode | `string` | `no` | The runtime expression evaluation mode.<br>*Supported values are:*<br>- `strict`: requires all expressions to be enclosed within `${ }` for proper identification and evaluation.<br>- `loose`: evaluates any value provided. If the evaluation fails, it results in a string with the expression as its content.<br>*Defaults to `strict`.*
 
 #### Examples
 
@@ -1708,7 +1707,6 @@ Defines the mechanism used to authenticate users and workflows attempting to acc
 | use | `string` | `no` | The name of the top-level authentication definition to use. Cannot be used by authentication definitions defined at top level. |
 | basic | [`basicAuthentication`](#basic-authentication) | `no` | The `basic` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | bearer | [`bearerAuthentication`](#bearer-authentication) | `no` | The `bearer` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
-| certificate | [`certificateAuthentication`](#certificate-authentication) | `no` | The `certificate` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | digest | [`digestAuthentication`](#digest-authentication) | `no` | The `digest` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | oauth2 | [`oauth2`](#oauth2-authentication) | `no` | The `oauth2` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
 | oidc | [`oidc`](#openidconnect-authentication) | `no` | The `oidc` authentication scheme to use, if any.<br>Required if no other property has been set, otherwise ignored. |
@@ -1804,9 +1802,6 @@ do:
             bearer:
               token: ${ .user.token }
 ```
-
-#### Certificate Authentication
-
 
 #### Digest Authentication
 

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -152,6 +152,23 @@ properties:
         $ref: '#/$defs/eventConsumptionStrategy'
         title: ScheduleOn
         description: Specifies the events that trigger the workflow execution.
+  evaluate:
+    type: object
+    title: Evaluate
+    description: Configures the workflow's runtime expression evaluation.
+    unevaluatedProperties: false
+    properties:
+      language:
+        type: string
+        default: jq
+        title: EvaluateLanguage
+        description: The language used for writing runtime expressions. Defaults to 'jq'.
+      mode:
+        type: string
+        enum: [ strict, loose ]
+        default: strict
+        title: EvaluateMode
+        description: The runtime expression evaluation mode. Defaults to 'strict'.
 $defs:
   taskList:
     title: TaskList
@@ -569,7 +586,7 @@ $defs:
                       type: string
                       title: McpClientName
                       description: The name of the client used to connect to the MCP server.
-                    description:
+                    version:
                       type: string
                       title: McpClientVersion
                       description: The version of the client used to connect to the MCP server.


### PR DESCRIPTION
## What

Fixes the three substantive divergences between `dsl-reference.md` and `schema/workflow.yaml` reported in #1156.

| Bug | Fix | Why this direction |
|-----|-----|--------------------|
| `evaluate` workflow property documented but missing from the schema | **Added** `evaluate` (`language`, `mode`) to `schema/workflow.yaml` | It's a real feature — `dsl.md` references `evaluate.language` and documents the `strict`/`loose` modes |
| Certificate authentication documented but absent from the schema | **Removed** from `dsl-reference.md` (TOC, auth properties-table row, empty section) | Not defined anywhere — no schema, no `dsl.md` mention, no `examples/`, no `ctk/`; the doc section was empty |
| MCP client `version` required but never defined (schema bug) | **Renamed** schema property `description` → `version` | The schema declared `required: [ name, version ]` but defined no `version` property — it was mis-keyed as `description` (its title was already `McpClientVersion`) |

Also flips the `Evaluate` table's `language`/`mode` from `yes` → `no`, since both have defaults and are therefore optional — matching the schema (this is item #6 from the issue, an internal contradiction in the same table).

## Scope

This addresses the **High**-priority items (#1, #2, #3) plus the closely-related #6 from #1156. The remaining medium/minor items in that issue are left for follow-up, as several are direction-dependent and benefit from maintainer guidance.

`schema/workflow.yaml` was validated as parseable YAML after the change.

Addresses #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
