### PR TITLE
[Fix #1166] Relax URI patterns to conform to RFC 3986

### DIFF
--- a/.ci/validation/src/uri-pattern.test.ts
+++ b/.ci/validation/src/uri-pattern.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// RFC 3986 Appendix B URI-reference regex used in schema/workflow.yaml
+// for both LiteralUri and LiteralUriTemplate
+const URI_REFERENCE_PATTERN =
+  /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
+
+describe("LiteralUri pattern (RFC 3986 URI-reference)", () => {
+  const absoluteUris = [
+    "http://example.com",
+    "https://example.com/path",
+    "https://example.com/path?query=1",
+    "https://example.com/path#fragment",
+    "https://example.com/path?query=1#fragment",
+    "https://user:pass@example.com:8080/path",
+    "ftp://files.example.com/public",
+    "grpc://localhost:50051",
+    "file:///etc/hosts",
+    "custom-scheme://authority/path",
+  ];
+
+  const relativePathUris = [
+    "openapi/petstore.json",
+    "proto/greeter.proto",
+    "schemas/user.yaml",
+    "docs/api.json",
+    "../parent/file.json",
+    "./sibling/file.yaml",
+    "file.json",
+  ];
+
+  const absolutePathUris = [
+    "/api/v1/users",
+    "/openapi/petstore.json",
+    "/proto/greeter.proto",
+  ];
+
+  const urisWithQueryFragment = [
+    "openapi/petstore.json?version=3",
+    "/api/docs#section",
+    "resource?key=value&other=1",
+    "path/to/resource#anchor",
+  ];
+
+  const networkPathUris = ["//example.com/path", "//localhost:8080/api"];
+
+  test.each(absoluteUris)("accepts absolute URI: %s", (uri) => {
+    expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+  });
+
+  test.each(relativePathUris)("accepts relative path URI: %s", (uri) => {
+    expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+  });
+
+  test.each(absolutePathUris)("accepts absolute-path URI: %s", (uri) => {
+    expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+  });
+
+  test.each(urisWithQueryFragment)(
+    "accepts URI with query/fragment: %s",
+    (uri) => {
+      expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+    }
+  );
+
+  test.each(networkPathUris)("accepts network-path URI: %s", (uri) => {
+    expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+  });
+});
+
+describe("LiteralUriTemplate pattern (RFC 3986 URI-reference)", () => {
+  const absoluteTemplates = [
+    "http://example.com",
+    "https://example.com/path/{id}",
+    "https://server.com/{path}",
+    "https://api.example.com/v1/{resource}?limit={limit}",
+    "ftp://files.example.com",
+    "grpc://localhost:50051",
+    "custom-scheme://authority/path",
+  ];
+
+  const relativeTemplates = [
+    "openapi/{version}/petstore.json",
+    "{basePath}/resource",
+    "proto/greeter.proto",
+    "../{parent}/file.json",
+    "/api/{version}/users",
+    "docs/{file}.json",
+  ];
+
+  test.each(absoluteTemplates)(
+    "accepts absolute URI template: %s",
+    (uri) => {
+      expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+    }
+  );
+
+  test.each(relativeTemplates)(
+    "accepts relative URI template: %s",
+    (uri) => {
+      expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+    }
+  );
+});

--- a/.ci/validation/src/uri-pattern.test.ts
+++ b/.ci/validation/src/uri-pattern.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as yaml from "js-yaml";
 
 const schemaPath = path.resolve(__dirname, "../../../schema/workflow.yaml");

--- a/.ci/validation/src/uri-pattern.test.ts
+++ b/.ci/validation/src/uri-pattern.test.ts
@@ -14,12 +14,31 @@
  * limitations under the License.
  */
 
-// Anchored RFC 3986 URI-reference regex used in schema/workflow.yaml
-// for both LiteralUri and LiteralUriTemplate.
-// Adds: $ end anchor, (?!\s*\$\{) to exclude runtime expressions,
-// (?=\S) to reject empty/whitespace-only strings.
-const URI_REFERENCE_PATTERN =
-  /^(?!\s*\$\{)(?=\S)(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$/;
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+
+const schemaPath = path.resolve(__dirname, "../../../schema/workflow.yaml");
+const schema = yaml.load(
+  fs.readFileSync(schemaPath, "utf-8")
+) as any;
+
+const uriTemplateDef = schema["$defs"]["uriTemplate"];
+const literalUriTemplateDef = uriTemplateDef.anyOf.find(
+  (v: any) => v.title === "LiteralUriTemplate"
+);
+const literalUriDef = uriTemplateDef.anyOf.find(
+  (v: any) => v.title === "LiteralUri"
+);
+
+const LITERAL_URI_PATTERN = new RegExp(literalUriDef.pattern);
+const LITERAL_URI_TEMPLATE_PATTERN = new RegExp(literalUriTemplateDef.pattern);
+
+describe("Schema pattern consistency", () => {
+  test("LiteralUri and LiteralUriTemplate use the same pattern", () => {
+    expect(literalUriDef.pattern).toBe(literalUriTemplateDef.pattern);
+  });
+});
 
 describe("LiteralUri pattern (RFC 3986 URI-reference)", () => {
   const absoluteUris = [
@@ -61,26 +80,26 @@ describe("LiteralUri pattern (RFC 3986 URI-reference)", () => {
   const networkPathUris = ["//example.com/path", "//localhost:8080/api"];
 
   test.each(absoluteUris)("accepts absolute URI: %s", (uri) => {
-    expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+    expect(LITERAL_URI_PATTERN.test(uri)).toBe(true);
   });
 
   test.each(relativePathUris)("accepts relative path URI: %s", (uri) => {
-    expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+    expect(LITERAL_URI_PATTERN.test(uri)).toBe(true);
   });
 
   test.each(absolutePathUris)("accepts absolute-path URI: %s", (uri) => {
-    expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+    expect(LITERAL_URI_PATTERN.test(uri)).toBe(true);
   });
 
   test.each(urisWithQueryFragment)(
     "accepts URI with query/fragment: %s",
     (uri) => {
-      expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+      expect(LITERAL_URI_PATTERN.test(uri)).toBe(true);
     }
   );
 
   test.each(networkPathUris)("accepts network-path URI: %s", (uri) => {
-    expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+    expect(LITERAL_URI_PATTERN.test(uri)).toBe(true);
   });
 });
 
@@ -107,14 +126,14 @@ describe("LiteralUriTemplate pattern (RFC 3986 URI-reference)", () => {
   test.each(absoluteTemplates)(
     "accepts absolute URI template: %s",
     (uri) => {
-      expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+      expect(LITERAL_URI_TEMPLATE_PATTERN.test(uri)).toBe(true);
     }
   );
 
   test.each(relativeTemplates)(
     "accepts relative URI template: %s",
     (uri) => {
-      expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
+      expect(LITERAL_URI_TEMPLATE_PATTERN.test(uri)).toBe(true);
     }
   );
 });
@@ -130,15 +149,15 @@ describe("URI pattern rejects invalid or ambiguous values", () => {
   test.each(runtimeExpressions)(
     "rejects runtime expression: %s",
     (expr) => {
-      expect(URI_REFERENCE_PATTERN.test(expr)).toBe(false);
+      expect(LITERAL_URI_PATTERN.test(expr)).toBe(false);
     }
   );
 
   test("rejects empty string", () => {
-    expect(URI_REFERENCE_PATTERN.test("")).toBe(false);
+    expect(LITERAL_URI_PATTERN.test("")).toBe(false);
   });
 
   test("rejects whitespace-only string", () => {
-    expect(URI_REFERENCE_PATTERN.test("   ")).toBe(false);
+    expect(LITERAL_URI_PATTERN.test("   ")).toBe(false);
   });
 });

--- a/.ci/validation/src/uri-pattern.test.ts
+++ b/.ci/validation/src/uri-pattern.test.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-// RFC 3986 Appendix B URI-reference regex used in schema/workflow.yaml
-// for both LiteralUri and LiteralUriTemplate
+// Anchored RFC 3986 URI-reference regex used in schema/workflow.yaml
+// for both LiteralUri and LiteralUriTemplate.
+// Adds: $ end anchor, (?!\s*\$\{) to exclude runtime expressions,
+// (?=\S) to reject empty/whitespace-only strings.
 const URI_REFERENCE_PATTERN =
-  /^(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
+  /^(?!\s*\$\{)(?=\S)(([^:/?#]+):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$/;
 
 describe("LiteralUri pattern (RFC 3986 URI-reference)", () => {
   const absoluteUris = [
@@ -115,4 +117,28 @@ describe("LiteralUriTemplate pattern (RFC 3986 URI-reference)", () => {
       expect(URI_REFERENCE_PATTERN.test(uri)).toBe(true);
     }
   );
+});
+
+describe("URI pattern rejects invalid or ambiguous values", () => {
+  const runtimeExpressions = [
+    "${ .foo }",
+    "  ${ .bar }  ",
+    "${.baz}",
+    "${ .context.endpoint }",
+  ];
+
+  test.each(runtimeExpressions)(
+    "rejects runtime expression: %s",
+    (expr) => {
+      expect(URI_REFERENCE_PATTERN.test(expr)).toBe(false);
+    }
+  );
+
+  test("rejects empty string", () => {
+    expect(URI_REFERENCE_PATTERN.test("")).toBe(false);
+  });
+
+  test("rejects whitespace-only string", () => {
+    expect(URI_REFERENCE_PATTERN.test("   ")).toBe(false);
+  });
 });

--- a/.ci/validation/src/uri-pattern.test.ts
+++ b/.ci/validation/src/uri-pattern.test.ts
@@ -160,4 +160,22 @@ describe("URI pattern rejects invalid or ambiguous values", () => {
   test("rejects whitespace-only string", () => {
     expect(LITERAL_URI_PATTERN.test("   ")).toBe(false);
   });
+
+  const urisWithWhitespace = [
+    "http://example.com/path with spaces",
+    "openapi/pet store.json",
+    "/api/v1/my resource",
+    "https://example.com/path?query=has space",
+    "https://example.com/path#frag ment",
+    "proto/greeter .proto",
+    "//example.com/some path",
+  ];
+
+  test.each(urisWithWhitespace)(
+    "rejects URI containing whitespace: %s",
+    (uri) => {
+      expect(LITERAL_URI_PATTERN.test(uri)).toBe(false);
+      expect(LITERAL_URI_TEMPLATE_PATTERN.test(uri)).toBe(false);
+    }
+  );
 });

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -2464,6 +2464,8 @@ headers:
 
 The DSL has limited support for URI template syntax as defined by [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570). Specifically, only the [Simple String Expansion](https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.2) is supported, which allows authors to embed variables in a URI.
 
+All URI and URI template types in the DSL conform to the [URI-reference](https://datatracker.ietf.org/doc/html/rfc3986#appendix-B) syntax defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), meaning both absolute URIs (e.g., `https://example.com/path`) and relative references (e.g., `openapi/petstore.json`, `/api/v1/users`) are accepted.
+
 To substitute a variable within a URI, use the `{}` syntax. The identifier inside the curly braces will be replaced with its value during runtime evaluation. If no value is found for the identifier, an empty string will be used.
 
 This has the following limitations compared to runtime expressions:

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -2464,7 +2464,7 @@ headers:
 
 The DSL has limited support for URI template syntax as defined by [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570). Specifically, only the [Simple String Expansion](https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.2) is supported, which allows authors to embed variables in a URI.
 
-All URI types in the DSL accept [URI-references](https://datatracker.ietf.org/doc/html/rfc3986#section-4.1) as defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), meaning both absolute URIs (e.g., `https://example.com/path`) and relative references (e.g., `openapi/petstore.json`, `/api/v1/users`) are accepted. URI templates are validated against the same pattern before variable expansion.
+URI-typed string fields that use the schema’s `uriTemplate` type accept [URI-references](https://datatracker.ietf.org/doc/html/rfc3986#section-4.1) as defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), meaning both absolute URIs (e.g., `https://example.com/path`) and relative references (e.g., `openapi/petstore.json`, `/api/v1/users`) are accepted. In the JSON Schema, both `LiteralUri` and `LiteralUriTemplate` are validated using the RFC 3986 Appendix B URI-reference regex (with an extra guard to avoid matching runtime expressions).
 
 To substitute a variable within a URI, use the `{}` syntax. The identifier inside the curly braces will be replaced with its value during runtime evaluation. If no value is found for the identifier, an empty string will be used.
 

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -2464,7 +2464,7 @@ headers:
 
 The DSL has limited support for URI template syntax as defined by [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570). Specifically, only the [Simple String Expansion](https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.2) is supported, which allows authors to embed variables in a URI.
 
-All URI and URI template types in the DSL conform to the [URI-reference](https://datatracker.ietf.org/doc/html/rfc3986#section-4.1) syntax defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), meaning both absolute URIs (e.g., `https://example.com/path`) and relative references (e.g., `openapi/petstore.json`, `/api/v1/users`) are accepted.
+All URI types in the DSL accept [URI-references](https://datatracker.ietf.org/doc/html/rfc3986#section-4.1) as defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), meaning both absolute URIs (e.g., `https://example.com/path`) and relative references (e.g., `openapi/petstore.json`, `/api/v1/users`) are accepted. URI templates are validated against the same pattern before variable expansion.
 
 To substitute a variable within a URI, use the `{}` syntax. The identifier inside the curly braces will be replaced with its value during runtime evaluation. If no value is found for the identifier, an empty string will be used.
 

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -2464,7 +2464,7 @@ headers:
 
 The DSL has limited support for URI template syntax as defined by [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570). Specifically, only the [Simple String Expansion](https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.2) is supported, which allows authors to embed variables in a URI.
 
-All URI and URI template types in the DSL conform to the [URI-reference](https://datatracker.ietf.org/doc/html/rfc3986#appendix-B) syntax defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), meaning both absolute URIs (e.g., `https://example.com/path`) and relative references (e.g., `openapi/petstore.json`, `/api/v1/users`) are accepted.
+All URI and URI template types in the DSL conform to the [URI-reference](https://datatracker.ietf.org/doc/html/rfc3986#section-4.1) syntax defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), meaning both absolute URIs (e.g., `https://example.com/path`) and relative references (e.g., `openapi/petstore.json`, `/api/v1/users`) are accepted.
 
 To substitute a variable within a URI, use the `{}` syntax. The identifier inside the curly braces will be replaced with its value during runtime evaluation. If no value is found for the identifier, an empty string will be used.
 

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1455,11 +1455,11 @@ $defs:
       - title: LiteralUriTemplate
         type: string
         format: uri-template
-        pattern: "^(?!\\s*\\$\\{)(?=\\S)(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"
+        pattern: "^(?!\\s*\\$\\{)(?=\\S)(([^:/?#]+):)?(//([^/?#\\s]*))?([^?#\\s]*)(\\?([^#\\s]*))?(#(\\S*))?$"
       - title: LiteralUri
         type: string
         format: uri-reference
-        pattern: "^(?!\\s*\\$\\{)(?=\\S)(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"
+        pattern: "^(?!\\s*\\$\\{)(?=\\S)(([^:/?#]+):)?(//([^/?#\\s]*))?([^?#\\s]*)(\\?([^#\\s]*))?(#(\\S*))?$"
   endpoint:
     title: Endpoint
     description: Represents an endpoint.

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1459,7 +1459,7 @@ $defs:
       - title: LiteralUri
         type: string
         format: uri
-        pattern: "^[A-Za-z][A-Za-z0-9+\\-.]*://.*"
+        pattern: "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
   endpoint:
     title: Endpoint
     description: Represents an endpoint.

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1455,7 +1455,7 @@ $defs:
       - title: LiteralUriTemplate
         type: string
         format: uri-template
-        pattern: "^[A-Za-z][A-Za-z0-9+\\-.]*://.*"
+        pattern: "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
       - title: LiteralUri
         type: string
         format: uri

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1458,7 +1458,7 @@ $defs:
         pattern: "^(?!\\s*\\$\\{)(?=\\S)(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"
       - title: LiteralUri
         type: string
-        format: uri
+        format: uri-reference
         pattern: "^(?!\\s*\\$\\{)(?=\\S)(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"
   endpoint:
     title: Endpoint

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -1455,11 +1455,11 @@ $defs:
       - title: LiteralUriTemplate
         type: string
         format: uri-template
-        pattern: "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+        pattern: "^(?!\\s*\\$\\{)(?=\\S)(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"
       - title: LiteralUri
         type: string
         format: uri
-        pattern: "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+        pattern: "^(?!\\s*\\$\\{)(?=\\S)(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$"
   endpoint:
     title: Endpoint
     description: Represents an endpoint.


### PR DESCRIPTION
## Summary

- The `LiteralUri` and `LiteralUriTemplate` patterns only accepted absolute URIs with a scheme
- Relative URIs like `openapi/petstore.json` or `proto/greeter.proto` are valid per RFC 3986 and used in practice
- Replace both patterns with the [RFC 3986 Appendix B](https://www.rfc-editor.org/rfc/rfc3986.html#appendix-B) URI-reference regex, which accepts both absolute and relative URIs
- URI types in the DSL must conform to [RFC 3986 URI-reference](https://datatracker.ietf.org/doc/html/rfc3986#appendix-B) syntax

### Context

The original absolute-only pattern was added in #1017 to work around `format: uri-template` inconsistencies across JSON Schema validators. The RFC 3986 regex maintains structural validation while supporting relative references.

### Changes

- `schema/workflow.yaml`: Updated both `LiteralUri` and `LiteralUriTemplate` patterns to RFC 3986 Appendix B regex
- `dsl-reference.md`: Added reasoning that all URI types conform to RFC 3986 URI-reference syntax
- `.ci/validation/src/uri-pattern.test.ts`: Added 39 tests covering absolute URIs, relative paths, query/fragment combinations, network-path references, and URI templates

Fixes #1166